### PR TITLE
fix: make page inspector link counts agree with the link filter

### DIFF
--- a/apps/web/src/components/project/SiteHealthSection.tsx
+++ b/apps/web/src/components/project/SiteHealthSection.tsx
@@ -291,26 +291,77 @@ function deadLinkLabel(state: string, found?: number): { label: string; tone: Me
   return { label: 'Broken links: not checked', tone: 'neutral' }
 }
 
-function LinkMetrics({ page }: { page: InspectableCrawlPage }) {
+/**
+ * What one direction's tile should say, given the active link filter.
+ *
+ * The tiles used to always show the crawl's full-graph totals while the tables
+ * beneath them honoured the content-only filter, so one panel read "Links in
+ * 48" directly above a table headed "Links in (1)". Both were right and the
+ * pair was unreadable. The tile now counts exactly what the table lists.
+ */
+export function linkTileCount(counts: {
+  total: number
+  visible: number
+  hidden: number
+  truncated: boolean
+  showTemplateLinks: boolean
+  known: boolean
+}): { value: string; hiddenNote: string | null } {
+  // Filter off, or no per-kind answer to give: the crawl's own total, which is
+  // the only number here that covers every link.
+  if (counts.showTemplateLinks || !counts.known) {
+    return { value: metricValue(counts.total), hiddenNote: null }
+  }
+  // The neighbour read is bounded, so a truncated list can only prove a lower
+  // bound. Say so rather than presenting a partial count as the answer.
+  return {
+    value: counts.truncated ? `${metricValue(counts.visible)}+` : metricValue(counts.visible),
+    hiddenNote: counts.hidden === 0
+      ? null
+      : counts.truncated
+        ? `At least ${metricValue(counts.hidden)} nav and footer hidden`
+        : `${metricValue(counts.hidden)} nav and footer hidden`,
+  }
+}
+
+function LinkMetricTile({ label, value, hiddenNote }: {
+  label: string
+  value: string
+  hiddenNote?: string | null
+}) {
   return (
-    <dl className="grid grid-cols-2 divide-x divide-y divide-default rounded-lg border border-default sm:grid-cols-4 sm:divide-y-0">
-      <div className="px-4 py-3">
-        <dt className="text-xs text-muted">Clicks from home</dt>
-        <dd className="mt-1 text-sm font-medium tabular-nums text-heading">{page.depth ?? 'Not reached'}</dd>
-      </div>
-      <div className="px-4 py-3">
-        <dt className="text-xs text-muted">Links in</dt>
-        <dd className="mt-1 text-sm font-medium tabular-nums text-heading">{metricValue(page.inboundUniqueEdges)}</dd>
-      </div>
-      <div className="px-4 py-3">
-        <dt className="text-xs text-muted">Links out</dt>
-        <dd className="mt-1 text-sm font-medium tabular-nums text-heading">{metricValue(page.outboundUniqueEdges)}</dd>
-      </div>
-      <div className="px-4 py-3">
-        <dt className="text-xs text-muted">Link importance</dt>
-        <dd className="mt-1 text-sm font-medium tabular-nums text-heading">{formatImportance(page.linkScoreNormalized)}</dd>
-      </div>
-    </dl>
+    <div className="px-4 py-3">
+      <dt className="text-xs text-muted">{label}</dt>
+      <dd className="mt-1 text-sm font-medium tabular-nums text-heading">{value}</dd>
+      {hiddenNote && <dd className="mt-0.5 text-xs text-muted">{hiddenNote}</dd>}
+    </div>
+  )
+}
+
+function LinkMetrics({ page, inbound, outbound }: {
+  page: InspectableCrawlPage
+  inbound: ReturnType<typeof linkTileCount>
+  outbound: ReturnType<typeof linkTileCount>
+}) {
+  // Depth and link importance are computed by the crawl engine over the FULL
+  // link graph, before nav and footer links are classified, so the filter does
+  // not change them. Saying so is the honest fix: quietly leaving them beside
+  // filtered numbers implies they were filtered too.
+  const filtered = Boolean(inbound.hiddenNote || outbound.hiddenNote)
+  return (
+    <>
+      <dl className="grid grid-cols-2 divide-x divide-y divide-default rounded-lg border border-default sm:grid-cols-4 sm:divide-y-0">
+        <LinkMetricTile label="Clicks from home" value={String(page.depth ?? 'Not reached')} />
+        <LinkMetricTile label="Links in" value={inbound.value} hiddenNote={inbound.hiddenNote} />
+        <LinkMetricTile label="Links out" value={outbound.value} hiddenNote={outbound.hiddenNote} />
+        <LinkMetricTile label="Link importance" value={formatImportance(page.linkScoreNormalized)} />
+      </dl>
+      {filtered && (
+        <p className="mt-2 text-xs text-muted">
+          Clicks from home and link importance always count every link, including nav and footer.
+        </p>
+      )}
+    </>
   )
 }
 
@@ -466,8 +517,29 @@ function PageInspector({
   // hiding would make the two disagree about the same page.
   const visibleInbound = showTemplateLinks ? inbound : inbound.filter((edge) => !edge.isTemplate)
   const visibleOutbound = showTemplateLinks ? outbound : outbound.filter((edge) => !edge.isTemplate)
+  // Until the neighbour read lands there is no per-kind answer, so the tiles
+  // stay on the crawl's own totals rather than briefly showing a zero.
+  const linkCountsKnown = !isLoading && !error
   const hiddenInboundCount = inbound.length - visibleInbound.length
   const hiddenOutboundCount = outbound.length - visibleOutbound.length
+  // The tiles read from exactly the lists the tables render, so the panel
+  // cannot show two different answers for the same page again.
+  const inboundTile = linkTileCount({
+    total: page.inboundUniqueEdges,
+    visible: visibleInbound.length,
+    hidden: hiddenInboundCount,
+    truncated: inboundTruncated,
+    showTemplateLinks,
+    known: linkCountsKnown,
+  })
+  const outboundTile = linkTileCount({
+    total: page.outboundUniqueEdges,
+    visible: visibleOutbound.length,
+    hidden: hiddenOutboundCount,
+    truncated: outboundTruncated,
+    showTemplateLinks,
+    known: linkCountsKnown,
+  })
   return (
     <section className="border-t border-default pt-5" aria-labelledby="site-health-page-inspector-title">
       <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-start">
@@ -514,7 +586,7 @@ function PageInspector({
         <h3 id="site-health-page-links-heading" className="text-base font-semibold text-heading">Internal links</h3>
         <p className="mt-1 text-sm text-secondary">Observed links to and from this page in the selected scan.</p>
         <div className="mt-4">
-          <LinkMetrics page={page} />
+          <LinkMetrics page={page} inbound={inboundTile} outbound={outboundTile} />
         </div>
         <div className="mt-5">
           {isLoading ? (

--- a/apps/web/test/site-health-section.test.tsx
+++ b/apps/web/test/site-health-section.test.tsx
@@ -17,7 +17,7 @@ import {
   getApiV1ProjectsByNameTechnicalAeoStructureQueryKey,
 } from '@ainyc/canonry-api-client/react-query'
 
-import { SiteHealthSection } from '../src/components/project/SiteHealthSection.js'
+import { linkTileCount, SiteHealthSection } from '../src/components/project/SiteHealthSection.js'
 import { heyClient } from '../src/api.js'
 
 const mutationMock = vi.hoisted(() => ({ mutate: vi.fn() }))
@@ -1329,4 +1329,187 @@ test('reads an empty content-link set as a finding, with the real hidden counts'
   // Switching nav links on shows them rather than the finding.
   fireEvent.click(screen.getByRole('checkbox', { name: 'Show nav and footer links' }))
   expect(screen.queryByText('No content links to this page. 2 nav and footer links hidden.')).toBeNull()
+})
+
+test('the link tiles count exactly what the tables list, in both toggle states', async () => {
+  // Reported on canonry.ai: the tiles read "Links in 48 / Links out 26" while
+  // the tables directly beneath read "(1)" and "(2)". Both were right, and
+  // side by side with no labels the pair read as a broken table.
+  const fetchMock = vi.fn(async () => new Response('{}', { status: 500 }))
+  vi.stubGlobal('fetch', fetchMock)
+  // The crawl's own totals for this page must match the links seeded below,
+  // the way a real crawl's do: 5 unique inbound edges, 2 outbound.
+  const servicesWithLinks = { ...servicesPage, inboundUniqueEdges: 5, outboundUniqueEdges: 2 }
+  const queryClient = seedTemplateLinkGraph({
+    nodes: [
+      { ...homePage, x: 0, y: 0 },
+      { ...servicesWithLinks, x: 1, y: 1 },
+      { ...contactPage, x: -1, y: 1 },
+    ],
+  })
+
+  const link = (edgeKey: string, isTemplate: boolean) => ({
+    edgeKey,
+    sourceNodeKey: 'page_home',
+    sourceUrl: 'https://citypoint.example/',
+    targetNodeKey: 'page_services',
+    targetUrl: servicesPage.url,
+    relation: 'anchor',
+    internal: true,
+    followable: true,
+    occurrences: 1,
+    followableOccurrences: 1,
+    nofollowOccurrences: 0,
+    anchors: ['Roof repair'],
+    isTemplate,
+    templateRatio: isTemplate ? 0.9 : 0.1,
+  })
+  // One content link in among four nav links in; two content links out.
+  const inbound = [link('in-content', false), ...Array.from({ length: 4 }, (_, i) => link(`in-nav-${i}`, true))]
+  const outbound = [link('out-a', false), link('out-b', false)]
+  queryClient.setQueryData(getApiV1ProjectsByNameTechnicalAeoInternalLinksNeighborsQueryKey({
+    client: heyClient,
+    path: { name: projectName },
+    query: { runId: 'run_1', nodeKey: 'page_services', limit: 100 },
+  }), {
+    project: projectName,
+    hasCrawlData: true,
+    runId: 'run_1',
+    nodeKey: 'page_services',
+    url: servicesPage.url,
+    templateDetection: 'applied',
+    linkKind: 'all',
+    inbound,
+    outbound,
+    inboundTruncated: false,
+    outboundTruncated: false,
+  })
+
+  renderSection(queryClient)
+  fireEvent.click(screen.getByRole('button', { name: '/services/roof-repair' }))
+
+  const tile = (label: string) => {
+    const term = screen.getByText(label)
+    return term.parentElement as HTMLElement
+  }
+
+  // Filter ON (the default): tile and table agree on the content-only count,
+  // and the hidden amount is named rather than silently dropped.
+  await waitFor(() => expect(within(tile('Links in')).getByText('1')).toBeTruthy())
+  expect(within(tile('Links in')).getByText('4 nav and footer hidden')).toBeTruthy()
+  expect(screen.getByRole('region', { name: 'Links in (1)' })).toBeTruthy()
+  // The hidden count is exactly the difference between the two states.
+  expect(within(tile('Links out')).getByText('2')).toBeTruthy()
+  expect(within(tile('Links out')).queryByText(/nav and footer hidden/)).toBeNull()
+  expect(screen.getByRole('region', { name: 'Links out (2)' })).toBeTruthy()
+
+  // Depth and importance are full-graph values, and the panel says so rather
+  // than letting them look filtered.
+  expect(screen.getByText('Clicks from home and link importance always count every link, including nav and footer.')).toBeTruthy()
+
+  // Filter OFF: both show totals and the secondary line disappears.
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Show nav and footer links' }))
+  expect(within(tile('Links in')).getByText('5')).toBeTruthy()
+  expect(within(tile('Links in')).queryByText(/nav and footer hidden/)).toBeNull()
+  expect(screen.getByRole('region', { name: 'Links in (5)' })).toBeTruthy()
+  expect(screen.queryByText('Clicks from home and link importance always count every link, including nav and footer.')).toBeNull()
+})
+
+test('a link tile never presents a bounded count as a total', () => {
+  // The neighbour read is capped, so a truncated list proves only a lower
+  // bound. Rounding that into a flat number would be a quiet lie.
+  expect(linkTileCount({ total: 48, visible: 1, hidden: 47, truncated: false, showTemplateLinks: false, known: true }))
+    .toEqual({ value: '1', hiddenNote: '47 nav and footer hidden' })
+
+  expect(linkTileCount({ total: 500, visible: 100, hidden: 400, truncated: true, showTemplateLinks: false, known: true }))
+    .toEqual({ value: '100+', hiddenNote: 'At least 400 nav and footer hidden' })
+
+  // Filter off: the crawl's own total, and no secondary line.
+  expect(linkTileCount({ total: 48, visible: 1, hidden: 47, truncated: false, showTemplateLinks: true, known: true }))
+    .toEqual({ value: '48', hiddenNote: null })
+
+  // Nothing hidden is not a note worth showing.
+  expect(linkTileCount({ total: 3, visible: 3, hidden: 0, truncated: false, showTemplateLinks: false, known: true }))
+    .toEqual({ value: '3', hiddenNote: null })
+
+  // Before the neighbour read lands there is no per-kind answer, so the tile
+  // shows the total rather than flashing a zero.
+  expect(linkTileCount({ total: 48, visible: 0, hidden: 0, truncated: false, showTemplateLinks: false, known: false }))
+    .toEqual({ value: '48', hiddenNote: null })
+})
+
+test('both count fixes hold at once: filtered tiles and no self-link anywhere', async () => {
+  // The two bugs on this panel were independent and had to be true together:
+  // the tiles must follow the toggle, and neither surface may count a page's
+  // link to itself. This is a page with template inbound AND a self-link.
+  const fetchMock = vi.fn(async () => new Response('{}', { status: 500 }))
+  vi.stubGlobal('fetch', fetchMock)
+  // 2 real inbound (1 content, 1 nav) and 1 real outbound, as the crawl's own
+  // page metrics count them: the self-link is in neither, at either layer.
+  const servicesWithLinks = { ...servicesPage, inboundUniqueEdges: 2, outboundUniqueEdges: 1 }
+  const queryClient = seedTemplateLinkGraph({
+    nodes: [
+      { ...homePage, x: 0, y: 0 },
+      { ...servicesWithLinks, x: 1, y: 1 },
+      { ...contactPage, x: -1, y: 1 },
+    ],
+  })
+  const link = (edgeKey: string, from: string, to: string, isTemplate: boolean) => ({
+    edgeKey,
+    sourceNodeKey: from,
+    sourceUrl: `https://citypoint.example/${from}`,
+    targetNodeKey: to,
+    targetUrl: `https://citypoint.example/${to}`,
+    relation: 'anchor',
+    internal: true,
+    followable: true,
+    occurrences: 1,
+    followableOccurrences: 1,
+    nofollowOccurrences: 0,
+    anchors: isTemplate ? [] : ['Roof repair'],
+    isTemplate,
+    templateRatio: isTemplate ? 0.9 : 0.1,
+  })
+  queryClient.setQueryData(getApiV1ProjectsByNameTechnicalAeoInternalLinksNeighborsQueryKey({
+    client: heyClient,
+    path: { name: projectName },
+    query: { runId: 'run_1', nodeKey: 'page_services', limit: 100 },
+  }), {
+    project: projectName,
+    hasCrawlData: true,
+    runId: 'run_1',
+    nodeKey: 'page_services',
+    url: servicesPage.url,
+    templateDetection: 'applied',
+    linkKind: 'all',
+    // The API no longer returns the self-link in either direction: the writer
+    // drops it and the migration cleared the stored ones.
+    inbound: [link('in-content', 'page_home', 'page_services', false), link('in-nav', 'page_contact', 'page_services', true)],
+    outbound: [link('out-content', 'page_services', 'page_home', false)],
+    inboundTruncated: false,
+    outboundTruncated: false,
+  })
+
+  renderSection(queryClient)
+  fireEvent.click(screen.getByRole('button', { name: '/services/roof-repair' }))
+
+  const tile = (label: string) => screen.getByText(label).parentElement as HTMLElement
+  const selfLinkRows = () => screen.queryAllByText('/page_services')
+
+  // Filter on: tiles match the tables, and no self-link is listed anywhere.
+  await waitFor(() => expect(within(tile('Links in')).getByText('1')).toBeTruthy())
+  expect(within(tile('Links in')).getByText('1 nav and footer hidden')).toBeTruthy()
+  expect(screen.getByRole('region', { name: 'Links in (1)' })).toBeTruthy()
+  expect(within(tile('Links out')).getByText('1')).toBeTruthy()
+  expect(screen.getByRole('region', { name: 'Links out (1)' })).toBeTruthy()
+  expect(selfLinkRows()).toHaveLength(0)
+
+  // Filter off: tiles show the crawl's totals, which also exclude the
+  // self-link, and the tables agree with them.
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Show nav and footer links' }))
+  expect(within(tile('Links in')).getByText('2')).toBeTruthy()
+  expect(screen.getByRole('region', { name: 'Links in (2)' })).toBeTruthy()
+  expect(within(tile('Links out')).getByText('1')).toBeTruthy()
+  expect(screen.getByRole('region', { name: 'Links out (1)' })).toBeTruthy()
+  expect(selfLinkRows()).toHaveLength(0)
 })

--- a/packages/canonry/src/execute-site-audit.ts
+++ b/packages/canonry/src/execute-site-audit.ts
@@ -28,6 +28,7 @@ import {
   SITE_AUDIT_MAX_PAGE_LIMIT,
   deriveSiteHealthState,
   factorStatusFromScore,
+  isSelfLink,
   type RunStatus,
   type SiteAuditCrossCuttingIssueDto,
   type SiteAuditFactorSummaryDto,
@@ -470,6 +471,14 @@ export async function executeSiteAudit(
   }
 
   const persistEdge = (tx: DatabaseTransaction, edge: CrawlEdgeObservation, now: string): void => {
+    // A page linking to itself is not a link TO or FROM another page, and the
+    // engine's own page metrics already exclude it. Persisting it made the
+    // edge table disagree with the page rows built from the same crawl: a
+    // self-loop landed in BOTH the inbound and the outbound neighbour list, so
+    // every self-linking page read one higher in each direction than its own
+    // tiles. Dropping it here is what makes every reader agree by
+    // construction, instead of each one remembering to filter.
+    if (isSelfLink(edge.from, edge.to)) return
     observedEdges.set(edge.key, edge)
     tx.insert(siteCrawlEdges).values({
       id: crypto.randomUUID(), projectId, runId, attemptId, edgeKey: edge.key,

--- a/packages/canonry/test/execute-site-audit.test.ts
+++ b/packages/canonry/test/execute-site-audit.test.ts
@@ -246,6 +246,63 @@ describe('executeSiteAudit', () => {
     expect(db.select().from(siteAuditPages).where(eq(siteAuditPages.runId, runId)).all()).toHaveLength(2)
   })
 
+  it('never stores a self-link, so edges agree with the page metrics', async () => {
+    // A page linking to itself is not a link to or from another page, and the
+    // engine already excludes it from that page's metrics. Storing it made a
+    // self-loop appear in BOTH neighbour lists, so the page read one link
+    // higher in each direction than its own tiles.
+    vi.mocked(runSiteCrawl).mockImplementation(async (_url, options) => {
+      await options.onEvent?.({
+        type: 'pages', sequence: 1, batchId: 'pages-1', checksum: 'pages-checksum',
+        rows: [page('page:root', 'https://example.com/'), page('page:a', 'https://example.com/a')],
+      })
+      await options.onEvent?.({
+        type: 'edges', sequence: 2, batchId: 'edges-1', checksum: 'edges-checksum',
+        rows: [
+          {
+            key: 'edge:root-a', from: 'https://example.com/', to: 'https://example.com/a',
+            type: 'anchor', classification: 'internal',
+            totalOccurrences: 2, followableOccurrences: 2, nofollowOccurrences: 0,
+            anchorSummaries: [{ text: 'A', occurrences: 2 }],
+          },
+          {
+            // The self-link, with no anchor text, exactly as observed.
+            key: 'edge:a-a', from: 'https://example.com/a', to: 'https://example.com/a',
+            type: 'anchor', classification: 'internal',
+            totalOccurrences: 1, followableOccurrences: 1, nofollowOccurrences: 0,
+            anchorSummaries: [],
+          },
+        ],
+      })
+      await options.onEvent?.({
+        type: 'metrics', sequence: 3, batchId: 'metrics-1', checksum: 'metrics-checksum',
+        rows: [
+          { key: 'page:root', metrics: page('page:root', 'https://example.com/').metrics },
+          { key: 'page:a', metrics: page('page:a', 'https://example.com/a').metrics },
+        ],
+      })
+      const endSummary = summary()
+      await options.onEvent?.({ type: 'summary', sequence: 4, batchId: 'summary', checksum: 'summary', summary: endSummary })
+      return { mode: 'summary', summary: endSummary, deadLinks: { state: 'disabled', findings: [] } }
+    })
+    const runId = seedRun()
+    await executeSiteAudit(db, runId, projectId)
+
+    const edges = db.select().from(siteCrawlEdges).where(eq(siteCrawlEdges.runId, runId)).all()
+    expect(edges.map((edge) => edge.edgeKey)).toEqual(['edge:root-a'])
+    expect(edges.every((edge) => edge.sourceUrl !== edge.targetUrl)).toBe(true)
+    // The published graph sample cannot contain one either, so the map is
+    // never asked to draw a loop from a node to itself.
+    expect(db.select().from(siteCrawlGraphEdges).where(eq(siteCrawlGraphEdges.runId, runId)).all()
+      .every((edge) => edge.sourceNodeKey !== edge.targetNodeKey)).toBe(true)
+
+    // The page metrics the engine reported are untouched: importance and depth
+    // never counted the self-link, and dropping it changes neither.
+    const pageA = db.select().from(siteCrawlPages).where(eq(siteCrawlPages.nodeKey, 'page:a')).get()!
+    expect(pageA.depth).toBe(page('page:a', 'https://example.com/a').metrics.shortestFollowableAnchorDepth)
+    expect(pageA.linkScoreNormalized).toBe(page('page:a', 'https://example.com/a').metrics.linkScore)
+  })
+
   it('publishes the crawl when ForceAtlas2 times out and records layout unavailability', async () => {
     vi.mocked(runSiteCrawl).mockImplementation(async (_url, options) => emitCompleteGraph(options))
     const runId = seedRun()

--- a/packages/contracts/src/technical-aeo.ts
+++ b/packages/contracts/src/technical-aeo.ts
@@ -232,6 +232,18 @@ export const siteCrawlTerminationSchema = z.enum([
 ])
 export type SiteCrawlTermination = z.infer<typeof siteCrawlTerminationSchema>
 
+/**
+ * A link from a page to itself.
+ *
+ * Self-links carry no navigational meaning: they are not a link to or from
+ * another page, and the crawl engine already leaves them out of a page's
+ * inbound and outbound metrics. Defined once here so every writer and reader
+ * uses the same rule, and compared on the normalized URLs the crawl stores.
+ */
+export function isSelfLink(sourceUrl: string, targetUrl: string): boolean {
+  return sourceUrl === targetUrl
+}
+
 /** Shared meaning behind Site Health node color across API, agents, and UI. */
 /**
  * What a crawled page is, for a reader.

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -272,6 +272,23 @@ export function relinkOrphanedSnapshotQueryIds(tx: MigrationDb): void {
  * idempotent: only `health_state IS NULL` rows are candidates, so a re-run is
  * a no-op.
  */
+/**
+ * Remove stored self-links (v132).
+ *
+ * Pure data change, no schema change. An older binary reading these tables
+ * simply sees fewer edge rows, and the rows removed are ones it was counting
+ * INCONSISTENTLY with its own page metrics, so a downgrade is strictly better
+ * off without them.
+ *
+ * The graph sample is cleared by node key because a published sample edge is
+ * already resolved to nodes; the source table is cleared by the normalized
+ * URLs the writer compares in `isSelfLink`.
+ */
+export function dropSiteCrawlSelfLinks(tx: MigrationDb): void {
+  tx.run(sql.raw('DELETE FROM site_crawl_edges WHERE source_url = target_url'))
+  tx.run(sql.raw('DELETE FROM site_crawl_graph_edges WHERE source_node_key = target_node_key'))
+}
+
 export function backfillSiteCrawlPageHealthState(tx: MigrationDb): void {
   const BATCH = 500
   for (;;) {
@@ -3464,6 +3481,26 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
         ON site_crawl_edges(project_id, run_id, attempt_id, internal, is_template, edge_key)`,
     ],
     run: backfillSiteCrawlTemplateLinks,
+  },
+  {
+    version: 132,
+    name: 'site-crawl-drop-self-links',
+    // A page linking to itself is not a link to or from another page, and the
+    // crawl engine already excludes self-loops from a page's inbound and
+    // outbound metrics. The edge tables kept them, so the stored edges
+    // disagreed with the page rows produced by the same crawl: a self-loop
+    // appeared in BOTH neighbour lists, so every self-linking page read one
+    // higher in each direction than its own tiles.
+    //
+    // The writer now drops them, which fixes new scans. This clears the ones
+    // already stored so an existing scan is correct without a re-crawl.
+    // Comparing the stored normalized URLs is exactly the rule the writer
+    // applies (`isSelfLink`), expressed as the equality SQL can do without
+    // reimplementing any derivation.
+    //
+    // Idempotent: a re-run deletes nothing once the rows are gone.
+    statements: [],
+    run: dropSiteCrawlSelfLinks,
   },
 ]
 

--- a/packages/db/test/migration-downgrade-safety.test.ts
+++ b/packages/db/test/migration-downgrade-safety.test.ts
@@ -107,6 +107,15 @@ const RUN_HOOK_ALLOWLIST: ReadonlySet<number> = new Set([
   // which are immutable per attempt; those rows keep
   // `template_links_excluded = 0` so the map can say so.
   131,
+  // v132 deletes stored self-links and makes NO schema change. It uses run()
+  // only because the statement allowlist is schema-shaped; the work is a
+  // DELETE of rows the crawl engine already excluded from the page metrics
+  // built in the same crawl, so the edge tables disagreed with their own page
+  // rows and every self-linking page read one link higher in each direction.
+  // Downgrade-safe: an older binary sees fewer edge rows, and the ones removed
+  // are exactly the rows it was miscounting, so it is strictly better off.
+  // Idempotent: a re-run deletes nothing once they are gone.
+  132,
 ])
 
 test(`migrations after v${DOWNGRADE_BASELINE} define no run() hook unless explicitly allowlisted`, () => {

--- a/packages/db/test/site-crawl-self-links-migration.test.ts
+++ b/packages/db/test/site-crawl-self-links-migration.test.ts
@@ -1,0 +1,90 @@
+import { test, expect, onTestFinished } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { sql } from 'drizzle-orm'
+import { createClient, migrate, projects, runs, siteCrawlAttempts, siteCrawlEdges } from '../src/index.js'
+import { dropSiteCrawlSelfLinks } from '../src/migrate.js'
+
+// v132 clears stored self-links. The crawl engine already leaves them out of a
+// page's inbound and outbound metrics, so keeping them made the edge tables
+// disagree with the page rows built by the same crawl: a self-loop landed in
+// BOTH neighbour lists, and every self-linking page read one link higher in
+// each direction than its own tiles.
+
+function freshDb() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-self-links-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  return db
+}
+
+function seedEdges(db: ReturnType<typeof createClient>) {
+  const projectId = crypto.randomUUID()
+  const runId = crypto.randomUUID()
+  const attemptId = crypto.randomUUID()
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: projectId, name: `p-${projectId.slice(0, 8)}`, displayName: 'p',
+    canonicalDomain: 'example.com', country: 'US', language: 'en',
+    createdAt: now, updatedAt: now,
+  }).run()
+  db.insert(runs).values({
+    id: runId, projectId, kind: 'site-audit', status: 'completed',
+    trigger: 'manual', createdAt: now,
+  }).run()
+  db.insert(siteCrawlAttempts).values({
+    id: attemptId, projectId, runId, attemptNumber: 1, state: 'completed',
+    createdAt: now, updatedAt: now,
+  }).run()
+  const edge = (edgeKey: string, from: string, to: string) => ({
+    id: crypto.randomUUID(), projectId, runId, attemptId, edgeKey,
+    sourceNodeKey: from, sourceUrl: `https://example.com/${from}`,
+    targetNodeKey: to, targetUrl: `https://example.com/${to}`,
+    relation: 'anchor', internal: true, followable: true,
+    occurrences: 1, followableOccurrences: 1, nofollowOccurrences: 0,
+    anchors: [], createdAt: now, updatedAt: now,
+  })
+  db.insert(siteCrawlEdges).values([
+    edge('a-b', 'a', 'b'),
+    edge('b-a', 'b', 'a'),
+    // The page links to itself, with no anchor text. This is the row that made
+    // /aeo-vs-seo-for-nyc-businesses read 4 inbound against a page row of 3.
+    edge('a-a', 'a', 'a'),
+  ]).run()
+  return { runId }
+}
+
+test('clears stored self-links and leaves every real link alone', () => {
+  const db = freshDb()
+  seedEdges(db)
+  expect(db.select().from(siteCrawlEdges).all()).toHaveLength(3)
+
+  dropSiteCrawlSelfLinks(db)
+
+  const remaining = db.select().from(siteCrawlEdges).all()
+  expect(remaining.map((row) => row.edgeKey).sort()).toEqual(['a-b', 'b-a'])
+  expect(remaining.every((row) => row.sourceUrl !== row.targetUrl)).toBe(true)
+})
+
+test('is idempotent, so a re-run removes nothing further', () => {
+  const db = freshDb()
+  seedEdges(db)
+  dropSiteCrawlSelfLinks(db)
+  const afterFirst = db.select().from(siteCrawlEdges).all().map((row) => row.edgeKey).sort()
+
+  expect(() => dropSiteCrawlSelfLinks(db)).not.toThrow()
+  expect(db.select().from(siteCrawlEdges).all().map((row) => row.edgeKey).sort()).toEqual(afterFirst)
+})
+
+test('leaves no self-link behind after a full migrate', () => {
+  const db = freshDb()
+  seedEdges(db)
+  dropSiteCrawlSelfLinks(db)
+  migrate(db)
+
+  const selfLinks = db.all(sql`SELECT count(*) AS n FROM site_crawl_edges WHERE source_url = target_url`) as Array<{ n: number }>
+  expect(selfLinks[0]!.n).toBe(0)
+})


### PR DESCRIPTION
Two independent count bugs on the same panel. Both showed *correct* numbers, and both made the panel read as broken.

## 1. The tiles ignored the link filter

**Repro:** canonry.ai page inspector — tiles read *"Links in 48 / Links out 26"*, tables directly beneath read *"Links in (1) / Links out (2)"*. The tiles counted all links; the tables honoured the content-only toggle #987 wired into the inspector.

**Fix.** The tiles now read from exactly the lists the tables render, so the two cannot disagree by construction. When template links are hidden the tile shows the content-only count with the hidden amount beneath it (`1` / *"47 nav and footer hidden"*); with the toggle on both show totals and the secondary line disappears.

The neighbour read is bounded at 100, so a truncated list can only prove a lower bound: it shows `100+` and *"At least 400 nav and footer hidden"* rather than presenting a partial count as a total. Before the read lands the tile keeps the crawl's total instead of flashing a zero.

**Clicks from home and link importance are not filtered, and are not made to look filtered.** I checked rather than assumed: both come from `page.metrics` in `@canonry/aeo-audit`, computed over the full link graph *before* nav/footer classification happens at publish. The filter cannot change them. Since they sit beside two now-filtered values, the tile group carries a one-line note when the filter is active: *"Clicks from home and link importance always count every link, including nav and footer."*

## 2. Self-links counted by one path, not the other

**Verified diagnosis** (`/aeo-vs-seo-for-nyc-businesses`): page row 3 in / 26 out, neighbours 4 in / 27 out. Exactly one self-loop, which lands in *both* lists.

**Fix at the source, one rule.** `isSelfLink` is defined once in the contract and applied where the edge is **written**, so no reader has to remember it. Migration **132** clears the rows already stored, so an existing scan is correct without a re-crawl.

### Consumers that were counting self-loops (all fixed by the same change)

| Consumer | Was counting self-loops? |
|---|---|
| Neighbours inbound/outbound lists | **Yes** — the reported bug, double-counted (both directions) |
| `internal-links` list + total | **Yes** |
| Graph read / published edge sample | **Yes** — the map was asked to draw a loop from a node to itself |
| Subgraph traversal | **Yes** |
| Path BFS | **Yes** |
| Changes diff | **Yes** |
| Template-link classifier | **Yes** — a self-link counted toward a target's page-share ratio |
| Page metrics (`inboundUniqueEdges`, `linkScore`, `depth`) | **No** — the engine already excluded them; this is the side that was right |
| Dead-link findings | **No** — separate table, unaffected |

**Why write-time, not a read filter.** A shared read predicate would still be a rule every one of those seven call sites has to remember. Excluding at write means the table cannot contain one, which is what "agree by construction" requires. The DELETE is a data change with no schema change, so it goes through a `run` hook and is listed in `RUN_HOOK_ALLOWLIST` with a downgrade-safety justification: an older binary just sees fewer edge rows, and the removed rows are exactly the ones it was miscounting.

## Tests

- Tiles and tables agree in **both** toggle states; the hidden count is exactly the difference
- `linkTileCount` unit test covers truncation (`100+`, "At least N"), nothing-hidden, and the pre-read state
- A self-link is never persisted; the published graph sample never contains one; importance and depth are unchanged by adding one
- Migration clears stored self-links, leaves real links alone, and is idempotent
- **Combined:** a page with template inbound *and* a self-link, checked in both toggle states — both fixes must hold simultaneously

## Validation

- `pnpm run typecheck` - clean
- `pnpm run test` - **639 files, 8165 tests, all passing**
- `pnpm run lint` - 0 errors
- `pnpm --filter @ainyc/canonry-api-client gen:check` - no drift
- `node scripts/sync-canonry-plugin.mjs --check` - matches v4.158.0
- `bash scripts/check-docs.sh` - passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)