### PR TITLE
fix: stop hiding editorial links that share an edge with a nav link

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -131,7 +131,13 @@ graph-edge endpoints so derived-layout cleanup stays bounded.
 Migration 131 separates nav, header, and footer links from content links. A
 `(target page, normalized anchor)` pair carried by at least 70 percent of the
 scan's fetched pages is template chrome; on real sites that distribution is
-bimodal, so the threshold sits in an empty middle. Template links are excluded
+bimodal, so the threshold sits in an empty middle. A stored link row aggregates
+EVERY anchor the crawl saw between the same two pages, so migration 133
+corrects which anchor decides: chrome only when every anchor on the row is
+ubiquitous. Migration 131 used the most ubiquitous one, which handed an
+in-prose link that shared a row with a footer link to the same target the
+footer's ratio and hid it. Any site with a comprehensive footer had this, so
+133 re-runs the same backfill to reclassify every stored scan. Template links are excluded
 from the ForceAtlas2 physics, so positions describe content structure, but they
 are still published in the sample and tagged, so a viewer can draw them without
 a refetch and without any page moving. Below 15 fetched pages nothing is marked

--- a/packages/canonry/src/site-crawl-graph-layout.ts
+++ b/packages/canonry/src/site-crawl-graph-layout.ts
@@ -256,8 +256,16 @@ export function siteCrawlGraphLayoutSettingsFingerprint(settings: unknown): stri
  * v3 excludes template links from the physics. That changes what the same
  * crawl produces, so it is an ALGORITHM change, not a settings change: v2
  * coordinates must not be reused as seeds for a v3 layout.
+ *
+ * v4 is the same exclusion over a corrected classification. A link that is
+ * both a footer link and an in-prose link used to be marked chrome and was
+ * dropped from the physics, so every stored v3 layout was solved over a graph
+ * missing much of the site's real editorial structure. The settings
+ * fingerprint below cannot catch this: the threshold did not move, the rule
+ * that applies it did. Bumping the algorithm is what stops a v3 layout being
+ * reused, or its coordinates being seeded into the corrected solve.
  */
