### PR TITLE
fix(ga): collapse GA4's unattributed landing-page sentinels into one row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.148.0",
+  "version": "4.148.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -30,6 +30,37 @@ function gaLog(level: 'info' | 'warn' | 'error', action: string, ctx?: Record<st
   stream.write(JSON.stringify(entry) + '\n')
 }
 
+/**
+ * The label GA4 itself uses for a session it could not attribute to a landing
+ * page. It is also the single bucket every unattributed variant collapses into,
+ * so the dashboard shows one such row instead of several.
+ */
+const UNATTRIBUTED_LANDING_PAGE = '(not set)'
+
+/**
+ * Group key for a landing page.
+ *
+ * `landing_page_normalized` is NULL for two unrelated reasons, and a plain
+ * `COALESCE(normalized, raw)` cannot tell them apart:
+ *
+ *   1. the row predates the normalizer, so the raw value is the best we have
+ *      and falling back to it is correct;
+ *   2. `normalizeUrlPath` looked at the raw value and deliberately mapped it to
+ *      nothing — GA4's `(not set)` placeholder, the empty string, or whitespace.
+ *
+ * In case 2 the fallback resurrects the very sentinel normalization discarded,
+ * and because GA4 emits both `(not set)` and `''` for the same condition they
+ * land as two separate rows for one thing. Blanking the sentinels before the
+ * fallback collapses them into a single `(not set)` bucket while leaving case 1
+ * untouched. The trailing `COALESCE` arm keeps the key total: both landing-page
+ * columns are NOT NULL today, so it is defensive rather than reachable.
+ *
+ * Keep the sentinel list in step with `normalizeUrlPath`.
+ */
+function landingPageGroupKey(normalized: SQLWrapper, raw: SQLWrapper): SQL<string> {
+  return sql<string>`COALESCE(${normalized}, NULLIF(NULLIF(TRIM(${raw}), ''), ${UNATTRIBUTED_LANDING_PAGE}), ${UNATTRIBUTED_LANDING_PAGE})`
+}
+
 // Format a session-share as a display string. Returns "<1%" for non-zero shares
 // that round below 1%, so 18 AI sessions out of 6000 reads "<1%" instead of
 // "0%" — the display matches the integer pct field exactly otherwise.
@@ -1104,12 +1135,13 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .where(eq(gaTrafficSummaries.projectId, project.id))
       .get()
 
-    // Group by COALESCE(normalized, raw) so click-ID-fragmented variants
-    // of the same page collapse, and partially-backfilled state (where
-    // older rows have null normalized) still aggregates correctly.
+    // Group by the shared landing-page key so click-ID-fragmented variants of
+    // the same page collapse, partially-backfilled state (where older rows have
+    // null normalized) still aggregates correctly, and GA4's unattributed
+    // sentinels land in one bucket rather than one row each.
     const rows = app.db
       .select({
-        landingPage: sql<string>`COALESCE(${gaTrafficSnapshots.landingPageNormalized}, ${gaTrafficSnapshots.landingPage})`,
+        landingPage: landingPageGroupKey(gaTrafficSnapshots.landingPageNormalized, gaTrafficSnapshots.landingPage),
         sessions: sql<number>`SUM(${gaTrafficSnapshots.sessions})`,
         organicSessions: sql<number>`SUM(${gaTrafficSnapshots.organicSessions})`,
         directSessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.directSessions}), 0)`,
@@ -1117,7 +1149,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       })
       .from(gaTrafficSnapshots)
       .where(and(...snapshotConditions))
-      .groupBy(sql`COALESCE(${gaTrafficSnapshots.landingPageNormalized}, ${gaTrafficSnapshots.landingPage})`)
+      .groupBy(landingPageGroupKey(gaTrafficSnapshots.landingPageNormalized, gaTrafficSnapshots.landingPage))
       .orderBy(sql`SUM(${gaTrafficSnapshots.sessions}) DESC`)
       .limit(limit)
       .all()
@@ -1141,7 +1173,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         medium: gaAiReferrals.medium,
         trafficClass: gaAiReferrals.trafficClass,
         sourceDimension: gaAiReferrals.sourceDimension,
-        landingPage: sql<string>`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
+        landingPage: landingPageGroupKey(gaAiReferrals.landingPageNormalized, gaAiReferrals.landingPage),
         sessions: sql<number>`SUM(${gaAiReferrals.sessions})`,
       })
       .from(gaAiReferrals)
@@ -1151,7 +1183,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         gaAiReferrals.medium,
         gaAiReferrals.trafficClass,
         gaAiReferrals.sourceDimension,
