### PR TITLE
feat: explain the site health metrics in plain words

### DIFF
--- a/apps/web/src/components/project/SiteHealthSection.tsx
+++ b/apps/web/src/components/project/SiteHealthSection.tsx
@@ -56,6 +56,7 @@ import { PageAuditEvidence } from './PageAuditEvidence.js'
 import { TechnicalAeoSection } from './TechnicalAeoSection.js'
 import { WriteButton } from '../shared/AccessControls.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
+import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { Button } from '../ui/button.js'
 
 type SiteHealthView = 'map' | 'inventory' | 'technical'
@@ -186,6 +187,66 @@ function metricValue(value: number | null | undefined): string {
   return value == null ? 'Not available' : numberFormatter.format(value)
 }
 
+/**
+ * What every Site Health number means, in plain words.
+ *
+ * One source of truth, because the same four metrics appear on the page
+ * inspector tiles AND as Pages table columns. Two copies would drift, and a
+ * metric explained differently in two places is worse than one not explained
+ * at all.
+ */
+type SiteHealthMetric =
+  | 'clicksFromHome'
+  | 'linksIn'
+  | 'linksOut'
+  | 'linkImportance'
+  | 'technicalScore'
+  | 'linkTimes'
+  | 'pagesFound'
+  | 'pagesChecked'
+  | 'internalLinks'
+
+const SITE_HEALTH_METRIC_HELP: Record<SiteHealthMetric, string> = {
+  clicksFromHome: 'How many clicks it takes to reach this page from the home page, following links.',
+  linksIn: 'How many other pages link to this page.',
+  linksOut: 'How many other pages this page links to.',
+  linkImportance: 'How much link value flows to this page, based on how many pages link to it and how important those pages are. Shown relative to the highest page on this site, which is 100%.',
+  technicalScore: 'How well this page is set up for AI and search engines to read, from 0 to 100. Open a page to see what it is marked down for.',
+  linkTimes: 'How many times this link appears on the page it comes from.',
+  pagesFound: 'How many pages this scan discovered, whether or not it could load them.',
+  pagesChecked: 'How many of the pages it found this scan actually loaded.',
+  internalLinks: 'How many links between pages on this site the scan recorded.',
+}
+
+/**
+ * Metrics the crawl engine computes over the FULL link graph, before nav and
+ * footer links are told apart. The filter cannot change them, so they say so
+ * out loud: without that, a reader seeing them beside two filtered counts
+ * would reasonably assume all four were filtered.
+ */
+const FULL_GRAPH_METRICS: ReadonlySet<SiteHealthMetric> = new Set([
+  'clicksFromHome',
+  'linkImportance',
+  'internalLinks',
+  'pagesFound',
+  'pagesChecked',
+])
+
+/**
+ * Help text for one metric, told truthfully for the surface it sits on.
+ * `filtered` means THIS surface is currently hiding nav and footer links.
+ */
+export function siteHealthMetricHelp(metric: SiteHealthMetric, filtered: boolean): string {
+  const base = SITE_HEALTH_METRIC_HELP[metric]
+  if (FULL_GRAPH_METRICS.has(metric)) {
+    return `${base} This always counts every link, including nav and footer.`
+  }
+  if (metric === 'technicalScore' || metric === 'linkTimes') return base
+  return filtered
+    ? `${base} Right now this counts content links only. Nav and footer links are hidden.`
+    : `${base} This counts every link, including nav and footer.`
+}
+
 /** Counted nouns in map copy. "1 content links" reads like a bug report. */
 function countedLinks(count: number, noun: string): string {
   return `${numberFormatter.format(count)} ${noun}${count === 1 ? '' : 's'}`
@@ -306,15 +367,19 @@ export function linkTileCount(counts: {
   truncated: boolean
   showTemplateLinks: boolean
   known: boolean
-}): { value: string; hiddenNote: string | null } {
+}): { value: string; hiddenNote: string | null; filtered: boolean } {
+  // `filtered` is decided HERE, by the same branch that decides the number, so
+  // the tooltip can never describe a count this function did not produce.
+  //
   // Filter off, or no per-kind answer to give: the crawl's own total, which is
   // the only number here that covers every link.
   if (counts.showTemplateLinks || !counts.known) {
-    return { value: metricValue(counts.total), hiddenNote: null }
+    return { value: metricValue(counts.total), hiddenNote: null, filtered: false }
   }
   // The neighbour read is bounded, so a truncated list can only prove a lower
   // bound. Say so rather than presenting a partial count as the answer.
   return {
+    filtered: true,
     value: counts.truncated ? `${metricValue(counts.visible)}+` : metricValue(counts.visible),
     hiddenNote: counts.hidden === 0
       ? null
@@ -324,14 +389,18 @@ export function linkTileCount(counts: {
   }
 }
 
-function LinkMetricTile({ label, value, hiddenNote }: {
+function LinkMetricTile({ label, value, hiddenNote, help }: {
   label: string
   value: string
   hiddenNote?: string | null
+  help: string
 }) {
   return (
     <div className="px-4 py-3">
-      <dt className="text-xs text-muted">{label}</dt>
+      <dt className="flex items-center gap-1 text-xs text-muted">
+        {label}
+        <InfoTooltip text={help} />
+      </dt>
       <dd className="mt-1 text-sm font-medium tabular-nums text-heading">{value}</dd>
       {hiddenNote && <dd className="mt-0.5 text-xs text-muted">{hiddenNote}</dd>}
     </div>
@@ -347,16 +416,37 @@ function LinkMetrics({ page, inbound, outbound }: {
   // link graph, before nav and footer links are classified, so the filter does
   // not change them. Saying so is the honest fix: quietly leaving them beside
   // filtered numbers implies they were filtered too.
-  const filtered = Boolean(inbound.hiddenNote || outbound.hiddenNote)
+  // The footnote only earns its space when something is actually hidden; the
+  // tooltips key off the filter itself, which is in force even on a page that
+  // happens to have no nav or footer links.
+  const anythingHidden = Boolean(inbound.hiddenNote || outbound.hiddenNote)
   return (
     <>
       <dl className="grid grid-cols-2 divide-x divide-y divide-default rounded-lg border border-default sm:grid-cols-4 sm:divide-y-0">
-        <LinkMetricTile label="Clicks from home" value={String(page.depth ?? 'Not reached')} />
-        <LinkMetricTile label="Links in" value={inbound.value} hiddenNote={inbound.hiddenNote} />
-        <LinkMetricTile label="Links out" value={outbound.value} hiddenNote={outbound.hiddenNote} />
-        <LinkMetricTile label="Link importance" value={formatImportance(page.linkScoreNormalized)} />
+        <LinkMetricTile
+          label="Clicks from home"
+          value={String(page.depth ?? 'Not reached')}
+          help={siteHealthMetricHelp('clicksFromHome', false)}
+        />
+        <LinkMetricTile
+          label="Links in"
+          value={inbound.value}
+          hiddenNote={inbound.hiddenNote}
+          help={siteHealthMetricHelp('linksIn', inbound.filtered)}
+        />
+        <LinkMetricTile
+          label="Links out"
+          value={outbound.value}
+          hiddenNote={outbound.hiddenNote}
+          help={siteHealthMetricHelp('linksOut', outbound.filtered)}
+        />
+        <LinkMetricTile
+          label="Link importance"
+          value={formatImportance(page.linkScoreNormalized)}
+          help={siteHealthMetricHelp('linkImportance', false)}
+        />
       </dl>
-      {filtered && (
+      {anythingHidden && (
         <p className="mt-2 text-xs text-muted">
           Clicks from home and link importance always count every link, including nav and footer.
         </p>
@@ -395,6 +485,22 @@ export function emptyLinkCopy(
   return `${lead} ${hidden}`
 }
 
+/**
+ * A table column heading with its plain-words explanation attached.
+ *
+ * Table columns read the server's full-graph counts, so they are never the
+ * filtered variant. The page inspector tiles are, which is why they call
+ * `siteHealthMetricHelp` themselves with the live toggle state.
+ */
+function ColumnLabel({ label, metric }: { label: string; metric: SiteHealthMetric }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {label}
+      <InfoTooltip text={siteHealthMetricHelp(metric, false)} />
+    </span>
+  )
+}
+
 function NeighborTable({
   direction,
   edges,
@@ -428,7 +534,7 @@ function NeighborTable({
               <tr>
                 <th scope="col">Page</th>
                 <th scope="col">Anchor text</th>
-                <th scope="col">Times</th>
+                <th scope="col"><ColumnLabel label="Times" metric="linkTimes" /></th>
               </tr>
             </thead>
             <tbody>
@@ -700,11 +806,11 @@ function InventoryTable({
             <tr>
               <th scope="col">Page</th>
               <th scope="col" title={siteGraphStatusDescription('eligible')}>Status</th>
-              <th scope="col">Clicks from home</th>
-              <th scope="col">Links in</th>
-              <th scope="col">Links out</th>
-              <th scope="col">Link importance</th>
-              <th scope="col">Score</th>
+              <th scope="col"><ColumnLabel label="Clicks from home" metric="clicksFromHome" /></th>
+              <th scope="col"><ColumnLabel label="Links in" metric="linksIn" /></th>
+              <th scope="col"><ColumnLabel label="Links out" metric="linksOut" /></th>
+              <th scope="col"><ColumnLabel label="Link importance" metric="linkImportance" /></th>
+              <th scope="col"><ColumnLabel label="Score" metric="technicalScore" /></th>
             </tr>
           </thead>
           <tbody>
@@ -1296,11 +1402,17 @@ export function SiteHealthSection({ projectName, projectId }: { projectName: str
       {crawl?.hasCrawlData && view !== 'technical' && (
         <div className="grid grid-cols-2 divide-x divide-y divide-default rounded-lg border border-default bg-surface-subtle sm:grid-cols-4 sm:divide-y-0">
           <div className="px-4 py-3">
-            <div className="text-xs text-muted">Pages found</div>
+            <div className="flex items-center gap-1 text-xs text-muted">
+              Pages found
+              <InfoTooltip text={siteHealthMetricHelp('pagesFound', false)} />
+            </div>
             <div className="mt-1 text-xl font-semibold tabular-nums text-heading">{metricValue(crawl.counts.pagesDiscovered)}</div>
           </div>
           <div className="px-4 py-3">
-            <div className="text-xs text-muted">Pages checked</div>
+            <div className="flex items-center gap-1 text-xs text-muted">
+              Pages checked
+              <InfoTooltip text={siteHealthMetricHelp('pagesChecked', false)} />
+            </div>
             <div className="mt-1 text-xl font-semibold tabular-nums text-heading">{metricValue(crawl.counts.pagesFetched)}</div>
           </div>
           <div className="px-4 py-3">
@@ -1308,7 +1420,10 @@ export function SiteHealthSection({ projectName, projectId }: { projectName: str
             <div className="mt-1 text-xl font-semibold tabular-nums text-heading">{metricValue(crawl.counts.pagesEligible)}</div>
           </div>
           <div className="px-4 py-3">
-            <div className="text-xs text-muted">Internal links</div>
+            <div className="flex items-center gap-1 text-xs text-muted">
+              Internal links
+              <InfoTooltip text={siteHealthMetricHelp('internalLinks', false)} />
+            </div>
             <div className="mt-1 text-xl font-semibold tabular-nums text-heading">{metricValue(internalLinkCount)}</div>
           </div>
         </div>

--- a/apps/web/test/site-health-section.test.tsx
+++ b/apps/web/test/site-health-section.test.tsx
@@ -17,7 +17,7 @@ import {
   getApiV1ProjectsByNameTechnicalAeoStructureQueryKey,
 } from '@ainyc/canonry-api-client/react-query'
 
-import { linkTileCount, SiteHealthSection } from '../src/components/project/SiteHealthSection.js'
+import { linkTileCount, siteHealthMetricHelp, SiteHealthSection } from '../src/components/project/SiteHealthSection.js'
 import { heyClient } from '../src/api.js'
 
 const mutationMock = vi.hoisted(() => ({ mutate: vi.fn() }))
@@ -1419,23 +1419,27 @@ test('a link tile never presents a bounded count as a total', () => {
   // The neighbour read is capped, so a truncated list proves only a lower
   // bound. Rounding that into a flat number would be a quiet lie.
   expect(linkTileCount({ total: 48, visible: 1, hidden: 47, truncated: false, showTemplateLinks: false, known: true }))
-    .toEqual({ value: '1', hiddenNote: '47 nav and footer hidden' })
+    .toEqual({ value: '1', hiddenNote: '47 nav and footer hidden', filtered: true })
 
   expect(linkTileCount({ total: 500, visible: 100, hidden: 400, truncated: true, showTemplateLinks: false, known: true }))
-    .toEqual({ value: '100+', hiddenNote: 'At least 400 nav and footer hidden' })
+    .toEqual({ value: '100+', hiddenNote: 'At least 400 nav and footer hidden', filtered: true })
 
   // Filter off: the crawl's own total, and no secondary line.
   expect(linkTileCount({ total: 48, visible: 1, hidden: 47, truncated: false, showTemplateLinks: true, known: true }))
-    .toEqual({ value: '48', hiddenNote: null })
+    .toEqual({ value: '48', hiddenNote: null, filtered: false })
 
   // Nothing hidden is not a note worth showing.
+  // Nothing hidden, but the filter IS in force: no note to show, yet the tile
+  // is still a content-only count and the tooltip must say so.
   expect(linkTileCount({ total: 3, visible: 3, hidden: 0, truncated: false, showTemplateLinks: false, known: true }))
-    .toEqual({ value: '3', hiddenNote: null })
+    .toEqual({ value: '3', hiddenNote: null, filtered: true })
 
   // Before the neighbour read lands there is no per-kind answer, so the tile
   // shows the total rather than flashing a zero.
+  // A legacy scan cannot tell nav from content, so the tile is NOT filtered:
+  // claiming "content links only" there would be a lie.
   expect(linkTileCount({ total: 48, visible: 0, hidden: 0, truncated: false, showTemplateLinks: false, known: false }))
-    .toEqual({ value: '48', hiddenNote: null })
+    .toEqual({ value: '48', hiddenNote: null, filtered: false })
 })
 
 test('both count fixes hold at once: filtered tiles and no self-link anywhere', async () => {
@@ -1512,4 +1516,113 @@ test('both count fixes hold at once: filtered tiles and no self-link anywhere', 
   expect(within(tile('Links out')).getByText('1')).toBeTruthy()
   expect(screen.getByRole('region', { name: 'Links out (1)' })).toBeTruthy()
   expect(selfLinkRows()).toHaveLength(0)
+})
+
+test('metric help text tells the truth about what the nav and footer filter changes', () => {
+  // Depth and link score are computed by the crawl over the FULL link graph,
+  // before nav links are told apart, so the filter cannot move them. Sitting
+  // beside two filtered tiles, they have to say so or they read as filtered.
+  expect(siteHealthMetricHelp('clicksFromHome', false)).toBe(
+    'How many clicks it takes to reach this page from the home page, following links. This always counts every link, including nav and footer.',
+  )
+  expect(siteHealthMetricHelp('linkImportance', false)).toBe(
+    'How much link value flows to this page, based on how many pages link to it and how important those pages are. Shown relative to the highest page on this site, which is 100%. This always counts every link, including nav and footer.',
+  )
+  // A full-graph metric ignores the argument entirely: there is no state in
+  // which it is a filtered number, so no caller can make it claim otherwise.
+  expect(siteHealthMetricHelp('clicksFromHome', true)).toBe(siteHealthMetricHelp('clicksFromHome', false))
+  expect(siteHealthMetricHelp('linkImportance', true)).toBe(siteHealthMetricHelp('linkImportance', false))
+
+  // The two counts that DO follow the toggle describe whichever number is on
+  // screen right now.
+  expect(siteHealthMetricHelp('linksIn', true)).toBe(
+    'How many other pages link to this page. Right now this counts content links only. Nav and footer links are hidden.',
+  )
+  expect(siteHealthMetricHelp('linksIn', false)).toBe(
+    'How many other pages link to this page. This counts every link, including nav and footer.',
+  )
+  expect(siteHealthMetricHelp('linksOut', true)).toBe(
+    'How many other pages this page links to. Right now this counts content links only. Nav and footer links are hidden.',
+  )
+  expect(siteHealthMetricHelp('linksOut', false)).toBe(
+    'How many other pages this page links to. This counts every link, including nav and footer.',
+  )
+
+  // Metrics with nothing to qualify are left alone rather than padded with a
+  // sentence about a filter that does not apply to them.
+  expect(siteHealthMetricHelp('technicalScore', true)).toBe(siteHealthMetricHelp('technicalScore', false))
+  expect(siteHealthMetricHelp('linkTimes', true)).toBe(siteHealthMetricHelp('linkTimes', false))
+})
+
+test('the tile tooltips are keyboard reachable and follow the nav and footer toggle', async () => {
+  const fetchMock = vi.fn(async () => new Response('{}', { status: 500 }))
+  vi.stubGlobal('fetch', fetchMock)
+  const servicesWithLinks = { ...servicesPage, inboundUniqueEdges: 2, outboundUniqueEdges: 1 }
+  const queryClient = seedTemplateLinkGraph({
+    nodes: [
+      { ...homePage, x: 0, y: 0 },
+      { ...servicesWithLinks, x: 1, y: 1 },
+      { ...contactPage, x: -1, y: 1 },
+    ],
+  })
+  const link = (edgeKey: string, from: string, to: string, isTemplate: boolean) => ({
+    edgeKey,
+    sourceNodeKey: from,
+    sourceUrl: `https://citypoint.example/${from}`,
+    targetNodeKey: to,
+    targetUrl: `https://citypoint.example/${to}`,
+    relation: 'anchor',
+    internal: true,
+    followable: true,
+    occurrences: 1,
+    followableOccurrences: 1,
+    nofollowOccurrences: 0,
+    anchors: isTemplate ? [] : ['Roof repair'],
+    isTemplate,
+    templateRatio: isTemplate ? 0.9 : 0.1,
+  })
+  queryClient.setQueryData(getApiV1ProjectsByNameTechnicalAeoInternalLinksNeighborsQueryKey({
+    client: heyClient,
+    path: { name: projectName },
+    query: { runId: 'run_1', nodeKey: 'page_services', limit: 100 },
+  }), {
+    project: projectName,
+    hasCrawlData: true,
+    runId: 'run_1',
+    nodeKey: 'page_services',
+    url: servicesPage.url,
+    templateDetection: 'applied',
+    linkKind: 'all',
+    inbound: [link('in-content', 'page_home', 'page_services', false), link('in-nav', 'page_contact', 'page_services', true)],
+    outbound: [link('out-content', 'page_services', 'page_home', false)],
+    inboundTruncated: false,
+    outboundTruncated: false,
+  })
+
+  renderSection(queryClient)
+  fireEvent.click(screen.getByRole('button', { name: '/services/roof-repair' }))
+
+  // The explanation is the trigger's accessible name, so a screen reader gets
+  // it without a hover ever happening.
+  await waitFor(() => expect(screen.getByRole('button', { name: siteHealthMetricHelp('linksIn', true) })).toBeTruthy())
+  expect(screen.getByRole('button', { name: siteHealthMetricHelp('linksOut', true) })).toBeTruthy()
+  expect(screen.getByRole('button', { name: siteHealthMetricHelp('clicksFromHome', false) })).toBeTruthy()
+  expect(screen.getByRole('button', { name: siteHealthMetricHelp('linkImportance', false) })).toBeTruthy()
+
+  // Focus alone reveals the bubble, so the copy is not hover-only.
+  const trigger = screen.getByRole('button', { name: siteHealthMetricHelp('linksIn', true) })
+  expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  fireEvent.focus(trigger)
+  expect(trigger.getAttribute('aria-expanded')).toBe('true')
+  fireEvent.keyDown(trigger, { key: 'Escape' })
+  expect(trigger.getAttribute('aria-expanded')).toBe('false')
+
+  // Toggle off the filter and the two filterable tiles stop claiming to be
+  // content-only, while the two full-graph tiles are untouched.
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Show nav and footer links' }))
+  expect(screen.getByRole('button', { name: siteHealthMetricHelp('linksIn', false) })).toBeTruthy()
+  expect(screen.getByRole('button', { name: siteHealthMetricHelp('linksOut', false) })).toBeTruthy()
+  expect(screen.queryByRole('button', { name: siteHealthMetricHelp('linksIn', true) })).toBeNull()
+  expect(screen.getByRole('button', { name: siteHealthMetricHelp('clicksFromHome', false) })).toBeTruthy()
+  expect(screen.getByRole('button', { name: siteHealthMetricHelp('linkImportance', false) })).toBeTruthy()
 })


### PR DESCRIPTION
## Why

"Link importance 100%" means nothing to a reader. Neither does "Clicks from home", or a bare "Score" column. Site Health shows a lot of numbers and explained almost none of them.

## What

Every metric label on the surface now carries a plain-words explanation, using the existing `InfoTooltip` (already used across Evidence, Backlinks, GBP, Visibility, and the technical checks). The trigger is a real `<button>` whose `aria-label` IS the copy, so it is keyboard reachable and screen readers get the text without any hover.

### Staying true under the nav and footer filter

After #988 the inspector's link counts follow the "Show nav and footer links" toggle. The explanations have to respect that, and the split is real:

| Tile | Source | Filter changes it? |
|---|---|---|
| Clicks from home | `page.depth`, crawl page metrics | No |
| Links in / Links out | the neighbour lists the tables render | **Yes** |
| Link importance | `page.linkScoreNormalized`, crawl page metrics | No |

Depth and link score are computed over the full link graph, before template links are classified. So:

- **Links in / out** say which number is on screen: "Right now this counts content links only. Nav and footer links are hidden." or "This counts every link, including nav and footer."
- **Clicks from home / Link importance** say "This always counts every link, including nav and footer." Sitting beside two filtered tiles, silence would read as filtered.

The filter fact is now returned by `linkTileCount` itself, from the same branch that picks the number, so a tooltip cannot describe a count that function did not produce. That gets two edge cases right that a naive `!showTemplateLinks` would not:

- a page with **no nav links at all** shows no "N hidden" note, but is still a content-only count
- a **legacy scan** that cannot tell nav from content is *not* filtered, and must not claim to be

## Survey: what else was unexplained

Reporting rather than guessing at scope, as asked.

**Fixed in this PR:**
- Pages table columns: `Clicks from home`, `Links in`, `Links out`, `Link importance` (same four metrics, same copy from one source of truth), plus `Score`
- Header tiles: `Pages found`, `Pages checked`, `Internal links`
- Neighbour tables: `Times`

**Notable finding:** the Pages table's `Links in` / `Links out` read the server's `inboundUniqueEdges` / `outboundUniqueEdges`, which are full-graph and **not** affected by the toggle, unlike the inspector tiles showing the same label. Their tooltips are therefore the all-links wording. Same for the `Internal links` header tile, which is `totalEdges` sitting above a map that may be filtered.

**Already explained, left alone:**
- `Status` (Pages table + header `Indexable`): already carry `siteGraphStatusDescription` via `title`
- Technical checks (`TechnicalAeoSection`): already has three `InfoTooltip`s covering the sitemap source, the 0-100 factor scoring and pass/partial/fail bands, and the cross-cutting issues ranking
- The map legend, `Folders in this scan`, and the `Page` / `Anchor text` columns: self-explanatory or already have copy

## Tests

- `siteHealthMetricHelp` unit test pins the exact copy for every metric and asserts a full-graph metric ignores the filter argument entirely, so no caller can make it lie
- `linkTileCount` assertions extended with the new `filtered` field, including the no-nav-links and legacy-scan cases
- DOM test drives the real toggle and asserts the four tooltips are reachable by accessible name and that the two filterable ones flip while the two full-graph ones do not; also asserts focus alone opens the bubble and Escape closes it (not hover-only)

Full suite green: 639 files / 8167 tests. `typecheck`, `lint`, `gen:check`, `plugin:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)