-const SITE_CRAWL_GRAPH_LAYOUT_ALGORITHM = 'site-health-fa2-v3'
+const SITE_CRAWL_GRAPH_LAYOUT_ALGORITHM = 'site-health-fa2-v4'
 
 export const SITE_CRAWL_GRAPH_LAYOUT_VERSION = `${SITE_CRAWL_GRAPH_LAYOUT_ALGORITHM}-${
   siteCrawlGraphLayoutSettingsFingerprint({

--- a/packages/canonry/test/site-crawl-graph-layout.test.ts
+++ b/packages/canonry/test/site-crawl-graph-layout.test.ts
@@ -610,7 +610,9 @@ describe('site crawl graph layout', () => {
   })
 
   it('fingerprints the physics settings into the layout version', () => {
-    expect(SITE_CRAWL_GRAPH_LAYOUT_VERSION).toMatch(/^site-health-fa2-v3-[0-9a-f]{8}$/)
+    // v4: the template rule that decides which edges enter the physics was
+    // corrected, so v3 coordinates are not valid seeds for this solve.
+    expect(SITE_CRAWL_GRAPH_LAYOUT_VERSION).toMatch(/^site-health-fa2-v4-[0-9a-f]{8}$/)
 
     // The fingerprint is what stops positions produced by one set of physics
     // being reused as seeds under another: `loadPriorSiteCrawlGraphPositions`

--- a/packages/contracts/src/technical-aeo.ts
+++ b/packages/contracts/src/technical-aeo.ts
@@ -493,16 +493,35 @@ export function observeTemplateLinkEdges(
 }
 
 /**
- * Share of fetched pages carrying this link's MOST ubiquitous anchor, or null
+ * Share of fetched pages carrying this link's LEAST ubiquitous anchor, or null
  * when nothing about the link is measurable (an unresolved target, or no
  * anchor at all).
  *
- * The maximum is deliberate. One persisted link row aggregates every anchor
- * the crawl saw between the same two pages, so a body link that also appears
- * in the footer arrives as a single row. Taking the maximum keeps that row out
- * of the content map, which is what the reader asked for; taking the minimum
- * would leave the whole nav mesh drawn because one page also links the target
- * editorially.
+ * The MINIMUM is the whole rule, and it is what makes a link editorial as soon
+ * as any one of its anchors is.
+ *
+ * One persisted link row aggregates EVERY anchor the crawl saw between the
+ * same two pages. A site with a comprehensive footer links from nearly every
+ * page to nearly every page, so an in-prose link to a footer-linked target
+ * lands in the SAME row as that page's footer link. This function used to take
+ * the maximum, which handed that row the footer's ubiquity: the editorial link
+ * was marked chrome, hidden from the map, and dropped from content counts.
+ * Most sites have a comprehensive footer, so most sites had this.
+ *
+ * Taking the minimum asks the right question. The pair index is keyed by
+ * (target, ANCHOR), so a footer link and a body link to the same target are
+ * different pairs with different ubiquity. Reading the least ubiquitous one
+ * means: does any anchor on this link appear on few enough pages to be
+ * editorial? A page carrying only the footer link still has one anchor, still
+ * ubiquitous, and stays chrome. The nav mesh does not come back, because a
+ * page's edge only becomes editorial when that page really does link the
+ * target in its own words.
+ *
+ * The residual error now runs the safe way. A nav whose anchor text varies by
+ * page (a breadcrumb reading "Home" on some pages and "Back to home" on
+ * others) splits into low-ubiquity pairs and can read as editorial. That draws
+ * a link that exists; the old direction HID links that exist, on a map whose
+ * whole purpose is showing editorial structure.
  */
 export function templateLinkRatio(
   index: TemplateLinkPairIndex,
@@ -511,23 +530,36 @@ export function templateLinkRatio(
 ): number | null {
   if (edge.targetNodeKey == null || edge.anchors.length === 0) return null
   if (!Number.isFinite(pagesFetched) || pagesFetched <= 0) return null
-  let best: number | null = null
+  let least: number | null = null
   for (const anchor of edge.anchors) {
     const sources = index.sourcePagesByPair.get(
       templateLinkPairKey(edge.targetNodeKey, normalizeTemplateAnchorText(anchor)),
     )
+    // Unreachable for a resolved target: every caller builds the index from
+    // the same link set it then measures, so each anchor here was observed.
+    // Skipping contributes no evidence either way rather than inventing a
+    // zero, which would persist as a confident "editorial" for a link nothing
+    // was ever recorded about.
     if (!sources) continue
     // A source page outside the fetched count (a redirect node, say) must not
     // push the share above 1.
     const ratio = Math.min(1, sources.size / pagesFetched)
-    if (best == null || ratio > best) best = ratio
+    if (least == null || ratio < least) least = ratio
   }
   // Six decimals so the persisted number is stable across runs of the same
   // crawl rather than carrying float noise into an equality assertion.
-  return best == null ? null : Math.round(best * 1_000_000) / 1_000_000
+  return least == null ? null : Math.round(least * 1_000_000) / 1_000_000
 }
 
-/** The single threshold comparison. An unmeasurable link is never a template link. */
+/**
+ * The single threshold comparison. An unmeasurable link is never a template
+ * link.
+ *
+ * Paired with the minimum in `templateLinkRatio`, this reads as: chrome only
+ * when EVERY anchor on the link is ubiquitous. One editorial anchor is enough
+ * to make the whole link editorial, which is the direction that shows links
+ * rather than hiding them.
+ */
 export function isTemplateLinkRatio(ratio: number | null): boolean {
   return ratio != null && ratio >= TEMPLATE_LINK_RATIO_THRESHOLD
 }
@@ -542,7 +574,10 @@ export function templateLinkDetection(pagesFetched: number): SiteHealthTemplateD
 export interface TemplateLinkClassification {
   edgeKey: string
   isTemplate: boolean
-  /** Null when the link carries no measurable (target, anchor) pair. */
+  /**
+   * Ubiquity of the link's least ubiquitous anchor. Null when the link carries
+   * no measurable (target, anchor) pair.
+   */
   templateRatio: number | null
 }
 
@@ -746,7 +781,11 @@ export const siteCrawlEdgeSchema = z.object({
    * response's `templateDetection` explains; it never means "not a nav link".
    */
   isTemplate: z.union([z.boolean(), z.null()]),
-  /** Share of fetched pages carrying this link's most ubiquitous anchor. */
+  /**
+   * Share of fetched pages carrying this link's LEAST ubiquitous anchor: the
+   * most editorial thing anyone says when linking these two pages. At or above
+   * the threshold means every anchor on the link is chrome.
+   */
   templateRatio: z.union([z.number(), z.null()]),
 })
 export type SiteCrawlEdgeDto = z.infer<typeof siteCrawlEdgeSchema>

--- a/packages/contracts/test/template-links.test.ts
+++ b/packages/contracts/test/template-links.test.ts
@@ -172,10 +172,15 @@ describe('template link detection', () => {
     expect(result.edges.every((edge) => edge.templateRatio === 1)).toBe(true)
   })
 
-  it('uses a link row\'s most ubiquitous anchor, because one row holds them all', () => {
+  it('keeps an editorial link that shares a row with a footer link', () => {
     // One page links to /about twice: once from the footer, once from its
-    // body. The crawl stores that as ONE row carrying both anchors, so the
-    // row cannot be split and the footer anchor is what decides it.
+    // body. The crawl stores that as ONE row carrying both anchors.
+    //
+    // This is the regression. Reading the row's MOST ubiquitous anchor handed
+    // it the footer's ratio, so the in-prose link was marked chrome, hidden
+    // from the map, and dropped from every content count. On a site whose
+    // footer links to nearly every page, that is nearly every editorial link
+    // on the site.
     const edges: TemplateLinkEdgeInput[] = [
       ...Array.from({ length: 19 }, (_, index) => ({
         edgeKey: `footer:${index}`,
@@ -191,7 +196,61 @@ describe('template link detection', () => {
       },
     ]
     const result = classifyTemplateLinks({ pagesFetched: 20, edges })
-    expect(classificationOf(result, 'mixed')).toEqual({ edgeKey: 'mixed', isTemplate: true, templateRatio: 1 })
+    // 1 of 20 pages says "the story behind our shop", so that is what the row
+    // is worth: an editorial link, drawn and counted.
+    expect(classificationOf(result, 'mixed')).toEqual({ edgeKey: 'mixed', isTemplate: false, templateRatio: 0.05 })
+
+    // The nav mesh does not come back with it. Every OTHER page carries only
+    // the footer anchor, so those rows stay chrome: a page's link becomes
+    // editorial only when that page really does link the target in its own
+    // words.
+    for (let index = 0; index < 19; index += 1) {
+      expect(classificationOf(result, `footer:${index}`)).toEqual({
+        edgeKey: `footer:${index}`, isTemplate: true, templateRatio: 1,
+      })
+    }
+    expect(result.edges.filter((edge) => !edge.isTemplate)).toHaveLength(1)
+  })
+
+  it('stays chrome when every anchor on the row is ubiquitous', () => {
+    // A logo link and a nav item to the same target from every page. Two
+    // anchors, both site-wide: nothing here is editorial, and reading the
+    // least ubiquitous anchor must not turn the header into content.
+    const edges: TemplateLinkEdgeInput[] = Array.from({ length: 20 }, (_, index) => ({
+      edgeKey: `chrome:${index}`,
+      sourceNodeKey: `page-${index}`,
+      targetNodeKey: 'home',
+      anchors: ['', 'Home'],
+    }))
+    const result = classifyTemplateLinks({ pagesFetched: 20, edges })
+    expect(result.edges.every((edge) => edge.isTemplate)).toBe(true)
+    expect(result.edges.every((edge) => edge.templateRatio === 1)).toBe(true)
+  })
+
+  it('classifies chrome as a subset of what the old rule classified', () => {
+    // The rule changed from "any anchor is ubiquitous" to "every anchor is",
+    // so the chrome set can only shrink and the content set can only grow.
+    // That is why no count on this surface can go DOWN after the fix, and it
+    // is the property the whole change rests on.
+    const edges: TemplateLinkEdgeInput[] = [
+      ...Array.from({ length: 18 }, (_, index) => ({
+        edgeKey: `footer:${index}`,
+        sourceNodeKey: `page-${index}`,
+        targetNodeKey: 'pricing',
+        anchors: ['Pricing'],
+      })),
+      // Two pages that ALSO link editorially, each in their own words.
+      { edgeKey: 'body:a', sourceNodeKey: 'page-18', targetNodeKey: 'pricing', anchors: ['Pricing', 'what it costs'] },
+      { edgeKey: 'body:b', sourceNodeKey: 'page-19', targetNodeKey: 'pricing', anchors: ['Pricing', 'see our plans'] },
+    ]
+    const result = classifyTemplateLinks({ pagesFetched: 20, edges })
+
+    const contentKeys = result.edges.filter((edge) => !edge.isTemplate).map((edge) => edge.edgeKey)
+    expect(contentKeys).toEqual(['body:a', 'body:b'])
+    // Under the old maximum rule every one of these rows scored 0.9 and the
+    // content count was zero. The content links were always there.
+    expect(contentKeys).toHaveLength(2)
+    expect(result.edges.filter((edge) => edge.isTemplate)).toHaveLength(18)
   })
 
   it('never claims a link it cannot measure', () => {

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -3502,6 +3502,31 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
     statements: [],
     run: dropSiteCrawlSelfLinks,
   },
+  {
+    version: 133,
+    name: 'site-crawl-reclassify-template-links-per-anchor',
+    // v131 classified a link as chrome when its MOST ubiquitous anchor was
+    // ubiquitous. One stored link row aggregates every anchor the crawl saw
+    // between the same two pages, so on any site with a comprehensive footer
+    // (which is most sites) an in-prose link to a footer-linked target shared
+    // a row with that page's footer link and inherited its ratio. The
+    // editorial link was marked chrome, hidden from the map, and dropped from
+    // every content count. Observed on canonry.ai: /aeo-methodology had 24
+    // outbound links, all marked chrome at ratio 0.96, with anchors like
+    // "Explore the Canonry platform" that are plainly editorial.
+    //
+    // The rule is now the LEAST ubiquitous anchor: chrome only when every
+    // anchor on the link is chrome. This re-runs the same backfill hook, which
+    // reclassifies each attempt from its own stored rows through the corrected
+    // contract function, so an existing scan is right without a re-crawl.
+    //
+    // Statements stay empty because v131 already added every column; only the
+    // values were wrong. Re-running is safe: the hook resets each attempt to
+    // "classified, not chrome" before it writes, so it is idempotent and its
+    // result depends on nothing but the stored links.
+    statements: [],
+    run: backfillSiteCrawlTemplateLinks,
+  },
 ]
 
 function addRunsMeasurementPlanVersionForeignKey(tx: MigrationDb): void {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -904,11 +904,15 @@ export const siteCrawlEdges = sqliteTable('site_crawl_edges', {
   nofollowOccurrences: integer('nofollow_occurrences').notNull().default(0),
   anchors: text('anchors', { mode: 'json' }).$type<string[]>().notNull().default([]),
   /**
-   * True when the same (target page, anchor) pair appears on at least
-   * `TEMPLATE_LINK_RATIO_THRESHOLD` of the attempt's fetched pages: a nav,
-   * header, or footer link rather than an editorial one. Computed once at
+   * True when EVERY (target page, anchor) pair on this link appears on at
+   * least `TEMPLATE_LINK_RATIO_THRESHOLD` of the attempt's fetched pages: a
+   * nav, header, or footer link rather than an editorial one. Computed once at
    * publish time by the contract's `classifyTemplateLinks`, so the map, the
    * API filters, and the agents all read the same decision.
+   *
+   * One row aggregates every anchor between the same two pages, so a link that
+   * is BOTH a footer link and an in-prose link is one row with two anchors. It
+   * is editorial, because the in-prose link exists.
    *
    * NULL means this row was never classified, which reads report as
    * `unavailable-legacy-scan`. It never means "not a template link": the
@@ -917,8 +921,9 @@ export const siteCrawlEdges = sqliteTable('site_crawl_edges', {
    */
   isTemplate: integer('is_template', { mode: 'boolean' }),
   /**
-   * Share of fetched pages carrying this link's most ubiquitous anchor. NULL
-   * when the link has no measurable pair (an unresolved target or no anchor).
+   * Share of fetched pages carrying this link's LEAST ubiquitous anchor, which
+   * is the one that decides `is_template`. NULL when the link has no
+   * measurable pair (an unresolved target or no anchor).
    */
   templateRatio: real('template_ratio'),
   createdAt: text('created_at').notNull(),

--- a/packages/db/test/migration-downgrade-safety.test.ts
+++ b/packages/db/test/migration-downgrade-safety.test.ts
@@ -116,6 +116,21 @@ const RUN_HOOK_ALLOWLIST: ReadonlySet<number> = new Set([
   // are exactly the rows it was miscounting, so it is strictly better off.
   // Idempotent: a re-run deletes nothing once they are gone.
   132,
+  // v133 makes NO schema change: it re-runs v131's backfill because the rule
+  // v131 applied was wrong. v131 marked a link as chrome when its most
+  // ubiquitous anchor was ubiquitous, but one row aggregates every anchor
+  // between the same two pages, so an in-prose link sharing a row with a
+  // footer link to the same target inherited the footer's ratio and was
+  // hidden. The rule is now the least ubiquitous anchor. Downgrade-safe:
+  // `is_template` and `template_ratio` are unknown to any binary older than
+  // v131, and to a v131-or-newer binary these are the values its own
+  // classifier would now produce from the same stored rows. It uses run() for
+  // the same reason v131 does: the derivation counts DISTINCT source pages per
+  // (target, normalized anchor) pair using the contract's own normalizer,
+  // which SQL cannot express without becoming a second implementation.
+  // Idempotent: the hook resets each attempt before writing, so a retry writes
+  // the same values.
+  133,
 ])
 
 test(`migrations after v${DOWNGRADE_BASELINE} define no run() hook unless explicitly allowlisted`, () => {

--- a/packages/db/test/site-crawl-template-links-migration.test.ts
+++ b/packages/db/test/site-crawl-template-links-migration.test.ts
@@ -193,3 +193,43 @@ test('runs as part of migrate, so an existing install needs no manual step', () 
   expect(remaining[0]!.n).toBe(0)
   expect(db.select().from(siteCrawlSnapshots).get()?.templateDetection).toBe('applied')
 })
+
+test('keeps an in-prose link that shares a stored row with a nav link', () => {
+  // The regression, end to end through persistence. One row aggregates every
+  // anchor between the same two pages, so page-00's footer link to /services
+  // and its in-prose link to /services are ONE row with two anchors. Reading
+  // the row's most ubiquitous anchor gave it the nav ratio, so the editorial
+  // link was marked chrome: hidden from the map, and absent from every content
+  // count. A site whose footer reaches most pages has this on most of its
+  // editorial links.
+  const db = freshDb()
+  const seeded = seedLegacyCrawl(db, 20)
+  db.run(sql`
+    UPDATE site_crawl_edges
+    SET anchors = ${JSON.stringify(['services', 'why our roof crews book out'])}
+    WHERE edge_key = 'nav:page-00->services'
+  `)
+
+  backfillSiteCrawlTemplateLinks(db)
+
+  const mixed = db.select().from(siteCrawlEdges).where(sql`edge_key = 'nav:page-00->services'`).get()
+  // 1 of 20 pages says "why our roof crews book out". That is what the row is
+  // worth, and it is below the threshold, so the link is editorial.
+  expect(mixed?.isTemplate).toBe(false)
+  expect(mixed?.templateRatio).toBe(0.05)
+
+  // The nav mesh does not come back with it: every other page links /services
+  // with the nav anchor only, so those rows stay chrome. A page's link becomes
+  // editorial only when that page really does link the target in its own words.
+  const stillChrome = db.select().from(siteCrawlEdges).all()
+    .filter((row) => row.edgeKey.startsWith('nav:') && row.edgeKey !== 'nav:page-00->services')
+  expect(stillChrome).toHaveLength(seeded.navEdgeCount - 1)
+  expect(stillChrome.every((row) => row.isTemplate === true)).toBe(true)
+
+  // Every surface that reads the classification moves with it, so the map, the
+  // link filters, and the totals cannot tell three different stories.
+  const graphEdge = db.select().from(siteCrawlGraphEdges).where(sql`edge_key = 'nav:page-00->services'`).get()
+  expect(graphEdge?.isTemplate).toBe(false)
+  const layout = db.select().from(siteCrawlGraphLayouts).get()
+  expect(layout?.totalTemplateEdges).toBe(seeded.navEdgeCount - 1)
+})


### PR DESCRIPTION
## Root cause

A stored link row aggregates **every** anchor the crawl saw between the same two pages. `templateLinkRatio` scored a row by its **most** ubiquitous anchor. So on a site whose footer links to nearly every page, an in-prose link to a footer-linked target lands in the *same row* as that page's footer link and inherits its ratio.

The editorial link was then marked chrome: hidden from the map, dropped from content counts, and excluded from the layout physics. Any site with a comprehensive footer has this, which is most sites.

Confirmed by the reported evidence: `/aeo-methodology` on canonry.ai had 24 outbound links, all `isTemplate` at `templateRatio` 0.96 and zero content links, with anchors like "Explore the Canonry platform".

This was not an unknown: the old code carried a comment defending the maximum. That comment's stated fear — that the minimum "would leave the whole nav mesh drawn" — turns out not to hold, which is why the fix is safe (below).

## Fix: A, taking the least ubiquitous anchor

Chrome only when **every** anchor on the row is chrome. One line of semantics; `isTemplate = ratio >= threshold` still holds, so nothing downstream had to learn a new rule.

**Why the nav mesh does not come back.** The pair index is already keyed by `(target, ANCHOR)`, so a footer link and a body link to the same target are different pairs with different ubiquity. A page carrying *only* the footer link still has one ubiquitous anchor and stays chrome. A page's link becomes editorial only when that page really does link the target in its own words. Asserted directly: in the regression test, 1 of 20 rows flips and the other 19 stay chrome.

**The residual error now runs the safe way.** A nav whose anchor text varies by page (a breadcrumb reading "Home" here and "Back to home" there) can read as editorial. That draws a link that exists. The old direction hid links that exist, on a map whose entire purpose is showing editorial structure.

**Monotonicity.** "Every anchor is ubiquitous" implies "some anchor is", so the chrome set is a strict subset of what v131 produced and no content count on this surface can go down. There is a test for this.

### Why not B

B is the better idea on paper and I costed it before choosing. Two things sank it:

1. **It cannot be backfilled.** Per-anchor occurrences exist upstream (`CrawlAnchorSummary { text, occurrences }`) but `execute-site-audit.ts` maps them to `.text` and throws the counts away. So B is truthful only for scans re-crawled after the change, leaving a permanent two-regime read path plus a nullable column whose meaning depends on scan age. A recomputes correctly from data already stored, so every existing scan is fixed by the migration.
2. **The counts the product actually shows are edge counts** — the inspector tiles, the map, `totalContentEdges`, the neighbour list lengths. A makes all of those correct. B's extra precision lands only on the "Times" occurrence column, where an edge that is 1 body link + 50 footer occurrences would read 51 instead of 1.

Worth doing later as its own change, starting by persisting the per-anchor occurrences that are currently discarded. It is not a prerequisite for un-hiding the links.

## Where the assumption leaked (item 2)

Checked all four surfaces named, and found two real leaks:

| Surface | Verdict |
|---|---|
| **Layout physics** | **Leak, fixed.** `layoutEdges` drops template edges, so every stored layout was solved over a graph missing much of the real editorial structure. The settings fingerprint could not catch it: the *threshold* did not move, the rule applying it did. Bumped the layout **algorithm** v3 → v4. |
| **Served template totals** | **Leak, fixed.** `totalTemplateEdges` is served from the stored layout row, not recounted per request, so corrected edges would have been served beside a stale total. v131's backfill already recomputes that column, so re-running it covers this. |
| **Map's drawn edges** | Clean. `site_crawl_graph_edges.is_template` is copied from `site_crawl_edges.is_template`, and the backfill rewrites both. |
| **Neighbours read / `linkKind`** | Clean. `linkKindFilter` goes through `is_template` and follows it. |
| **Link importance** | Clean, and not merely today. `linkScoreNormalized` comes from the crawl's own page metrics over the full graph and is not template-aware at all. |

The v4 bump is **seeding-only**: `SITE_CRAWL_GRAPH_LAYOUT_VERSION` is used solely in `loadPriorSiteCrawlGraphPositions`, never as a gate on serving. Existing maps keep rendering, gain their previously-hidden editorial edges immediately via the migration, and get corrected *positions* on the next publish.

## Migration 133

Statements empty, `run: backfillSiteCrawlTemplateLinks` — v131 added every column; only the values were wrong. Re-running reclassifies each attempt from its own stored rows through the corrected function, updating `site_crawl_edges`, `site_crawl_graph_edges`, `site_crawl_graph_layouts.total_template_edges`, and `site_crawl_snapshots.template_detection` together. Idempotent (the hook resets each attempt before writing). Added to `RUN_HOOK_ALLOWLIST` with a downgrade-safety justification.

## Empirical re-grounding (item 1): not done, and I did not invent numbers

I could not recompute the ainyc / gjelina-hotel / azcoatings splits. That data lives on the tenant instances; the only canonry database on this machine predates the `site_crawl_edges` table entirely, and the running local instance (4.147.0) is older still. The previous figures (64/1237, 24/600, 21/157) were measured under the buggy rule and remain suspect — I have left them uncited rather than replace them with fabrications.

What can be said without measuring: the content set can only grow, because the new chrome set is a strict subset of the old. There is a test pinning that.

To get the real before/after, run this against a live instance before deploying and again after the migration:

```sql
SELECT p.name,
       SUM(CASE WHEN e.is_template = 1 THEN 1 ELSE 0 END) AS template_links,
       SUM(CASE WHEN e.is_template = 0 THEN 1 ELSE 0 END) AS content_links
FROM site_crawl_edges e
JOIN projects p ON p.id = e.project_id
WHERE e.internal = 1 AND e.relation = 'anchor'
GROUP BY p.name;
```

Happy to fold the numbers into this PR if someone can run it, or to take a dump of those three attempts.

## Tests (item 3)

- **Mixed row → content**: a row carrying both a ubiquitous nav anchor and a unique body anchor classifies as content at the body anchor's ratio, and the other 19 rows to the same target stay chrome (the nav mesh does not return).
- **All-ubiquitous row → chrome**: a logo + nav-item pair to the same target from every page stays chrome, so reading the least ubiquitous anchor does not turn the header into content.
- **Counts follow the rule**: 18 footer rows chrome, 2 rows that also link editorially become content, where the old rule produced zero content links.
- **End to end through persistence**: the migration test seeds the exact pathology and asserts the reclassified row, the unchanged siblings, `site_crawl_graph_edges.is_template`, and `site_crawl_graph_layouts.totalTemplateEdges` all move together.
- The old test that pinned the maximum is rewritten to pin the regression instead.

Full suite green: 639 files / 8170 tests. `typecheck`, `lint`, `gen:check`, `plugin:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)