-        sql`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
+        landingPageGroupKey(gaAiReferrals.landingPageNormalized, gaAiReferrals.landingPage),
       )
       .all()
 
@@ -1358,7 +1390,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         source: gaAiReferrals.source,
         medium: gaAiReferrals.medium,
         trafficClass: gaAiReferrals.trafficClass,
-        landingPage: sql<string>`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
+        landingPage: landingPageGroupKey(gaAiReferrals.landingPageNormalized, gaAiReferrals.landingPage),
         sourceDimension: gaAiReferrals.sourceDimension,
         sessions: sql<number>`SUM(${gaAiReferrals.sessions})`,
         users: sql<number>`SUM(${gaAiReferrals.users})`,
@@ -1371,7 +1403,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         gaAiReferrals.medium,
         gaAiReferrals.trafficClass,
         gaAiReferrals.sourceDimension,
-        sql`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
+        landingPageGroupKey(gaAiReferrals.landingPageNormalized, gaAiReferrals.landingPage),
       )
       .orderBy(gaAiReferrals.date)
       .all()
@@ -1718,20 +1750,20 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     const project = resolveProject(app.db, request.params.name)
     requireGa4Connection(opts, project.name, project.canonicalDomain)
 
-    // Group by COALESCE(normalized, raw) so click-ID-fragmented variants of
+    // Group by the shared landing-page key so click-ID-fragmented variants of
     // the same page collapse — same identity rule as /ga/traffic. Mirrored
     // here so `canonry ga coverage` and the MCP `canonry_ga_coverage` tool
     // see the same canonicalized page list as the dashboard.
     const trafficPages = app.db
       .select({
-        landingPage: sql<string>`COALESCE(${gaTrafficSnapshots.landingPageNormalized}, ${gaTrafficSnapshots.landingPage})`,
+        landingPage: landingPageGroupKey(gaTrafficSnapshots.landingPageNormalized, gaTrafficSnapshots.landingPage),
         sessions: sql<number>`SUM(${gaTrafficSnapshots.sessions})`,
         organicSessions: sql<number>`SUM(${gaTrafficSnapshots.organicSessions})`,
         users: sql<number>`SUM(${gaTrafficSnapshots.users})`,
       })
       .from(gaTrafficSnapshots)
       .where(eq(gaTrafficSnapshots.projectId, project.id))
-      .groupBy(sql`COALESCE(${gaTrafficSnapshots.landingPageNormalized}, ${gaTrafficSnapshots.landingPage})`)
+      .groupBy(landingPageGroupKey(gaTrafficSnapshots.landingPageNormalized, gaTrafficSnapshots.landingPage))
       .orderBy(sql`SUM(${gaTrafficSnapshots.sessions}) DESC`)
       .all()
 

--- a/packages/api-routes/test/ga-landing-page-grouping.test.ts
+++ b/packages/api-routes/test/ga-landing-page-grouping.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import Fastify from 'fastify'
+import { createClient, migrate, gaTrafficSnapshots, gaAiReferrals } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+import type { Ga4CredentialStore, Ga4CredentialRecord } from '../src/ga.js'
+
+/**
+ * GA4 has two spellings for "this session had no landing page": the literal
+ * string `(not set)` and an empty string. `normalizeUrlPath` maps both to NULL,
+ * but the read grouped by `COALESCE(normalized, raw)`, and that fallback fired
+ * on exactly the rows normalization had emptied — so the two sentinels came
+ * back as two separate rows for one condition.
+ *
+ * The values seeded here are the shapes observed in a production database:
+ * `(not set)` present since March, an empty string that first appeared on a
+ * single later date across several projects at once, and a trailing-paren path
+ * from a markdown link whose closing bracket was swallowed into the href.
+ */
+
+function buildApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ga-landing-group-test-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+
+  const credentials: Map<string, Ga4CredentialRecord> = new Map()
+  const ga4CredentialStore: Ga4CredentialStore = {
+    getConnection: (projectName: string) => credentials.get(projectName),
+    upsertConnection: (connection: Ga4CredentialRecord) => {
+      credentials.set(connection.projectName, connection)
+      return connection
+    },
+    deleteConnection: (projectName: string) => credentials.delete(projectName),
+  }
+
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true, ga4CredentialStore })
+  return { app, db, tmpDir, credentials }
+}
+
+describe('GA landing-page grouping', () => {
+  let app: ReturnType<typeof Fastify>
+  let db: ReturnType<typeof createClient>
+  let tmpDir: string
+  let credentials: Map<string, Ga4CredentialRecord>
+  let projectId: string
+  const now = new Date().toISOString()
+
+  beforeAll(async () => {
+    const ctx = buildApp()
+    app = ctx.app
+    db = ctx.db
+    tmpDir = ctx.tmpDir
+    credentials = ctx.credentials
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/lp-group',
+      payload: { displayName: 'LP Group', canonicalDomain: 'example.com', country: 'US', language: 'en' },
+    })
+    projectId = JSON.parse(res.payload).id
+
+    credentials.set('lp-group', {
+      projectName: 'lp-group',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const snapshot = (
+      date: string,
+      landingPage: string,
+      landingPageNormalized: string | null,
+      sessions: number,
+      organicSessions: number,
+    ) => {
+      db.insert(gaTrafficSnapshots).values({
+        id: crypto.randomUUID(),
+        projectId,
+        date,
+        landingPage,
+        landingPageNormalized,
+        sessions,
+        organicSessions,
+        users: sessions,
+        syncedAt: now,
+      }).run()
+    }
+
+    // A real page, split across two dates.
+    snapshot('2026-08-01', '/aeo-methodology', '/aeo-methodology', 11, 7)
+    snapshot('2026-08-02', '/aeo-methodology', '/aeo-methodology', 31, 4)
+    // The markdown-link variant. Normalization already folds it.
+    snapshot('2026-08-01', '/aeo-methodology)', '/aeo-methodology', 5, 0)
+    // GA4's two spellings of "unattributed", both normalized away. Both columns
+    // are NOT NULL, so the sentinel always arrives as one of these strings.
+    snapshot('2026-08-01', '(not set)', null, 57, 15)
+    snapshot('2026-08-04', '', null, 9, 0)
+    // Whitespace is the same condition wearing a third coat.
+    snapshot('2026-08-04', '   ', null, 3, 1)
+    // A legacy row written before the normalizer ran: raw is the best we have.
+    snapshot('2026-08-03', '/managed', null, 38, 1)
+  })
+
+  afterAll(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  async function topPages() {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/lp-group/ga/traffic' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.payload) as { topPages: Array<{ landingPage: string; sessions: number; organicSessions: number }> }
+    return body.topPages
+  }
+
+  it('reports one unattributed row, not one per GA4 sentinel spelling', async () => {
+    const pages = await topPages()
+    const unattributed = pages.filter((p) => p.landingPage === '(not set)')
+
+    expect(unattributed).toHaveLength(1)
+    // 57 from "(not set)" + 9 from "" + 3 from whitespace.
+    expect(unattributed[0]!.sessions).toBe(69)
+    expect(unattributed[0]!.organicSessions).toBe(16)
+
+    // The empty string must not survive as its own label.
+    expect(pages.map((p) => p.landingPage)).not.toContain('')
+  })
+
+  it('folds the trailing-paren variant into the real page', async () => {
+    const pages = await topPages()
+    const methodology = pages.filter((p) => p.landingPage === '/aeo-methodology')
+
+    expect(methodology).toHaveLength(1)
+    // 11 + 31 from the clean rows, 5 from "/aeo-methodology)".
+    expect(methodology[0]!.sessions).toBe(47)
+    expect(methodology[0]!.organicSessions).toBe(11)
+    expect(pages.map((p) => p.landingPage)).not.toContain('/aeo-methodology)')
+  })
+
+  it('still falls back to the raw path for a row the normalizer never touched', async () => {
+    const pages = await topPages()
+    const managed = pages.find((p) => p.landingPage === '/managed')
+
+    // The fallback is the whole reason COALESCE is there; blanking the
+    // sentinels must not cost us the partially-backfilled case.
+    expect(managed).toBeDefined()
+    expect(managed!.sessions).toBe(38)
+  })
+
+  it('conserves every seeded session across the grouping', async () => {
+    const pages = await topPages()
+    const seeded = 11 + 31 + 5 + 57 + 9 + 3 + 38
+
+    expect(seeded).toBe(154)
+    expect(pages.reduce((sum, p) => sum + p.sessions, 0)).toBe(seeded)
+    // /aeo-methodology, (not set), /managed — seven stored rows, three pages.
+    expect(pages).toHaveLength(3)
+  })
+
+  it('applies the same grouping to /ga/coverage', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/lp-group/ga/coverage' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.payload) as { pages: Array<{ landingPage: string; sessions: number }> }
+
+    expect(body.pages.filter((p) => p.landingPage === '(not set)')).toHaveLength(1)
+    expect(body.pages.find((p) => p.landingPage === '(not set)')!.sessions).toBe(69)
+    expect(body.pages.map((p) => p.landingPage)).not.toContain('')
+  })
+
+  it('applies the same grouping to AI referral landing pages', async () => {
+    const referral = (landingPage: string | null, landingPageNormalized: string | null, sessions: number) => {
+      db.insert(gaAiReferrals).values({
+        id: crypto.randomUUID(),
+        projectId,
+        date: '2026-08-01',
+        source: 'chatgpt.com',
+        medium: 'referral',
+        sourceDimension: 'session',
+        channelGroup: 'Referral',
+        trafficClass: 'organic',
+        landingPage,
+        landingPageNormalized,
+        sessions,
+        users: sessions,
+        syncedAt: now,
+      }).run()
+    }
+    referral('(not set)', null, 4)
+    referral('', null, 2)
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/lp-group/ga/ai-referral-history' })
+    expect(res.statusCode).toBe(200)
+    const rows = JSON.parse(res.payload) as Array<{ landingPage: string; sessions: number }>
+    const unattributed = rows.filter((r) => r.landingPage === '(not set)')
+
+    expect(unattributed).toHaveLength(1)
+    expect(unattributed[0]!.sessions).toBe(6)
+    expect(rows.map((r) => r.landingPage)).not.toContain('')
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.148.0",
+  "version": "4.148.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -785,9 +785,15 @@ export const gaTrafficSnapshots = sqliteTable('ga_traffic_snapshots', {
   /**
    * Canonicalized form of `landingPage` produced by `normalizeUrlPath()` in
    * `@ainyc/canonry-contracts`. Nullable so existing rows survive migration;
-   * new GA4 sync writes populate it. Per-page aggregations should
-   * `GROUP BY COALESCE(landing_page_normalized, landing_page)` so
-   * partially-backfilled state still aggregates correctly.
+   * new GA4 sync writes populate it.
+   *
+   * NULL means two different things — the row predates the normalizer, or the
+   * normalizer looked at the raw value and deliberately mapped it to nothing
+   * (GA4's `(not set)` placeholder, an empty string, whitespace). A bare
+   * `COALESCE(landing_page_normalized, landing_page)` cannot tell them apart
+   * and resurrects the sentinels as their own rows. Per-page aggregations go
+   * through `landingPageGroupKey()` in `packages/api-routes/src/ga.ts`, which
+   * blanks the sentinels before the fallback.
    */
   landingPageNormalized: text('landing_page_normalized'),
   sessions: integer('sessions').notNull().default(0),


### PR DESCRIPTION
## What

The GA per-page reads grouped by `COALESCE(landing_page_normalized, landing_page)`. That fallback fired on exactly the rows normalization had deliberately emptied, so GA4's two spellings of "no landing page" — the literal `(not set)` and an empty string — came back as two separate rows for the same condition.

`landingPageGroupKey()` blanks the sentinels before the fallback. They collapse into one `(not set)` bucket; rows written before the normalizer shipped still fall back to their raw value.

## Why

`landing_page_normalized` is NULL for two unrelated reasons and a bare COALESCE cannot tell them apart:

1. the row predates the normalizer — the raw value is the best we have, falling back is correct;
2. `normalizeUrlPath` looked at the raw value and mapped it to nothing — `(not set)`, an empty string, whitespace.

Only case 1 wants the fallback. Case 2 got it anyway.

Observed on a production database: `(not set)` carrying 210 sessions since March, plus an empty string that first appeared on 2026-08-04 across four projects on four separate sync runs. Two dashboard rows, one meaning.

## Scope

All four per-page aggregations:

| Route | Table |
|---|---|
| `/ga/traffic` | `ga_traffic_snapshots` |
| `/ga/traffic` (AI referral landing pages) | `ga_ai_referrals` |
| `/ga/ai-referral-history` | `ga_ai_referrals` |
| `/ga/coverage` | `ga_traffic_snapshots` |

No endpoint, request, or response shape changes. Merging the buckets raises the unattributed row's session count, so it can place differently against the top-N cut than it did before.

## Tests

`packages/api-routes/test/ga-landing-page-grouping.test.ts`, seeded with the shapes observed in production. Reverting `landingPageGroupKey` to the old expression fails 4 of the 6:

```
× reports one unattributed row, not one per GA4 sentinel spelling
    AssertionError: expected 57 to be 69
× conserves every seeded session across the grouping
    AssertionError: expected [ …(5) ] to have a length of 3 but got 5
× applies the same grouping to /ga/coverage
    AssertionError: expected 57 to be 69
× applies the same grouping to AI referral landing pages
    AssertionError: expected 4 to be 6
```

The other two are regression guards for behaviour this change preserves: the trailing-paren fold (already handled by `normalizeUrlPath`) and the raw-value fallback for an unbackfilled row. Both pass before and after, by design.

Full suite: 599 of 601 files pass. The two failures are `session-auth-panel*.test.ts` from #910 — wall-clock-sensitive rate-limiting tests that timed out under concurrent load. They pass in isolation at the default timeout and share no code with this diff.

## Note

The `landing_page_normalized` doc comment in `schema.ts` prescribed the bare COALESCE. Updated to point at the helper, so the pattern that caused this doesn't get reintroduced from the schema docs.
