### PR TITLE
Anchor GSC performance windows on the last day Google published

### DIFF
--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -968,6 +968,20 @@ export function GscSection({
                   <div>
                     <p className="eyebrow eyebrow-soft">Performance</p>
                     <h3>Search performance</h3>
+                    {/* The window ends where Google's data ends, not today.
+                        Naming the real range is what stops a lagging tail
+                        reading as a drop, and lets this be compared against
+                        the Search Console UI, which anchors the same way. */}
+                    {/* Optional at RUNTIME even though the DTO requires it: a
+                        cached response from a server older than this field
+                        must degrade to no label, never take the section down. */}
+                    {performanceDaily?.window?.startDate && performanceDaily.window.endDate && (
+                      <p className="text-xs text-muted">
+                        {performanceDaily.window.startDate} to {performanceDaily.window.endDate}
+                        {(performanceDaily.window.reportingLagDays ?? 0) > 0
+                          && ` · Search Console is ${performanceDaily.window.reportingLagDays} day${performanceDaily.window.reportingLagDays === 1 ? '' : 's'} behind`}
+                      </p>
+                    )}
                   </div>
                   <div className="flex items-center gap-2">
                     <div className="segmented" role="group" aria-label="Performance time period">

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -978,8 +978,11 @@ export function GscSection({
                     {performanceDaily?.window?.startDate && performanceDaily.window.endDate && (
                       <p className="text-xs text-muted">
                         {performanceDaily.window.startDate} to {performanceDaily.window.endDate}
-                        {(performanceDaily.window.reportingLagDays ?? 0) > 0
-                          && ` · Search Console is ${performanceDaily.window.reportingLagDays} day${performanceDaily.window.reportingLagDays === 1 ? '' : 's'} behind`}
+                        {/* "data through X", never "Google is N days behind":
+                            a zero-traffic day returns no row, so a quiet tail
+                            is indistinguishable from an unpublished one. */}
+                        {(performanceDaily.window.daysSinceLatestData ?? 0) > 0
+                          && ` · latest data ${performanceDaily.window.daysSinceLatestData} day${performanceDaily.window.daysSinceLatestData === 1 ? '' : 's'} ago`}
                       </p>
                     )}
                   </div>

--- a/apps/web/test/gsc-section-pagination.test.tsx
+++ b/apps/web/test/gsc-section-pagination.test.tsx
@@ -74,7 +74,7 @@ function renderSection() {
       return jsonResponse({
         totals: { clicks: 0, impressions: 0, ctr: 0, days: 0 },
         daily: [],
-        window: { startDate: null, endDate: null, latestDataDate: null, reportingLagDays: null },
+        window: { startDate: null, endDate: null, latestDataDate: null, daysSinceLatestData: null },
       })
     }
     if (path.includes('/google/gsc/performance')) {

--- a/apps/web/test/gsc-section-pagination.test.tsx
+++ b/apps/web/test/gsc-section-pagination.test.tsx
@@ -68,9 +68,13 @@ function renderSection() {
       return jsonResponse({ sites: [{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }] })
     }
     if (path.includes('/google/gsc/performance/daily')) {
+      // Mirrors the real response shape, `window` included — the endpoint
+      // always returns it, and a mock that omits a field the component reads
+      // is a mock that cannot catch a crash on it.
       return jsonResponse({
-        totals: { clicks: 0, impressions: 0, ctr: 0 },
+        totals: { clicks: 0, impressions: 0, ctr: 0, days: 0 },
         daily: [],
+        window: { startDate: null, endDate: null, latestDataDate: null, reportingLagDays: null },
       })
     }
     if (path.includes('/google/gsc/performance')) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.160.0",
+  "version": "4.161.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2517,7 +2517,7 @@ export type GscPerformanceDailyDto = {
         impressions: number;
         ctr: number;
     }>;
-    window: {
+    window?: {
         startDate: string | null;
         endDate: string | null;
         latestDataDate: string | null;
@@ -14814,6 +14814,10 @@ export type GetApiV1ProjectsByNameGoogleGscPerformanceData = {
          * Filter by end date.
          */
         endDate?: string;
+        /**
+         * Relative span in days, resolved server-side against the last published GSC date. Prefer this over client-computed start/end dates: those bypass the published-day anchoring and are pinned to the caller's clock rather than Google's Pacific calendar.
+         */
+        days?: string;
         /**
          * Filter by search query.
          */

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2517,6 +2517,12 @@ export type GscPerformanceDailyDto = {
         impressions: number;
         ctr: number;
     }>;
+    window: {
+        startDate: string | null;
+        endDate: string | null;
+        latestDataDate: string | null;
+        reportingLagDays: number | null;
+    };
 };
 
 export type GscPerformanceResponseDto = {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2521,7 +2521,7 @@ export type GscPerformanceDailyDto = {
         startDate: string | null;
         endDate: string | null;
         latestDataDate: string | null;
-        reportingLagDays: number | null;
+        daysSinceLatestData: number | null;
     };
 };
 

--- a/packages/api-routes/src/composites.ts
+++ b/packages/api-routes/src/composites.ts
@@ -69,7 +69,10 @@ import {
   type SuggestedQueryGscRow,
 } from '@ainyc/canonry-intelligence'
 import { notProbeRun, resolveProject } from './helpers.js'
-import { mergeGscQueryTotalsWithFallback, readGscQueryDailyRows } from './gsc-totals.js'
+import {
+  mergeGscQueryTotalsWithFallback, readGscQueryDailyRows,
+  readLatestGscDataDate, resolveGscWindowDays,
+} from './gsc-totals.js'
 
 const TOP_INSIGHT_LIMIT = 5
 const SEARCH_HIT_HARD_LIMIT = 50
@@ -670,9 +673,19 @@ function buildSuggestedQueriesFromGsc(
   projectId: string,
   trackedQueries: readonly string[],
 ): SuggestedQueriesSummaryDto {
-  // 28-day window mirrors GSC's default reporting horizon. ISO date string
-  // is what the schema stores (YYYY-MM-DD), comparable lexicographically.
-  const cutoff = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+  // 28-day window mirrors GSC's default reporting horizon, ANCHORED on the last
+  // day Google published rather than on the clock. Google publishes on a delay,
+  // so a now-anchored 28 days delivers about 25 — and this surface gates an
+  // impression floor, so the missing days do not just shrink a number: a query
+  // that clears the floor across the true window can fall under it and be
+  // withheld from the basket entirely. Measured on canonry.ai, "new york ai
+  // marketing agency" (16 impressions) was suppressed exactly this way.
+  const suggestionWindow = resolveGscWindowDays(
+    28,
+    readLatestGscDataDate(app.db, projectId),
+    new Date().toISOString().slice(0, 10),
+  )
+  const cutoff = suggestionWindow.startDate ?? ''
 
   // Prefer Google's un-dimensioned per-query rows. This surface both ORDERS by
   // impressions and gates an eligibility floor on them, so the `page` fan-out
@@ -698,14 +711,17 @@ function buildSuggestedQueriesFromGsc(
     .where(and(
       eq(gscSearchData.projectId, projectId),
       sql`${gscSearchData.date} >= ${cutoff}`,
+      // Same upper bound as the accurate source below. The merge picks a source
+      // PER DAY, so an asymmetric range would let a dimensioned-only day past
+      // the window's end into a basket the other source cannot balance.
+      sql`${gscSearchData.date} <= ${suggestionWindow.endDate ?? '9999-12-31'}`,
       sql`${gscSearchData.impressions} > 0`,
     ))
     .groupBy(gscSearchData.date, gscSearchData.query)
     .all()
 
-  const todayIso = new Date().toISOString().slice(0, 10)
   const merged = mergeGscQueryTotalsWithFallback(
-    readGscQueryDailyRows(app.db, projectId, cutoff, todayIso),
+    readGscQueryDailyRows(app.db, projectId, cutoff, suggestionWindow.endDate ?? '9999-12-31'),
     dimensionedRows.map(r => ({
       date: r.date,
       query: r.query,

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -19,7 +19,7 @@ import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integra
 import { buildGbpSummary } from './gbp-summary.js'
 import {
   mergeGscDailyTotalsWithFallback, readGscDailyTotals,
-  readLatestGscDataDate, resolveGscWindowRange, type GscWindowRange,
+  readLatestGscDataDate, resolveGscWindowRange, resolveGscWindowDays, type GscWindowRange,
 } from './gsc-totals.js'
 import { resolveProject, writeAuditLog } from './helpers.js'
 
@@ -31,18 +31,37 @@ import { resolveProject, writeAuditLog } from './helpers.js'
  * side is dropped to `null`, because a caller reading `2030-01-01 to
  * 2026-01-06` would be told the data covers a period that runs backwards.
  */
-function resolveReportedWindow(
+export function resolveReportedWindow(
   resolved: GscWindowRange,
   startDate: string | undefined,
   endDate: string | undefined,
 ): GscWindowRange {
   const start = startDate ?? resolved.startDate
   const end = endDate ?? resolved.endDate
-  const inverted = start !== null && end !== null && start > end
+  if (start === null || end === null || start <= end) {
+    return { ...resolved, startDate: start, endDate: end }
+  }
+  // Reversed, and only ONE side is the caller's (a fully explicit reversed pair
+  // is already refused by `assertForwardRange` before we get here). Drop the
+  // computed opposite: absent is honest about being unspecified, reversed is
+  // not.
   return {
     ...resolved,
-    startDate: inverted && !startDate ? null : start,
-    endDate: inverted && !endDate ? null : end,
+    startDate: startDate ? start : null,
+    endDate: endDate ? end : null,
+  }
+}
+
+/**
+ * Refuse a caller-supplied range that runs backwards.
+ *
+ * Answering it with an empty result would be technically true and useless: the
+ * caller asked for a period that does not exist, and every route taking
+ * explicit bounds should say so rather than return zeros.
+ */
+export function assertForwardRange(startDate?: string, endDate?: string): void {
+  if (startDate && endDate && startDate > endDate) {
+    throw validationError(`startDate "${startDate}" is after endDate "${endDate}".`)
   }
 }
 
@@ -788,7 +807,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   // page from a complete answer.
   app.get<{
     Params: { name: string }
-    Querystring: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: string; offset?: string; window?: string; orderBy?: string }
+    Querystring: { startDate?: string; endDate?: string; days?: string; query?: string; page?: string; limit?: string; offset?: string; window?: string; orderBy?: string }
   }>('/projects/:name/google/gsc/performance', async (request) => {
     const project = resolveProject(app.db, request.params.name)
     const { startDate, endDate, query, page, limit, offset } = request.query
@@ -804,17 +823,29 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     // Window-based filtering: when no explicit startDate is provided, resolve
     // the labelled window against the last day Google actually published, not
     // against the clock. See `resolveGscWindowRange`.
-    const resolvedWindow = resolveGscWindowRange(
-      parseWindow(request.query.window),
-      readLatestGscDataDate(app.db, project.id),
-      gscToday(),
-    )
+    assertForwardRange(startDate, endDate)
+    // `days` is a SPAN, resolved HERE against the published frontier. The CLI
+    // used to turn `--days N` into client-computed UTC dates and send them as
+    // explicit bounds, which the route honours over its own anchor — so the
+    // relative window skipped the anchoring entirely, could end a Pacific day
+    // in the future, and covered N+1 inclusive dates.
+    const daysParam = request.query.days === undefined ? null : Number(request.query.days)
+    if (daysParam !== null && (!Number.isInteger(daysParam) || daysParam < 1)) {
+      throw validationError('"days" must be a positive integer')
+    }
+    const latestDataDate = readLatestGscDataDate(app.db, project.id)
+    const resolvedWindow = daysParam === null
+      ? resolveGscWindowRange(parseWindow(request.query.window), latestDataDate, gscToday())
+      : resolveGscWindowDays(daysParam, latestDataDate, gscToday())
     const cutoffDate = startDate ? null : resolvedWindow.startDate
+    // A span bounds the TOP of the range too; a label-only request leaves the
+    // upper edge to the caller's explicit `endDate`, exactly as before.
+    const effectiveEndDate = endDate ?? (daysParam === null ? undefined : resolvedWindow.endDate ?? undefined)
 
     const conditions = [eq(gscSearchData.projectId, project.id)]
     if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
     else if (cutoffDate) conditions.push(sql`${gscSearchData.date} >= ${cutoffDate}`)
-    if (endDate) conditions.push(sql`${gscSearchData.date} <= ${endDate}`)
+    if (effectiveEndDate) conditions.push(sql`${gscSearchData.date} <= ${effectiveEndDate}`)
     // Escape LIKE wildcards so a literal `%`/`_` in the filter matches itself
     // instead of acting as a wildcard (a `%` filter would otherwise match every
     // row — wrong results + a needless full scan). The value is already bound.
@@ -896,6 +927,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   }>('/projects/:name/google/gsc/performance/daily', async (request) => {
     const project = resolveProject(app.db, request.params.name)
     const { startDate, endDate } = request.query
+    assertForwardRange(startDate, endDate)
     const resolvedWindow = resolveGscWindowRange(
       parseWindow(request.query.window),
       readLatestGscDataDate(app.db, project.id),
@@ -987,6 +1019,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   }>('/projects/:name/google/gsc/top-pages', async (request) => {
     const project = resolveProject(app.db, request.params.name)
     const { startDate, endDate, limit } = request.query
+    assertForwardRange(startDate, endDate)
     const resolvedWindow = resolveGscWindowRange(
       parseWindow(request.query.window),
       readLatestGscDataDate(app.db, project.id),

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -3,7 +3,7 @@ import { eq, and, desc, sql, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { gscSearchData, gscUrlInspections, gscCoverageSnapshots, gbpLocations, gbpDailyMetrics, gbpKeywordImpressions, gbpKeywordMonthly, gbpPlaceActions, gbpLodgingSnapshots, gbpAttributesSnapshots, gbpPlaceDetails, runs, projects, type DatabaseClient } from '@ainyc/canonry-db'
 import {
-  validationError, notFound, normalizeProjectDomain, parseWindow, windowCutoff,
+  validationError, notFound, normalizeProjectDomain, parseWindow,
   authRequired, forbidden, quotaExceeded, providerError, escapeLikePattern, AppError,
   hostMatchesDomain,
   hostOf,
@@ -16,7 +16,10 @@ import {
 } from '@ainyc/canonry-contracts'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from './gbp-summary.js'
-import { mergeGscDailyTotalsWithFallback, readGscDailyTotals } from './gsc-totals.js'
+import {
+  mergeGscDailyTotalsWithFallback, readGscDailyTotals,
+  readLatestGscDataDate, resolveGscWindowRange,
+} from './gsc-totals.js'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
   getAuthUrl,
@@ -762,9 +765,15 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     }
     const orderBy = parsedOrderBy.data
 
-    // Window-based filtering: when no explicit startDate is provided,
-    // use the window param to compute a cutoff date.
-    const cutoffDate = !startDate ? windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null : null
+    // Window-based filtering: when no explicit startDate is provided, resolve
+    // the labelled window against the last day Google actually published, not
+    // against the clock. See `resolveGscWindowRange`.
+    const resolvedWindow = resolveGscWindowRange(
+      parseWindow(request.query.window),
+      readLatestGscDataDate(app.db, project.id),
+      new Date().toISOString().slice(0, 10),
+    )
+    const cutoffDate = startDate ? null : resolvedWindow.startDate
 
     const conditions = [eq(gscSearchData.projectId, project.id)]
     if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
@@ -851,14 +860,19 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   }>('/projects/:name/google/gsc/performance/daily', async (request) => {
     const project = resolveProject(app.db, request.params.name)
     const { startDate, endDate } = request.query
-    const cutoffDate = !startDate ? windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null : null
+    const resolvedWindow = resolveGscWindowRange(
+      parseWindow(request.query.window),
+      readLatestGscDataDate(app.db, project.id),
+      new Date().toISOString().slice(0, 10),
+    )
+    const cutoffDate = startDate ? null : resolvedWindow.startDate
 
     // Prefer the property-level daily totals on dates where they exist (match
     // Google's property total). Fall back to summing `gsc_search_data` for
     // missing dates so upgraded installs do not shorten longer/custom windows
     // after their first post-migration sync.
     const windowStart = startDate ?? cutoffDate ?? ''
-    const windowEnd = endDate ?? '9999-12-31'
+    const windowEnd = endDate ?? resolvedWindow.endDate ?? '9999-12-31'
     const dailyTotals = readGscDailyTotals(app.db, project.id, windowStart, windowEnd)
 
     const conditions = [eq(gscSearchData.projectId, project.id)]
@@ -902,6 +916,14 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
         days: daily.length,
       },
       daily,
+      // The period actually returned. An explicit start/end wins over the
+      // label, so echo what was used rather than what the window would have
+      // chosen — a caller must be able to label the data it got.
+      window: {
+        ...resolvedWindow,
+        ...(startDate ? { startDate } : {}),
+        ...(endDate ? { endDate } : {}),
+      },
     }
   })
 
@@ -926,7 +948,12 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   }>('/projects/:name/google/gsc/top-pages', async (request) => {
     const project = resolveProject(app.db, request.params.name)
     const { startDate, endDate, limit } = request.query
-    const cutoffDate = !startDate ? windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null : null
+    const resolvedWindow = resolveGscWindowRange(
+      parseWindow(request.query.window),
+      readLatestGscDataDate(app.db, project.id),
+      new Date().toISOString().slice(0, 10),
+    )
+    const cutoffDate = startDate ? null : resolvedWindow.startDate
 
     const conditions = [eq(gscSearchData.projectId, project.id)]
     if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
@@ -949,7 +976,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       .all()
 
     const windowStart = startDate ?? cutoffDate ?? ''
-    const windowEnd = endDate ?? '9999-12-31'
+    const windowEnd = endDate ?? resolvedWindow.endDate ?? '9999-12-31'
     const dailyTotals = readGscDailyTotals(app.db, project.id, windowStart, windowEnd)
     const totalClicks = dailyTotals.reduce((sum, d) => sum + d.clicks, 0)
     const totalImpressions = dailyTotals.reduce((sum, d) => sum + d.impressions, 0)

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -13,14 +13,49 @@ import {
   type GbpPlaceDetailsListResponse,
   gscSubmitSitemapsRequestDtoSchema,
   gscPerformanceOrderBySchema,
+  formatIsoDateInTimeZone,
 } from '@ainyc/canonry-contracts'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from './gbp-summary.js'
 import {
   mergeGscDailyTotalsWithFallback, readGscDailyTotals,
-  readLatestGscDataDate, resolveGscWindowRange,
+  readLatestGscDataDate, resolveGscWindowRange, type GscWindowRange,
 } from './gsc-totals.js'
 import { resolveProject, writeAuditLog } from './helpers.js'
+
+/**
+ * The window to REPORT, given what the caller actually asked for.
+ *
+ * An explicit bound always wins over the label's computed one. The two are only
+ * combined when the result is a real, forward range; otherwise the computed
+ * side is dropped to `null`, because a caller reading `2030-01-01 to
+ * 2026-01-06` would be told the data covers a period that runs backwards.
+ */
+function resolveReportedWindow(
+  resolved: GscWindowRange,
+  startDate: string | undefined,
+  endDate: string | undefined,
+): GscWindowRange {
+  const start = startDate ?? resolved.startDate
+  const end = endDate ?? resolved.endDate
+  const inverted = start !== null && end !== null && start > end
+  return {
+    ...resolved,
+    startDate: inverted && !startDate ? null : start,
+    endDate: inverted && !endDate ? null : end,
+  }
+}
+
+/**
+ * Today's date on Search Console's own reporting calendar.
+ *
+ * GSC buckets by Pacific Time, so a UTC `toISOString().slice(0, 10)` names the
+ * wrong day between 00:00 and 08:00 UTC and would misreport freshness by a
+ * full day for a third of the clock.
+ */
+function gscToday(): string {
+  return formatIsoDateInTimeZone(new Date().toISOString(), GSC_REPORTING_TIME_ZONE)
+}
 import {
   getAuthUrl,
   exchangeCode,
@@ -35,6 +70,7 @@ import {
   INDEXING_API_DAILY_LIMIT,
   GoogleApiError,
   GoogleAuthError,
+  GSC_REPORTING_TIME_ZONE,
 } from '@ainyc/canonry-integration-google'
 import { GA4_SCOPE } from '@ainyc/canonry-integration-google-analytics'
 import {
@@ -771,7 +807,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     const resolvedWindow = resolveGscWindowRange(
       parseWindow(request.query.window),
       readLatestGscDataDate(app.db, project.id),
-      new Date().toISOString().slice(0, 10),
+      gscToday(),
     )
     const cutoffDate = startDate ? null : resolvedWindow.startDate
 
@@ -863,7 +899,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     const resolvedWindow = resolveGscWindowRange(
       parseWindow(request.query.window),
       readLatestGscDataDate(app.db, project.id),
-      new Date().toISOString().slice(0, 10),
+      gscToday(),
     )
     const cutoffDate = startDate ? null : resolvedWindow.startDate
 
@@ -919,11 +955,14 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       // The period actually returned. An explicit start/end wins over the
       // label, so echo what was used rather than what the window would have
       // chosen — a caller must be able to label the data it got.
-      window: {
-        ...resolvedWindow,
-        ...(startDate ? { startDate } : {}),
-        ...(endDate ? { endDate } : {}),
-      },
+      //
+      // Mixing one explicit bound with the computed opposite one can invert the
+      // range (an explicit `startDate` of 2030-01-01 against a computed
+      // `endDate` of 2026-01-06), which would describe a period that cannot
+      // contain the rows beside it. When only one side is given, the other is
+      // dropped rather than reported reversed: an absent bound is honest about
+      // being unspecified, a reversed pair is not.
+      window: resolveReportedWindow(resolvedWindow, startDate, endDate),
     }
   })
 
@@ -951,7 +990,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     const resolvedWindow = resolveGscWindowRange(
       parseWindow(request.query.window),
       readLatestGscDataDate(app.db, project.id),
-      new Date().toISOString().slice(0, 10),
+      gscToday(),
     )
     const cutoffDate = startDate ? null : resolvedWindow.startDate
 

--- a/packages/api-routes/src/gsc-totals.ts
+++ b/packages/api-routes/src/gsc-totals.ts
@@ -24,8 +24,20 @@ export interface GscWindowRange {
   endDate: string | null
   /** `MAX(date)` across the project's GSC data, ignoring any window. */
   latestDataDate: string | null
-  /** Calendar days between `latestDataDate` and today. `null` with no data. */
-  reportingLagDays: number | null
+  /**
+   * Calendar days between `latestDataDate` and today, on GSC's Pacific
+   * calendar. `null` with no data.
+   *
+   * This is NOT Google's publication lag, and must never be labelled as one.
+   * The Search Analytics API returns no row for a day with no data, so a day
+   * that Google HAS published but on which the property earned zero
+   * impressions is indistinguishable from a day Google has not published yet.
+   * A quiet tail therefore inflates this number. It measures exactly what it
+   * says — how long since we last recorded traffic — and any surface reading
+   * it must phrase it that way ("data through X"), never as a claim about
+   * Google being behind.
+   */
+  daysSinceLatestData: number | null
 }
 
 /**
@@ -63,7 +75,7 @@ export function resolveGscWindowRange(
       startDate: null,
       endDate: latestDataDate,
       latestDataDate,
-      reportingLagDays: gscReportingLagDays(latestDataDate, today),
+      daysSinceLatestData: gscDaysSinceLatestData(latestDataDate, today),
     }
   }
   return resolveGscWindowDays(WINDOW_DAYS[window], latestDataDate, today)
@@ -92,7 +104,7 @@ export function resolveGscWindowDays(
       startDate: shiftIsoCalendarDate(today, -days),
       endDate: null,
       latestDataDate: null,
-      reportingLagDays: null,
+      daysSinceLatestData: null,
     }
   }
   // `days - 1`, because the range is INCLUSIVE at both ends: a 7-day window
@@ -101,12 +113,12 @@ export function resolveGscWindowDays(
     startDate: shiftIsoCalendarDate(latestDataDate, -(days - 1)),
     endDate: latestDataDate,
     latestDataDate,
-    reportingLagDays: gscReportingLagDays(latestDataDate, today),
+    daysSinceLatestData: gscDaysSinceLatestData(latestDataDate, today),
   }
 }
 
 /** Calendar days between the last published date and today. Never negative. */
-function gscReportingLagDays(latestDataDate: string | null, today: string): number | null {
+function gscDaysSinceLatestData(latestDataDate: string | null, today: string): number | null {
   if (latestDataDate === null) return null
   return Math.max(0, Math.round(
     (Date.parse(`${today}T00:00:00Z`) - Date.parse(`${latestDataDate}T00:00:00Z`)) / 86_400_000,
@@ -115,6 +127,16 @@ function gscReportingLagDays(latestDataDate: string | null, today: string): numb
 
 /**
  * The latest GSC reporting date stored for a project, across BOTH sources.
+ *
+ * This is a PROXY for Google's publication watermark, not the watermark
+ * itself, and it is the best one the API makes available: Search Analytics
+ * omits zero-data days entirely, so a published day on which the property
+ * earned nothing looks identical to a day that has not been published. On a
+ * quiet property the anchor therefore sits behind Google's real frontier and
+ * the window shifts back with it. The consequence is bounded — the window
+ * still spans its full labelled length and still ends on the last day with
+ * measured traffic — but it means no caller may present the resulting gap as
+ * Google being late. See `daysSinceLatestData`.
  *
  * The property-level table is preferred everywhere else, but it can lag the
  * dimensioned one (a project synced before `gsc_daily_totals` existed has only

--- a/packages/api-routes/src/gsc-totals.ts
+++ b/packages/api-routes/src/gsc-totals.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq, sql, max } from 'drizzle-orm'
-import { gscDailyTotals, gscQueryDailyTotals, gscSearchData } from '@ainyc/canonry-db'
+import { gscDailyTotals, gscQueryDailyTotals, gscSearchData, gscDataWatermarks } from '@ainyc/canonry-db'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { shiftIsoCalendarDate, type MetricsWindow } from '@ainyc/canonry-contracts'
 
@@ -126,31 +126,35 @@ function gscDaysSinceLatestData(latestDataDate: string | null, today: string): n
 }
 
 /**
- * The latest GSC reporting date stored for a project, across BOTH sources.
+ * The furthest GSC reporting date a project has reached — the anchor every
+ * window hangs off.
  *
- * This is a PROXY for Google's publication watermark, not the watermark
- * itself, and it is the best one the API makes available: Search Analytics
- * omits zero-data days entirely, so a published day on which the property
- * earned nothing looks identical to a day that has not been published. On a
- * quiet property the anchor therefore sits behind Google's real frontier and
- * the window shifts back with it. The consequence is bounded — the window
- * still spans its full labelled length and still ends on the last day with
- * measured traffic — but it means no caller may present the resulting gap as
- * Google being late. See `daysSinceLatestData`.
+ * `MAX(date)` over the stored rows ALONE is not a frontier. Search Analytics
+ * returns no row for a day with no data, so on a quiet property the observed
+ * max walks backward and drags every anchored window back with it: a `30d`
+ * window slides into the previous month and its totals change for a reason
+ * that has nothing to do with the site's performance.
  *
- * The property-level table is preferred everywhere else, but it can lag the
- * dimensioned one (a project synced before `gsc_daily_totals` existed has only
- * dimensioned rows). Taking the max of the two means the anchor never sits
- * behind data the endpoint is about to return.
+ * So the persisted `gsc_data_watermarks.data_through_date` — which a sync may
+ * only ADVANCE — takes precedence, and the observed max is a floor under it
+ * for projects that synced before the watermark existed. A quiet tail can
+ * then leave the frontier where it is instead of moving it backward.
+ *
+ * Both stored tables are consulted for that floor because they sync
+ * independently: a project from before `gsc_daily_totals` existed has only
+ * dimensioned rows, and anchoring behind data the endpoint is about to return
+ * would cut it off.
  */
 export function readLatestGscDataDate(db: DatabaseClient, projectId: string): string | null {
+  const watermark = db.select({ through: gscDataWatermarks.dataThroughDate })
+    .from(gscDataWatermarks).where(eq(gscDataWatermarks.projectId, projectId)).get()?.through ?? null
   const property = db.select({ latest: max(gscDailyTotals.date) })
     .from(gscDailyTotals).where(eq(gscDailyTotals.projectId, projectId)).get()?.latest ?? null
   const dimensioned = db.select({ latest: max(gscSearchData.date) })
     .from(gscSearchData).where(eq(gscSearchData.projectId, projectId)).get()?.latest ?? null
-  if (property === null) return dimensioned
-  if (dimensioned === null) return property
-  return property >= dimensioned ? property : dimensioned
+  return [watermark, property, dimensioned]
+    .filter((d): d is string => d !== null)
+    .reduce<string | null>((maxDate, d) => (maxDate === null || d > maxDate ? d : maxDate), null)
 }
 
 /**

--- a/packages/api-routes/src/gsc-totals.ts
+++ b/packages/api-routes/src/gsc-totals.ts
@@ -1,12 +1,109 @@
-import { and, asc, eq, sql } from 'drizzle-orm'
-import { gscDailyTotals, gscQueryDailyTotals } from '@ainyc/canonry-db'
+import { and, asc, eq, sql, max } from 'drizzle-orm'
+import { gscDailyTotals, gscQueryDailyTotals, gscSearchData } from '@ainyc/canonry-db'
 import type { DatabaseClient } from '@ainyc/canonry-db'
+import { shiftIsoCalendarDate, type MetricsWindow } from '@ainyc/canonry-contracts'
 
 export interface GscDailyTotal {
   date: string
   clicks: number
   impressions: number
   position: number
+}
+
+/** Days a labelled rolling window covers. `all` has no fixed span. */
+const WINDOW_DAYS: Record<Exclude<MetricsWindow, 'all'>, number> = { '7d': 7, '30d': 30, '90d': 90 }
+
+/**
+ * The inclusive date range a labelled GSC window actually covers, plus the
+ * reporting lag that decided it.
+ */
+export interface GscWindowRange {
+  /** Inclusive lower bound, or `null` for `all`. */
+  startDate: string | null
+  /** Inclusive upper bound: the latest date the property has published. */
+  endDate: string | null
+  /** `MAX(date)` across the project's GSC data, ignoring any window. */
+  latestDataDate: string | null
+  /** Calendar days between `latestDataDate` and today. `null` with no data. */
+  reportingLagDays: number | null
+}
+
+/**
+ * Resolve a labelled window against the last day Search Console actually
+ * published, NOT against the clock.
+ *
+ * Google publishes search analytics on a two-to-three day delay, so the most
+ * recent days of a now-anchored window are dates that cannot ever hold data.
+ * Anchoring `30d` at today therefore returns 27 or 28 days of data under a
+ * label that promises 30, and the shortfall grows as the window shrinks: a
+ * `7d` window spends three of its seven days on the lag and delivers four.
+ *
+ * Worse, the shortfall is invisible and it is not monotonic across labels.
+ * Canonry's now-anchored `30d` covered 2026-07-13..2026-08-09 while Search
+ * Console's own `28 days` covered 2026-07-14..2026-08-10 — neither range
+ * contains the other, so the wider Canonry window reported FEWER impressions
+ * (1,174) than the narrower Google one (1,360). A total that moves the wrong
+ * way when you widen the window reads as missing data, and there is no way for
+ * an operator to tell that apart from a real decline.
+ *
+ * Anchoring on the last published day is what Search Console's own UI does, so
+ * `30d` means thirty days of data and the two surfaces become comparable.
+ *
+ * `today` is injected rather than read from the clock so this stays pure and
+ * testable, matching the `gbp-summary` precedent.
+ */
+export function resolveGscWindowRange(
+  window: MetricsWindow,
+  latestDataDate: string | null,
+  today: string,
+): GscWindowRange {
+  const reportingLagDays = latestDataDate === null
+    ? null
+    : Math.max(0, Math.round(
+      (Date.parse(`${today}T00:00:00Z`) - Date.parse(`${latestDataDate}T00:00:00Z`)) / 86_400_000,
+    ))
+
+  // `all` has no lower bound to place, and with no data at all there is no
+  // anchor: fall back to the now-anchored cutoff so an empty project still
+  // filters rather than returning everything.
+  if (window === 'all') {
+    return { startDate: null, endDate: latestDataDate, latestDataDate, reportingLagDays }
+  }
+  const days = WINDOW_DAYS[window]
+  if (latestDataDate === null) {
+    return {
+      startDate: shiftIsoCalendarDate(today, -days),
+      endDate: null,
+      latestDataDate: null,
+      reportingLagDays: null,
+    }
+  }
+  // `days - 1`, because the range is INCLUSIVE at both ends: a 7-day window
+  // ending on the 10th starts on the 4th, not the 3rd.
+  return {
+    startDate: shiftIsoCalendarDate(latestDataDate, -(days - 1)),
+    endDate: latestDataDate,
+    latestDataDate,
+    reportingLagDays,
+  }
+}
+
+/**
+ * The latest GSC reporting date stored for a project, across BOTH sources.
+ *
+ * The property-level table is preferred everywhere else, but it can lag the
+ * dimensioned one (a project synced before `gsc_daily_totals` existed has only
+ * dimensioned rows). Taking the max of the two means the anchor never sits
+ * behind data the endpoint is about to return.
+ */
+export function readLatestGscDataDate(db: DatabaseClient, projectId: string): string | null {
+  const property = db.select({ latest: max(gscDailyTotals.date) })
+    .from(gscDailyTotals).where(eq(gscDailyTotals.projectId, projectId)).get()?.latest ?? null
+  const dimensioned = db.select({ latest: max(gscSearchData.date) })
+    .from(gscSearchData).where(eq(gscSearchData.projectId, projectId)).get()?.latest ?? null
+  if (property === null) return dimensioned
+  if (dimensioned === null) return property
+  return property >= dimensioned ? property : dimensioned
 }
 
 /**

--- a/packages/api-routes/src/gsc-totals.ts
+++ b/packages/api-routes/src/gsc-totals.ts
@@ -57,19 +57,36 @@ export function resolveGscWindowRange(
   latestDataDate: string | null,
   today: string,
 ): GscWindowRange {
-  const reportingLagDays = latestDataDate === null
-    ? null
-    : Math.max(0, Math.round(
-      (Date.parse(`${today}T00:00:00Z`) - Date.parse(`${latestDataDate}T00:00:00Z`)) / 86_400_000,
-    ))
-
-  // `all` has no lower bound to place, and with no data at all there is no
-  // anchor: fall back to the now-anchored cutoff so an empty project still
-  // filters rather than returning everything.
+  // `all` has no lower bound to place, but it still stops where the data does.
   if (window === 'all') {
-    return { startDate: null, endDate: latestDataDate, latestDataDate, reportingLagDays }
+    return {
+      startDate: null,
+      endDate: latestDataDate,
+      latestDataDate,
+      reportingLagDays: gscReportingLagDays(latestDataDate, today),
+    }
   }
-  const days = WINDOW_DAYS[window]
+  return resolveGscWindowDays(WINDOW_DAYS[window], latestDataDate, today)
+}
+
+/**
+ * The same anchoring for a window expressed as a day count rather than a
+ * label.
+ *
+ * Surfaces that hard-code their own horizon (the suggested-queries basket
+ * mirrors Google's 28-day default) need identical treatment: a now-anchored
+ * 28 days delivers 25 under the reporting lag. There, the shortfall does more
+ * than shrink a number — the surface gates an impression floor, so a query
+ * that clears the floor across the true window can fall under it and be
+ * withheld entirely.
+ */
+export function resolveGscWindowDays(
+  days: number,
+  latestDataDate: string | null,
+  today: string,
+): GscWindowRange {
+  // With no data there is no anchor: fall back to the now-anchored cutoff so
+  // an empty project still filters rather than scanning all history.
   if (latestDataDate === null) {
     return {
       startDate: shiftIsoCalendarDate(today, -days),
@@ -84,8 +101,16 @@ export function resolveGscWindowRange(
     startDate: shiftIsoCalendarDate(latestDataDate, -(days - 1)),
     endDate: latestDataDate,
     latestDataDate,
-    reportingLagDays,
+    reportingLagDays: gscReportingLagDays(latestDataDate, today),
   }
+}
+
+/** Calendar days between the last published date and today. Never negative. */
+function gscReportingLagDays(latestDataDate: string | null, today: string): number | null {
+  if (latestDataDate === null) return null
+  return Math.max(0, Math.round(
+    (Date.parse(`${today}T00:00:00Z`) - Date.parse(`${latestDataDate}T00:00:00Z`)) / 86_400_000,
+  ))
 }
 
 /**

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -3027,6 +3027,15 @@ const routeCatalog: OpenApiOperation[] = [
       nameParameter,
       { name: 'startDate', in: 'query', description: 'Filter by start date.', schema: stringSchema },
       { name: 'endDate', in: 'query', description: 'Filter by end date.', schema: stringSchema },
+      {
+        name: 'days',
+        in: 'query',
+        description:
+          'Relative span in days, resolved server-side against the last published GSC date. '
+          + 'Prefer this over client-computed start/end dates: those bypass the published-day '
+          + 'anchoring and are pinned to the caller\'s clock rather than Google\'s Pacific calendar.',
+        schema: stringSchema,
+      },
       { name: 'query', in: 'query', description: 'Filter by search query.', schema: stringSchema },
       { name: 'page', in: 'query', description: 'Filter by page URL.', schema: stringSchema },
       {

--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -454,6 +454,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
       createdAt: 'Row creation timestamp.',
     },
   },
+  gscDataWatermarks: {
+    kind: 'internal-only',
+    reason: 'Monotonic per-project GSC frontier (furthest reporting date ever observed, plus how far the last sync asked). Read through `readLatestGscDataDate` to anchor windows; surfaced only as the derived `window` block on the performance/daily response, never as a row DTO.',
+  },
   gscDailyTotals: {
     kind: 'internal-only',
     reason: 'Property-level daily GSC totals (no query/page dims). Backing store for the report `gsc` headline/trend + the gsc performance/daily response; not exposed as a direct row DTO.',

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -1532,6 +1532,15 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance offset pagina
   })
 })
 
+/** `YYYY-MM-DD` for N days back on GSC's Pacific reporting calendar. */
+function pacificDayIso(daysAgo: number): string {
+  const today = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date())
+  return new Date(Date.parse(`${today}T00:00:00Z`) - daysAgo * 86_400_000)
+    .toISOString().slice(0, 10)
+}
+
 describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () => {
   let context: ReturnType<typeof buildApp>
   let projectId: string
@@ -1695,8 +1704,10 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     // The canonry.ai case: Google published through 3 days ago, so a
     // now-anchored 30d spent 3 of its days on dates that cannot hold data and
     // returned 27. Anchored on the last published day it returns all 30.
-    const dayIso = (daysAgo: number) =>
-      new Date(Date.now() - daysAgo * 86_400_000).toISOString().slice(0, 10)
+    // Seed on GSC's PACIFIC reporting calendar, which is what the route now
+    // measures against. A UTC-seeded fixture drifts by a day between 00:00 and
+    // 08:00 UTC — the same off-by-one the Pacific fix exists to remove.
+    const dayIso = (daysAgo: number) => pacificDayIso(daysAgo)
     const LAG = 3
     const now = '2026-01-01T00:00:00.000Z'
     // 30 consecutive published days ending at the lag boundary, plus two older
@@ -1716,7 +1727,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     const body = res.json() as GscPerformanceDailyDto
 
     expect(body.window.latestDataDate).toBe(dayIso(LAG))
-    expect(body.window.reportingLagDays).toBe(LAG)
+    expect(body.window.daysSinceLatestData).toBe(LAG)
     expect(body.window.endDate).toBe(dayIso(LAG))
     expect(body.window.startDate).toBe(dayIso(LAG + 29))
 
@@ -1733,8 +1744,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     // The anomaly that started this: a 30d window reported FEWER impressions
     // than a 28d one because the two ranges only overlapped. Whatever the lag,
     // the wider window must contain the narrower.
-    const dayIso = (daysAgo: number) =>
-      new Date(Date.now() - daysAgo * 86_400_000).toISOString().slice(0, 10)
+    const dayIso = (daysAgo: number) => pacificDayIso(daysAgo)
     const now = '2026-01-01T00:00:00.000Z'
     for (let i = 0; i < 95; i += 1) {
       context.db.insert(gscDailyTotals).values({

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -6,7 +6,7 @@ import os from 'node:os'
 import Fastify from 'fastify'
 import { eq } from 'drizzle-orm'
 import { createClient, migrate, projects, runs, auditLog, gscCoverageSnapshots, gscUrlInspections, gscSearchData, gscDailyTotals } from '@ainyc/canonry-db'
-import { AppError } from '@ainyc/canonry-contracts'
+import { AppError, type GscPerformanceDailyDto } from '@ainyc/canonry-contracts'
 import { googleOAuthSuccessHtml, googleRoutes } from '../src/google.js'
 
 // Reproduce state signing functions from google.ts to verify behavior.
@@ -1674,10 +1674,13 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
       url: '/projects/perf/google/gsc/performance/daily?startDate=2030-01-01',
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({
-      totals: { clicks: 0, impressions: 0, ctr: 0, days: 0 },
-      daily: [],
-    })
+    const body = res.json() as GscPerformanceDailyDto
+    expect(body.totals).toEqual({ clicks: 0, impressions: 0, ctr: 0, days: 0 })
+    expect(body.daily).toEqual([])
+    // An explicit startDate wins over the label, and the upper bound is the
+    // last published day, so the caller can label the period it actually got.
+    expect(body.window.startDate).toBe('2030-01-01')
+    expect(body.window.latestDataDate).toBe('2026-01-06')
   })
 
   it('returns 404 for an unknown project', async () => {
@@ -1686,6 +1689,71 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
       url: '/projects/nope/google/gsc/performance/daily',
     })
     expect(res.statusCode).toBe(404)
+  })
+
+  it('anchors a labelled window on the last published day, not on today', async () => {
+    // The canonry.ai case: Google published through 3 days ago, so a
+    // now-anchored 30d spent 3 of its days on dates that cannot hold data and
+    // returned 27. Anchored on the last published day it returns all 30.
+    const dayIso = (daysAgo: number) =>
+      new Date(Date.now() - daysAgo * 86_400_000).toISOString().slice(0, 10)
+    const LAG = 3
+    const now = '2026-01-01T00:00:00.000Z'
+    // 30 consecutive published days ending at the lag boundary, plus two older
+    // days that a correct 30d window must EXCLUDE.
+    for (let i = 0; i < 32; i += 1) {
+      context.db.insert(gscDailyTotals).values({
+        id: crypto.randomUUID(), projectId, date: dayIso(LAG + i),
+        clicks: 1, impressions: 10, position: '5', createdAt: now,
+      }).run()
+    }
+
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily?window=30d',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as GscPerformanceDailyDto
+
+    expect(body.window.latestDataDate).toBe(dayIso(LAG))
+    expect(body.window.reportingLagDays).toBe(LAG)
+    expect(body.window.endDate).toBe(dayIso(LAG))
+    expect(body.window.startDate).toBe(dayIso(LAG + 29))
+
+    // The label is honoured exactly: 30 days, not 27.
+    expect(body.daily).toHaveLength(30)
+    expect(body.totals.days).toBe(30)
+    expect(body.totals.impressions).toBe(300)
+    // And it stops: the two older seeded days are outside the window.
+    expect(body.daily[0]!.date).toBe(dayIso(LAG + 29))
+    expect(body.daily.at(-1)!.date).toBe(dayIso(LAG))
+  })
+
+  it('keeps a wider label a superset of a narrower one under reporting lag', () => {
+    // The anomaly that started this: a 30d window reported FEWER impressions
+    // than a 28d one because the two ranges only overlapped. Whatever the lag,
+    // the wider window must contain the narrower.
+    const dayIso = (daysAgo: number) =>
+      new Date(Date.now() - daysAgo * 86_400_000).toISOString().slice(0, 10)
+    const now = '2026-01-01T00:00:00.000Z'
+    for (let i = 0; i < 95; i += 1) {
+      context.db.insert(gscDailyTotals).values({
+        id: crypto.randomUUID(), projectId, date: dayIso(2 + i),
+        clicks: 1, impressions: 10, position: '5', createdAt: now,
+      }).run()
+    }
+    return Promise.all(['7d', '30d', '90d'].map(async (w) => {
+      const res = await context.app.inject({
+        method: 'GET', url: `/projects/perf/google/gsc/performance/daily?window=${w}`,
+      })
+      return (res.json() as GscPerformanceDailyDto)
+    })).then(([week, month, quarter]) => {
+      expect(week!.totals.impressions).toBe(70)
+      expect(month!.totals.impressions).toBe(300)
+      expect(quarter!.totals.impressions).toBe(900)
+      expect(month!.totals.impressions).toBeGreaterThan(week!.totals.impressions)
+      expect(quarter!.totals.impressions).toBeGreaterThan(month!.totals.impressions)
+    })
   })
 
   it('sources the daily series from gsc_daily_totals (property total), not the summed dimensioned rows', async () => {
@@ -1773,9 +1841,13 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
       url: '/projects/perf/google/gsc/performance/daily?startDate=2026-02-01&endDate=2026-02-01',
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({
-      totals: { clicks: 12, impressions: 500, ctr: 12 / 500, days: 1 },
-      daily: [{ date: '2026-02-01', clicks: 12, impressions: 500, ctr: 12 / 500 }],
-    })
+    const body = res.json() as GscPerformanceDailyDto
+    expect(body.totals).toEqual({ clicks: 12, impressions: 500, ctr: 12 / 500, days: 1 })
+    expect(body.daily).toEqual([{ date: '2026-02-01', clicks: 12, impressions: 500, ctr: 12 / 500 }])
+    expect(body.window.startDate).toBe('2026-02-01')
+    expect(body.window.endDate).toBe('2026-02-01')
+    // MAX across BOTH tables: the property row here is later than the
+    // dimensioned rows the surrounding fixture seeds.
+    expect(body.window.latestDataDate).toBe('2026-02-01')
   })
 })

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -1700,6 +1700,17 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     expect(res.statusCode).toBe(404)
   })
 
+  it('refuses a caller range that runs backwards instead of answering it empty', async () => {
+    // Both bounds are the caller's own, so the REQUEST is impossible. An empty
+    // 200 would be technically true and useless.
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily?startDate=2030-01-01&endDate=2026-01-06',
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error.message).toMatch(/is after endDate/)
+  })
+
   it('anchors a labelled window on the last published day, not on today', async () => {
     // The canonry.ai case: Google published through 3 days ago, so a
     // now-anchored 30d spent 3 of its days on dates that cannot hold data and

--- a/packages/api-routes/test/gsc-performance-ordering.test.ts
+++ b/packages/api-routes/test/gsc-performance-ordering.test.ts
@@ -172,6 +172,41 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance ordering', ()
     expect(firstBody.truncated).toBe(true)
   })
 
+  it('resolves ?days= server-side against the published frontier', async () => {
+    // The CLI used to turn `--days N` into client-computed UTC dates and send
+    // them as EXPLICIT bounds, which the route honours over its own anchor —
+    // so the relative window skipped the published-day anchoring entirely and
+    // was pinned to the caller's clock. The span is now resolved here.
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?days=1&limit=500',
+    })
+    expect(res.statusCode).toBe(200)
+    // A 1-day span ends at the frontier and covers exactly that one date.
+    const dates = new Set(rowsOf(res.json()).map((r) => r.date))
+    expect(dates.size).toBe(1)
+    expect([...dates][0]).toBe(DATES[0])
+  })
+
+  it('rejects a non-positive or non-integer ?days=', async () => {
+    for (const bad of ['0', '-3', '2.5', 'abc']) {
+      const res = await context.app.inject({
+        method: 'GET',
+        url: `/projects/perf/google/gsc/performance?days=${bad}`,
+      })
+      expect(res.statusCode, `days=${bad}`).toBe(400)
+    }
+  })
+
+  it('refuses a caller range that runs backwards', async () => {
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?startDate=2030-01-01&endDate=2026-01-06',
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error.message).toMatch(/is after endDate/)
+  })
+
   it('returns rows spanning more than one date on a default call', async () => {
     const res = await context.app.inject({
       method: 'GET',

--- a/packages/api-routes/test/gsc-window-range.test.ts
+++ b/packages/api-routes/test/gsc-window-range.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { createClient, migrate, projects, runs, gscSearchData, gscDailyTotals } from '@ainyc/canonry-db'
 
-import { readLatestGscDataDate, resolveGscWindowRange } from '../src/gsc-totals.js'
+import { readLatestGscDataDate, resolveGscWindowDays, resolveGscWindowRange } from '../src/gsc-totals.js'
 
 /**
  * Reproduces the real canonry.ai disagreement that motivated the change.
@@ -159,5 +159,40 @@ describe('readLatestGscDataDate', () => {
 
     seedProperty('2026-08-11')
     expect(readLatestGscDataDate(db, projectId)).toBe('2026-08-11')
+  })
+})
+
+describe('resolveGscWindowDays', () => {
+  it('anchors a bare day count the same way a label does', () => {
+    // The suggested-queries basket hard-codes 28 days to mirror Google's
+    // default. Under a 3-day lag the now-anchored version delivered 25.
+    expect(resolveGscWindowDays(28, LATEST, TODAY)).toEqual({
+      startDate: '2026-07-13',
+      endDate: '2026-08-09',
+      latestDataDate: '2026-08-09',
+      reportingLagDays: 3,
+    })
+  })
+
+  it('agrees with the labelled resolver on the same span', () => {
+    expect(resolveGscWindowDays(30, LATEST, TODAY)).toEqual(resolveGscWindowRange('30d', LATEST, TODAY))
+    expect(resolveGscWindowDays(7, LATEST, TODAY)).toEqual(resolveGscWindowRange('7d', LATEST, TODAY))
+  })
+
+  it('covers exactly the requested number of inclusive days', () => {
+    const range = resolveGscWindowDays(28, LATEST, TODAY)
+    const spanDays =
+      (Date.parse(`${range.endDate!}T00:00:00Z`) - Date.parse(`${range.startDate!}T00:00:00Z`))
+      / 86_400_000 + 1
+    expect(spanDays).toBe(28)
+  })
+
+  it('falls back to a now-anchored cutoff with no data', () => {
+    expect(resolveGscWindowDays(28, null, TODAY)).toEqual({
+      startDate: '2026-07-15',
+      endDate: null,
+      latestDataDate: null,
+      reportingLagDays: null,
+    })
   })
 })

--- a/packages/api-routes/test/gsc-window-range.test.ts
+++ b/packages/api-routes/test/gsc-window-range.test.ts
@@ -3,9 +3,10 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { createClient, migrate, projects, runs, gscSearchData, gscDailyTotals } from '@ainyc/canonry-db'
+import { createClient, migrate, projects, runs, gscSearchData, gscDailyTotals, gscDataWatermarks } from '@ainyc/canonry-db'
 
 import { readLatestGscDataDate, resolveGscWindowDays, resolveGscWindowRange } from '../src/gsc-totals.js'
+import { assertForwardRange, resolveReportedWindow } from '../src/google.js'
 
 /**
  * Reproduces the real canonry.ai disagreement that motivated the change.
@@ -197,16 +198,58 @@ describe('resolveGscWindowDays', () => {
   })
 })
 
-describe('reported window bounds', () => {
-  // Finding: an explicit bound combined with the computed opposite one could
-  // describe a period running backwards (2030-01-01 to 2026-01-06).
-  it('drops a computed bound rather than reporting a reversed range', async () => {
-    const { resolveGscWindowRange: r } = await import('../src/gsc-totals.js')
-    const resolved = r('30d', LATEST, TODAY)
-    // Mirrors the route helper: explicit start, computed end, start > end.
-    const start = '2030-01-01'
-    const end = resolved.endDate
-    expect(start > end!).toBe(true)
+describe('resolveReportedWindow', () => {
+  const resolved = resolveGscWindowRange('30d', LATEST, TODAY)
+
+  it('passes a forward range through untouched', () => {
+    expect(resolveReportedWindow(resolved, '2026-07-20', '2026-08-01')).toMatchObject({
+      startDate: '2026-07-20', endDate: '2026-08-01',
+    })
+  })
+
+  it('lets an explicit bound win over the computed one', () => {
+    expect(resolveReportedWindow(resolved, '2026-07-20', undefined).startDate).toBe('2026-07-20')
+    expect(resolveReportedWindow(resolved, undefined, '2026-08-01').endDate).toBe('2026-08-01')
+  })
+
+  it('drops the COMPUTED bound when mixing it with an explicit one would reverse the range', () => {
+    // Explicit start past the computed end: report the start, drop the end.
+    // Absent is honest about being unspecified; reversed is not.
+    const forward = resolveReportedWindow(resolved, '2030-01-01', undefined)
+    expect(forward.startDate).toBe('2030-01-01')
+    expect(forward.endDate).toBeNull()
+    // And the mirror case: explicit end before the computed start.
+    const backward = resolveReportedWindow(resolved, undefined, '2020-01-01')
+    expect(backward.endDate).toBe('2020-01-01')
+    expect(backward.startDate).toBeNull()
+  })
+
+  it('never reports a range whose start is after its end, for any combination', () => {
+    for (const start of [undefined, '2020-01-01', '2030-01-01']) {
+      for (const end of [undefined, '2020-06-01', '2030-06-01']) {
+        if (start && end && start > end) continue // refused upstream, see below
+        const w = resolveReportedWindow(resolved, start, end)
+        if (w.startDate !== null && w.endDate !== null) {
+          expect(w.startDate <= w.endDate).toBe(true)
+        }
+      }
+    }
+  })
+})
+
+describe('assertForwardRange', () => {
+  it('refuses a caller range that runs backwards', () => {
+    // Both bounds are the caller's own, so the REQUEST is impossible. Returning
+    // an empty result would be true and useless.
+    expect(() => assertForwardRange('2030-01-01', '2026-01-06')).toThrow(/is after endDate/)
+  })
+
+  it('accepts a forward range, equal bounds, and a partial range', () => {
+    expect(() => assertForwardRange('2026-01-01', '2026-01-06')).not.toThrow()
+    expect(() => assertForwardRange('2026-01-06', '2026-01-06')).not.toThrow()
+    expect(() => assertForwardRange('2026-01-06', undefined)).not.toThrow()
+    expect(() => assertForwardRange(undefined, '2026-01-06')).not.toThrow()
+    expect(() => assertForwardRange(undefined, undefined)).not.toThrow()
   })
 })
 
@@ -220,5 +263,74 @@ describe('daysSinceLatestData', () => {
     expect(quietTail.endDate).toBe('2026-08-01')
     // And the window still spans its full labelled length off that anchor.
     expect(quietTail.startDate).toBe('2026-07-03')
+  })
+})
+
+describe('readLatestGscDataDate — monotonic watermark', () => {
+  let db: ReturnType<typeof createClient>
+  let tmpDir: string
+  let projectId: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-watermark-test-'))
+    db = createClient(path.join(tmpDir, 'test.db'))
+    migrate(db)
+    projectId = crypto.randomUUID()
+    const now = '2026-08-12T00:00:00.000Z'
+    db.insert(projects).values({
+      id: projectId, name: 'wm', displayName: 'WM', canonicalDomain: 'wm.example.com',
+      country: 'US', language: 'en', createdAt: now, updatedAt: now,
+    }).run()
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function seedProperty(date: string) {
+    db.insert(gscDailyTotals).values({
+      id: crypto.randomUUID(), projectId, date, clicks: 1, impressions: 10, position: '5',
+      createdAt: '2026-08-12T00:00:00.000Z',
+    }).run()
+  }
+
+  function setWatermark(dataThroughDate: string) {
+    db.insert(gscDataWatermarks).values({
+      projectId, dataThroughDate, syncedThroughDate: '2026-08-12',
+      updatedAt: '2026-08-12T00:00:00.000Z',
+    }).onConflictDoUpdate({
+      target: gscDataWatermarks.projectId,
+      set: { dataThroughDate },
+    }).run()
+  }
+
+  it('holds the frontier when a quiet tail makes the observed max walk backward', () => {
+    // THE BUG: Search Analytics omits zero-data days. The property reached
+    // 08-09, then went quiet — the newest row is now 08-01. Without the
+    // watermark the anchor follows the rows down and every window slides a week
+    // into the past, changing totals for a reason unrelated to performance.
+    seedProperty('2026-08-01')
+    setWatermark('2026-08-09')
+    expect(readLatestGscDataDate(db, projectId)).toBe('2026-08-09')
+
+    const window = resolveGscWindowRange('30d', readLatestGscDataDate(db, projectId), TODAY)
+    expect(window.endDate).toBe('2026-08-09')
+    expect(window.startDate).toBe('2026-07-11')
+  })
+
+  it('still advances when real data moves past the stored watermark', () => {
+    // Monotonic means "never backward", not "frozen".
+    setWatermark('2026-08-05')
+    seedProperty('2026-08-09')
+    expect(readLatestGscDataDate(db, projectId)).toBe('2026-08-09')
+  })
+
+  it('falls back to the observed max for a project that predates the watermark', () => {
+    seedProperty('2026-08-09')
+    expect(readLatestGscDataDate(db, projectId)).toBe('2026-08-09')
+  })
+
+  it('is null for a project with neither', () => {
+    expect(readLatestGscDataDate(db, projectId)).toBeNull()
   })
 })

--- a/packages/api-routes/test/gsc-window-range.test.ts
+++ b/packages/api-routes/test/gsc-window-range.test.ts
@@ -1,0 +1,163 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createClient, migrate, projects, runs, gscSearchData, gscDailyTotals } from '@ainyc/canonry-db'
+
+import { readLatestGscDataDate, resolveGscWindowRange } from '../src/gsc-totals.js'
+
+/**
+ * Reproduces the real canonry.ai disagreement that motivated the change.
+ *
+ * On 2026-08-12 the property had published through 2026-08-09 (a 3-day lag).
+ * Canonry's now-anchored `30d` covered 07-13..08-09 and reported 1,174
+ * impressions; Search Console's `28 days` covered 07-14..08-10 and reported
+ * 1,360. Neither range contains the other, so the WIDER window reported FEWER
+ * impressions — which is indistinguishable from a real decline.
+ */
+const TODAY = '2026-08-12'
+const LATEST = '2026-08-09'
+
+describe('resolveGscWindowRange', () => {
+  it('anchors the range on the last published day, not on today', () => {
+    expect(resolveGscWindowRange('30d', LATEST, TODAY)).toEqual({
+      startDate: '2026-07-11',
+      endDate: '2026-08-09',
+      latestDataDate: '2026-08-09',
+      reportingLagDays: 3,
+    })
+  })
+
+  it('covers exactly as many calendar days as its label promises', () => {
+    // The inclusive range is the bug's whole surface: a now-anchored 30d
+    // delivered 28 days of data under a label that said 30.
+    for (const [window, days] of [['7d', 7], ['30d', 30], ['90d', 90]] as const) {
+      const range = resolveGscWindowRange(window, LATEST, TODAY)
+      const spanDays =
+        (Date.parse(`${range.endDate!}T00:00:00Z`) - Date.parse(`${range.startDate!}T00:00:00Z`))
+        / 86_400_000 + 1
+      expect(spanDays).toBe(days)
+    }
+  })
+
+  it('is monotonic: a wider label always contains a narrower one', () => {
+    // This is the property the now-anchored window broke. It has to hold for
+    // ANY lag, including a lag longer than the shortest window.
+    for (const lagDays of [0, 1, 2, 3, 7, 30]) {
+      const latest = new Date(Date.parse(`${TODAY}T00:00:00Z`) - lagDays * 86_400_000)
+        .toISOString().slice(0, 10)
+      const week = resolveGscWindowRange('7d', latest, TODAY)
+      const month = resolveGscWindowRange('30d', latest, TODAY)
+      const quarter = resolveGscWindowRange('90d', latest, TODAY)
+      expect(month.startDate! <= week.startDate!).toBe(true)
+      expect(quarter.startDate! <= month.startDate!).toBe(true)
+      // All three end on the same published day, so each is a strict superset.
+      expect(week.endDate).toBe(latest)
+      expect(month.endDate).toBe(latest)
+      expect(quarter.endDate).toBe(latest)
+    }
+  })
+
+  it('reports the lag it measured', () => {
+    expect(resolveGscWindowRange('7d', '2026-08-12', TODAY).reportingLagDays).toBe(0)
+    expect(resolveGscWindowRange('7d', '2026-08-10', TODAY).reportingLagDays).toBe(2)
+    // A property that somehow published ahead of today is clamped, not negative.
+    expect(resolveGscWindowRange('7d', '2026-08-20', TODAY).reportingLagDays).toBe(0)
+  })
+
+  it('steps calendar dates, so a month boundary does not lose a day', () => {
+    // 7 inclusive days ending 2026-03-02 is 2026-02-24 — only correct if the
+    // step is calendar arithmetic rather than a fixed 24h subtraction.
+    expect(resolveGscWindowRange('7d', '2026-03-02', '2026-03-04').startDate).toBe('2026-02-24')
+    // Across a leap day.
+    expect(resolveGscWindowRange('7d', '2028-03-02', '2028-03-04').startDate).toBe('2028-02-25')
+  })
+
+  it('leaves `all` unbounded below but still stops at the published day', () => {
+    expect(resolveGscWindowRange('all', LATEST, TODAY)).toEqual({
+      startDate: null,
+      endDate: '2026-08-09',
+      latestDataDate: '2026-08-09',
+      reportingLagDays: 3,
+    })
+  })
+
+  it('falls back to a now-anchored cutoff when the project has no data at all', () => {
+    // With no anchor there is nothing to anchor ON. Returning an unbounded
+    // range instead would turn an empty project into a full-history scan.
+    expect(resolveGscWindowRange('30d', null, TODAY)).toEqual({
+      startDate: '2026-07-13',
+      endDate: null,
+      latestDataDate: null,
+      reportingLagDays: null,
+    })
+  })
+})
+
+describe('readLatestGscDataDate', () => {
+  let db: ReturnType<typeof createClient>
+  let tmpDir: string
+  let projectId: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-window-test-'))
+    db = createClient(path.join(tmpDir, 'test.db'))
+    migrate(db)
+    projectId = crypto.randomUUID()
+    const now = '2026-08-12T00:00:00.000Z'
+    db.insert(projects).values({
+      id: projectId, name: 'perf', displayName: 'Perf', canonicalDomain: 'perf.example.com',
+      country: 'US', language: 'en', createdAt: now, updatedAt: now,
+    }).run()
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function seedDimensioned(date: string) {
+    const syncRunId = crypto.randomUUID()
+    db.insert(runs).values({
+      id: syncRunId, projectId, kind: 'gsc-sync', status: 'completed', trigger: 'manual',
+      createdAt: '2026-08-12T00:00:00.000Z',
+    }).run()
+    db.insert(gscSearchData).values({
+      id: crypto.randomUUID(), projectId, syncRunId, date, query: 'q', page: '/p',
+      country: 'usa', device: 'DESKTOP', impressions: 10, clicks: 1, ctr: '0.1', position: '5',
+      createdAt: '2026-08-12T00:00:00.000Z',
+    }).run()
+  }
+
+  function seedProperty(date: string) {
+    db.insert(gscDailyTotals).values({
+      id: crypto.randomUUID(), projectId, date, clicks: 1, impressions: 10, position: '5',
+      createdAt: '2026-08-12T00:00:00.000Z',
+    }).run()
+  }
+
+  it('returns null for a project with no GSC data', () => {
+    expect(readLatestGscDataDate(db, projectId)).toBeNull()
+  })
+
+  it('reads the property table when it is the only source', () => {
+    seedProperty('2026-08-09')
+    expect(readLatestGscDataDate(db, projectId)).toBe('2026-08-09')
+  })
+
+  it('reads the dimensioned table for a project that predates property totals', () => {
+    seedDimensioned('2026-08-08')
+    expect(readLatestGscDataDate(db, projectId)).toBe('2026-08-08')
+  })
+
+  it('takes the later of the two, so the anchor never sits behind returned data', () => {
+    // The two tables sync independently. Anchoring on the property table alone
+    // would cut off dimensioned dates the endpoint is about to serve.
+    seedProperty('2026-08-05')
+    seedDimensioned('2026-08-09')
+    expect(readLatestGscDataDate(db, projectId)).toBe('2026-08-09')
+
+    seedProperty('2026-08-11')
+    expect(readLatestGscDataDate(db, projectId)).toBe('2026-08-11')
+  })
+})

--- a/packages/api-routes/test/gsc-window-range.test.ts
+++ b/packages/api-routes/test/gsc-window-range.test.ts
@@ -25,7 +25,7 @@ describe('resolveGscWindowRange', () => {
       startDate: '2026-07-11',
       endDate: '2026-08-09',
       latestDataDate: '2026-08-09',
-      reportingLagDays: 3,
+      daysSinceLatestData: 3,
     })
   })
 
@@ -60,10 +60,10 @@ describe('resolveGscWindowRange', () => {
   })
 
   it('reports the lag it measured', () => {
-    expect(resolveGscWindowRange('7d', '2026-08-12', TODAY).reportingLagDays).toBe(0)
-    expect(resolveGscWindowRange('7d', '2026-08-10', TODAY).reportingLagDays).toBe(2)
+    expect(resolveGscWindowRange('7d', '2026-08-12', TODAY).daysSinceLatestData).toBe(0)
+    expect(resolveGscWindowRange('7d', '2026-08-10', TODAY).daysSinceLatestData).toBe(2)
     // A property that somehow published ahead of today is clamped, not negative.
-    expect(resolveGscWindowRange('7d', '2026-08-20', TODAY).reportingLagDays).toBe(0)
+    expect(resolveGscWindowRange('7d', '2026-08-20', TODAY).daysSinceLatestData).toBe(0)
   })
 
   it('steps calendar dates, so a month boundary does not lose a day', () => {
@@ -79,7 +79,7 @@ describe('resolveGscWindowRange', () => {
       startDate: null,
       endDate: '2026-08-09',
       latestDataDate: '2026-08-09',
-      reportingLagDays: 3,
+      daysSinceLatestData: 3,
     })
   })
 
@@ -90,7 +90,7 @@ describe('resolveGscWindowRange', () => {
       startDate: '2026-07-13',
       endDate: null,
       latestDataDate: null,
-      reportingLagDays: null,
+      daysSinceLatestData: null,
     })
   })
 })
@@ -170,7 +170,7 @@ describe('resolveGscWindowDays', () => {
       startDate: '2026-07-13',
       endDate: '2026-08-09',
       latestDataDate: '2026-08-09',
-      reportingLagDays: 3,
+      daysSinceLatestData: 3,
     })
   })
 
@@ -192,7 +192,33 @@ describe('resolveGscWindowDays', () => {
       startDate: '2026-07-15',
       endDate: null,
       latestDataDate: null,
-      reportingLagDays: null,
+      daysSinceLatestData: null,
     })
+  })
+})
+
+describe('reported window bounds', () => {
+  // Finding: an explicit bound combined with the computed opposite one could
+  // describe a period running backwards (2030-01-01 to 2026-01-06).
+  it('drops a computed bound rather than reporting a reversed range', async () => {
+    const { resolveGscWindowRange: r } = await import('../src/gsc-totals.js')
+    const resolved = r('30d', LATEST, TODAY)
+    // Mirrors the route helper: explicit start, computed end, start > end.
+    const start = '2030-01-01'
+    const end = resolved.endDate
+    expect(start > end!).toBe(true)
+  })
+})
+
+describe('daysSinceLatestData', () => {
+  it('is named for what it measures, not for a lag it cannot observe', () => {
+    // Search Analytics omits zero-data days, so a quiet tail is
+    // indistinguishable from an unpublished one. The number is still exact as
+    // "days since we last recorded traffic" — which is what it now claims.
+    const quietTail = resolveGscWindowRange('30d', '2026-08-01', TODAY)
+    expect(quietTail.daysSinceLatestData).toBe(11)
+    expect(quietTail.endDate).toBe('2026-08-01')
+    // And the window still spans its full labelled length off that anchor.
+    expect(quietTail.startDate).toBe('2026-07-03')
   })
 })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.160.0",
+  "version": "4.161.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -285,8 +285,15 @@ export async function googlePerformanceDaily(project: string, opts: {
   console.log(`GSC daily summary (${days} day${days === 1 ? '' : 's'}${range}):\n`)
   // The window stops short of today by design. Say what it covers, or a short
   // window reads as a sudden drop in coverage.
-  if (win?.endDate && (win.daysSinceLatestData ?? 0) > 0) {
+  // Freshness describes the PROJECT's latest data, not the requested range, so
+  // it may only be printed beside a range that actually ends there. Against an
+  // explicit historical range it read as `2026-01-31 (2 days ago)`.
+  const endsAtFrontier = win?.endDate !== undefined && win.endDate === win.latestDataDate
+  if (endsAtFrontier && (win.daysSinceLatestData ?? 0) > 0) {
     console.log(`  Search Console data through ${win.endDate} (${win.daysSinceLatestData} day${win.daysSinceLatestData === 1 ? '' : 's'} ago).`)
+    console.log()
+  } else if (win?.latestDataDate && win.endDate !== win.latestDataDate) {
+    console.log(`  Showing a fixed range. Latest Search Console data is ${win.latestDataDate}.`)
     console.log()
   }
   console.log(`  Clicks:      ${clicks.toLocaleString()}`)
@@ -378,11 +385,13 @@ export async function googlePerformance(project: string, opts: {
     if (opts.startDate) params.startDate = opts.startDate
     if (opts.endDate) params.endDate = opts.endDate
   } else if (opts.days) {
-    const end = new Date()
-    const start = new Date()
-    start.setDate(start.getDate() - opts.days)
-    params.startDate = start.toISOString().split('T')[0]!
-    params.endDate = end.toISOString().split('T')[0]!
+    // Forward the SPAN, never client-computed dates. Deriving bounds here
+    // pinned them to the UTC clock and sent them as explicit dates, which the
+    // route honours over its own anchor — so `--days 30` skipped the
+    // published-day anchoring entirely, could end a Pacific day in the future,
+    // and spanned 31 inclusive dates for a 30-day request. The server resolves
+    // the span against the same frontier every other window uses.
+    params.days = String(opts.days)
   }
   if (opts.keyword) params.query = opts.keyword
   if (opts.page) params.page = opts.page

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -1,4 +1,5 @@
 import type {
+  GscPerformanceDailyDto,
   GscSubmitSitemapsResponseDto,
   GscUrlInspectionDto,
   IndexingRequestResultDto,
@@ -264,7 +265,9 @@ export async function googlePerformanceDaily(project: string, opts: {
     console.log(JSON.stringify(data, null, 2))
     return
   } else if (opts.format === 'jsonl') {
-    emitJsonl(data.daily.map((row) => ({ project, ...row })))
+    // Carry the envelope's window onto every record — a bare daily row cannot
+    // say which period it belongs to or how fresh that period is.
+    emitJsonl(data.daily.map((row) => ({ project, window: data.window, ...row })))
     return
   }
 
@@ -274,13 +277,16 @@ export async function googlePerformanceDaily(project: string, opts: {
   }
 
   const { clicks, impressions, ctr, days } = data.totals
-  const { startDate: from, endDate: to, reportingLagDays } = data.window
-  const range = from && to ? ` ${from} to ${to}` : ''
+  // Optional at RUNTIME even though the DTO requires it: a server older than
+  // this field omits it, and a new CLI against an older server must degrade to
+  // no range label rather than crash. The web guards the same skew.
+  const win = data.window as GscPerformanceDailyDto['window'] | undefined
+  const range = win?.startDate && win.endDate ? ` ${win.startDate} to ${win.endDate}` : ''
   console.log(`GSC daily summary (${days} day${days === 1 ? '' : 's'}${range}):\n`)
-  // Google publishes on a delay, so the window stops short of today by design.
-  // Say so, or a short window looks like a sudden drop in coverage.
-  if (reportingLagDays !== null && reportingLagDays > 0) {
-    console.log(`  Search Console has published through ${to} (${reportingLagDays} day${reportingLagDays === 1 ? '' : 's'} behind today).`)
+  // The window stops short of today by design. Say what it covers, or a short
+  // window reads as a sudden drop in coverage.
+  if (win?.endDate && (win.daysSinceLatestData ?? 0) > 0) {
+    console.log(`  Search Console data through ${win.endDate} (${win.daysSinceLatestData} day${win.daysSinceLatestData === 1 ? '' : 's'} ago).`)
     console.log()
   }
   console.log(`  Clicks:      ${clicks.toLocaleString()}`)

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -274,7 +274,15 @@ export async function googlePerformanceDaily(project: string, opts: {
   }
 
   const { clicks, impressions, ctr, days } = data.totals
-  console.log(`GSC daily summary (${days} day${days === 1 ? '' : 's'}):\n`)
+  const { startDate: from, endDate: to, reportingLagDays } = data.window
+  const range = from && to ? ` ${from} to ${to}` : ''
+  console.log(`GSC daily summary (${days} day${days === 1 ? '' : 's'}${range}):\n`)
+  // Google publishes on a delay, so the window stops short of today by design.
+  // Say so, or a short window looks like a sudden drop in coverage.
+  if (reportingLagDays !== null && reportingLagDays > 0) {
+    console.log(`  Search Console has published through ${to} (${reportingLagDays} day${reportingLagDays === 1 ? '' : 's'} behind today).`)
+    console.log()
+  }
   console.log(`  Clicks:      ${clicks.toLocaleString()}`)
   console.log(`  Impressions: ${impressions.toLocaleString()}`)
   console.log(`  CTR:         ${(ctr * 100).toFixed(2)}%`)

--- a/packages/canonry/src/gsc-sync.ts
+++ b/packages/canonry/src/gsc-sync.ts
@@ -78,9 +78,19 @@ export async function executeGscSync(
       saveConfigPatch(opts.config)
     }
 
-    // Determine date range
+    // Determine date range.
+    //
+    // Ask through TODAY, not through a hard-coded lag boundary. Google's
+    // publishing delay varies; pinning the ceiling at `today - 3` meant the
+    // sync never requested the day Google had already published, so stored
+    // data sat a day behind the Search Console UI forever (measured on
+    // canonry.ai: GSC served through 08-10 while Canonry held 08-09). The API
+    // returns the days that exist and omits the rest, so asking wide is free.
+    //
+    // The lag still pads the START, so a `days`-day request yields `days` days
+    // of PUBLISHED data rather than `days` minus the delay.
     const lagOffset = GSC_DATA_LAG_DAYS
-    const endDate = formatDate(daysAgo(lagOffset))
+    const endDate = formatDate(new Date())
     const days = opts.full ? 480 : (opts.days ?? 30) // 480 days ≈ 16 months (GSC max)
     const startDate = formatDate(daysAgo(days + lagOffset))
 

--- a/packages/canonry/src/gsc-sync.ts
+++ b/packages/canonry/src/gsc-sync.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import { eq, and, sql } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { runs, projects, gscSearchData, gscDailyTotals, gscQueryDailyTotals } from '@ainyc/canonry-db'
+import { runs, projects, gscSearchData, gscDailyTotals, gscQueryDailyTotals, gscDataWatermarks } from '@ainyc/canonry-db'
 import {
   fetchSearchAnalytics,
   refreshAccessToken,
@@ -179,7 +179,42 @@ export async function executeGscSync(
       }).run()
     }
 
-    log.info('daily-totals.complete', { runId, projectId, rowCount: totalRows.length })
+    // Advance the monotonic data watermark.
+    //
+    // The furthest date this sync SAW, never lower than what a previous sync
+    // already recorded. Search Analytics omits zero-data days, so the observed
+    // max walks backward across a quiet stretch; letting the anchor follow it
+    // would slide every window into the past and move its totals. Monotonic is
+    // the property that makes this usable as a frontier at all.
+    //
+    // `syncedThroughDate` records how far we ASKED, so the gap between the two
+    // is attributable rather than mysterious.
+    const observedThrough = totalRows
+      .map((row) => row.keys[0] ?? '')
+      .filter((date) => date !== '')
+      .reduce<string | null>((max, date) => (max === null || date > max ? date : max), null)
+    if (observedThrough !== null || endDate) {
+      const existing = db.select().from(gscDataWatermarks)
+        .where(eq(gscDataWatermarks.projectId, projectId)).get()
+      const nextThrough = [existing?.dataThroughDate ?? null, observedThrough]
+        .filter((d): d is string => d !== null)
+        .reduce<string | null>((max, d) => (max === null || d > max ? d : max), null)
+      if (nextThrough !== null) {
+        db.insert(gscDataWatermarks).values({
+          projectId,
+          dataThroughDate: nextThrough,
+          syncedThroughDate: endDate,
+          updatedAt: dailyTotalsNow,
+        }).onConflictDoUpdate({
+          target: gscDataWatermarks.projectId,
+          set: { dataThroughDate: nextThrough, syncedThroughDate: endDate, updatedAt: dailyTotalsNow },
+        }).run()
+      }
+    }
+
+    log.info('daily-totals.complete', {
+      runId, projectId, rowCount: totalRows.length, observedThrough, syncedThrough: endDate,
+    })
 
     // Per-query daily totals (no `page` dimension). Same reason as above,
     // applied one level down: summing `gsc_search_data` by query multiplies

--- a/packages/canonry/src/gsc-sync.ts
+++ b/packages/canonry/src/gsc-sync.ts
@@ -6,7 +6,9 @@ import {
   fetchSearchAnalytics,
   refreshAccessToken,
   GSC_DATA_LAG_DAYS,
+  GSC_REPORTING_TIME_ZONE,
 } from '@ainyc/canonry-integration-google'
+import { formatIsoDateInTimeZone, shiftIsoCalendarDate } from '@ainyc/canonry-contracts'
 import type { CanonryConfig } from './config.js'
 import { saveConfigPatch } from './config.js'
 import { writeCoverageSnapshot } from './gsc-coverage-snapshot.js'
@@ -15,15 +17,10 @@ import { createLogger } from './logger.js'
 
 const log = createLogger('GscSync')
 
-function formatDate(d: Date): string {
-  return d.toISOString().split('T')[0]!
-}
-
-function daysAgo(n: number): Date {
-  const d = new Date()
-  d.setDate(d.getDate() - n)
-  return d
-}
+// `formatDate` / `daysAgo` were the UTC-calendar helpers this file used to
+// bound its fetch window. Both are gone: GSC reports on the Pacific calendar,
+// so the bounds now come from `formatIsoDateInTimeZone` +
+// `shiftIsoCalendarDate`, which step real calendar dates in the right zone.
 
 interface GscSyncOptions {
   days?: number
@@ -89,10 +86,14 @@ export async function executeGscSync(
     //
     // The lag still pads the START, so a `days`-day request yields `days` days
     // of PUBLISHED data rather than `days` minus the delay.
+    // Both bounds are dates on GOOGLE's reporting calendar, which is Pacific
+    // Time. A UTC date names the following day between 00:00 and 08:00 UTC —
+    // exactly when a nightly sync tends to fire — so both bounds would sit a
+    // day out for a third of the clock.
     const lagOffset = GSC_DATA_LAG_DAYS
-    const endDate = formatDate(new Date())
+    const endDate = formatIsoDateInTimeZone(new Date().toISOString(), GSC_REPORTING_TIME_ZONE)
     const days = opts.full ? 480 : (opts.days ?? 30) // 480 days ≈ 16 months (GSC max)
-    const startDate = formatDate(daysAgo(days + lagOffset))
+    const startDate = shiftIsoCalendarDate(endDate, -(days + lagOffset))
 
     // Fetch search analytics with pagination
     log.info('fetch.start', { runId, projectId, propertyId: conn.propertyId, startDate, endDate })

--- a/packages/canonry/test/gsc-sync-daily-totals.test.ts
+++ b/packages/canonry/test/gsc-sync-daily-totals.test.ts
@@ -107,6 +107,35 @@ beforeEach(() => {
   })
 })
 
+describe('executeGscSync — fetch window', () => {
+  test('asks Google through today instead of stopping at a hard-coded lag', async () => {
+    // The ceiling used to be `today - GSC_DATA_LAG_DAYS`, so the sync never
+    // requested the most recent day Google had already published and stored
+    // data stayed a day behind the Search Console UI on every run. Google's
+    // delay varies, so the only correct ceiling is today: the API returns the
+    // days that exist and omits the rest.
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+      seedRun(db, 'run_window')
+      fetchSearchAnalyticsMock.mockResolvedValue([])
+
+      await executeGscSync(db, 'run_window', 'proj_gsc', { config: testConfig() })
+
+      const today = new Date().toISOString().slice(0, 10)
+      for (const call of fetchSearchAnalyticsMock.mock.calls) {
+        expect((call[2] as { endDate: string }).endDate).toBe(today)
+      }
+      // The lag still pads the START, so a 30-day request still covers 30 days
+      // of PUBLISHED data rather than 30 minus the delay.
+      const firstCall = fetchSearchAnalyticsMock.mock.calls[0]!
+      expect((firstCall[2] as { startDate: string }).startDate).toBe(daysAgo(33))
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('executeGscSync — gsc_daily_totals (property total)', () => {
   test('stores property-level daily totals from the dimensions:[date] call', async () => {
     const { db, tmpDir } = createTempDb()

--- a/packages/canonry/test/gsc-sync-daily-totals.test.ts
+++ b/packages/canonry/test/gsc-sync-daily-totals.test.ts
@@ -10,6 +10,7 @@ import {
   runs,
   gscSearchData,
   gscDailyTotals,
+  gscDataWatermarks,
 } from '@ainyc/canonry-db'
 import type { CanonryConfig } from '../src/config.js'
 
@@ -42,6 +43,16 @@ function daysAgo(n: number): string {
   const d = new Date()
   d.setDate(d.getDate() - n)
   return d.toISOString().slice(0, 10)
+}
+
+/**
+ * Today on GSC's PACIFIC reporting calendar — the calendar the sync bounds its
+ * fetch by. A UTC "today" names the next day between 00:00 and 08:00 UTC.
+ */
+function pacificToday(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date())
 }
 
 function createTempDb() {
@@ -135,6 +146,92 @@ describe('executeGscSync — fetch window', () => {
       const start = new Date(Date.parse(`${today}T00:00:00Z`) - 33 * 86_400_000)
         .toISOString().slice(0, 10)
       expect((firstCall[2] as { startDate: string }).startDate).toBe(start)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('executeGscSync — data watermark', () => {
+  /** Return only property-level (`dimensions: ['date']`) rows for these dates. */
+  function respondWithDates(dates: readonly string[]) {
+    fetchSearchAnalyticsMock.mockImplementation(
+      (_t: string, _p: string, opts: { dimensions?: string[] }) => {
+        const dateOnly = Array.isArray(opts.dimensions)
+          && opts.dimensions.length === 1 && opts.dimensions[0] === 'date'
+        if (!dateOnly) return Promise.resolve([])
+        return Promise.resolve(dates.map((d) => ({
+          keys: [d], clicks: 1, impressions: 10, ctr: 0.1, position: 5,
+        })))
+      },
+    )
+  }
+
+  function watermark(db: ReturnType<typeof createClient>) {
+    return db.select().from(gscDataWatermarks)
+      .where(eq(gscDataWatermarks.projectId, 'proj_gsc')).get()
+  }
+
+  test('records the furthest date the sync observed, and how far it asked', async () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+      seedRun(db, 'run_wm1')
+      respondWithDates([daysAgo(9), daysAgo(5), daysAgo(4)])
+
+      await executeGscSync(db, 'run_wm1', 'proj_gsc', { config: testConfig() })
+
+      const row = watermark(db)
+      expect(row?.dataThroughDate).toBe(daysAgo(4))
+      // We asked through today even though Google stopped at day-4; the gap is
+      // what makes "zero traffic" distinguishable from "never requested".
+      expect(row?.syncedThroughDate).toBe(pacificToday())
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('NEVER moves the frontier backward when a later sync sees a quiet tail', async () => {
+    // The P1 this table exists for. Search Analytics omits zero-data days, so a
+    // quiet stretch makes the observed max walk backward. If the watermark
+    // followed it, every anchored window would slide into the past and its
+    // totals would move for a reason unrelated to the site.
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+
+      seedRun(db, 'run_wm2')
+      respondWithDates([daysAgo(6), daysAgo(4)])
+      await executeGscSync(db, 'run_wm2', 'proj_gsc', { config: testConfig() })
+      expect(watermark(db)?.dataThroughDate).toBe(daysAgo(4))
+
+      // Second sync: the property went quiet, so Google returns nothing past
+      // day-8. The observed max is now OLDER than the stored frontier.
+      seedRun(db, 'run_wm3')
+      respondWithDates([daysAgo(8)])
+      await executeGscSync(db, 'run_wm3', 'proj_gsc', { config: testConfig() })
+
+      expect(watermark(db)?.dataThroughDate).toBe(daysAgo(4))
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('advances when real data moves past the stored frontier', async () => {
+    // Monotonic means "never backward", not "frozen".
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+
+      seedRun(db, 'run_wm4')
+      respondWithDates([daysAgo(8)])
+      await executeGscSync(db, 'run_wm4', 'proj_gsc', { config: testConfig() })
+      expect(watermark(db)?.dataThroughDate).toBe(daysAgo(8))
+
+      seedRun(db, 'run_wm5')
+      respondWithDates([daysAgo(8), daysAgo(3)])
+      await executeGscSync(db, 'run_wm5', 'proj_gsc', { config: testConfig() })
+      expect(watermark(db)?.dataThroughDate).toBe(daysAgo(3))
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true })
     }

--- a/packages/canonry/test/gsc-sync-daily-totals.test.ts
+++ b/packages/canonry/test/gsc-sync-daily-totals.test.ts
@@ -122,14 +122,19 @@ describe('executeGscSync — fetch window', () => {
 
       await executeGscSync(db, 'run_window', 'proj_gsc', { config: testConfig() })
 
-      const today = new Date().toISOString().slice(0, 10)
+      // GSC's reporting calendar is Pacific, not UTC.
+      const today = new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'America/Los_Angeles', year: 'numeric', month: '2-digit', day: '2-digit',
+      }).format(new Date())
       for (const call of fetchSearchAnalyticsMock.mock.calls) {
         expect((call[2] as { endDate: string }).endDate).toBe(today)
       }
       // The lag still pads the START, so a 30-day request still covers 30 days
       // of PUBLISHED data rather than 30 minus the delay.
       const firstCall = fetchSearchAnalyticsMock.mock.calls[0]!
-      expect((firstCall[2] as { startDate: string }).startDate).toBe(daysAgo(33))
+      const start = new Date(Date.parse(`${today}T00:00:00Z`) - 33 * 86_400_000)
+        .toISOString().slice(0, 10)
+      expect((firstCall[2] as { startDate: string }).startDate).toBe(start)
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true })
     }

--- a/packages/canonry/test/gsc-sync-no-inspection.test.ts
+++ b/packages/canonry/test/gsc-sync-no-inspection.test.ts
@@ -39,7 +39,15 @@ function makeDb(project: unknown) {
         innerJoin: () => ({ where: () => emptyRows }),
       }),
     }),
-    insert: () => ({ values: (v: unknown) => ({ run: () => { inserted.push(v); return { changes: 1 } } }) }),
+    // `onConflictDoUpdate` is part of the real drizzle insert builder (the
+    // documented pattern for atomic upserts), so the stand-in has to answer it
+    // or it lies about the surface it is standing in for.
+    insert: () => ({
+      values: (v: unknown) => ({
+        run: () => { inserted.push(v); return { changes: 1 } },
+        onConflictDoUpdate: () => ({ run: () => { inserted.push(v); return { changes: 1 } } }),
+      }),
+    }),
     delete: () => ({ where: () => ({ run: () => ({ changes: 0 }) }) }),
   }
 }

--- a/packages/contracts/src/formatting.ts
+++ b/packages/contracts/src/formatting.ts
@@ -133,17 +133,26 @@ export function formatIsoDateInTimeZone(iso: string, timeZone: string): string {
 /**
  * The calendar date `days` days after `isoDate`, both plain `YYYY-MM-DD`.
  *
+ * Step a `YYYY-MM-DD` calendar date by `days`, forward or back.
+ *
  * Pure calendar arithmetic. `Date.UTC` is only a convenient month/year rollover
  * engine here: UTC has no daylight saving, so adding to its day field cannot
  * gain or lose an hour and cannot land on a different date than a paper
  * calendar would. Doing the same step in milliseconds against a ZONED instant
- * is what produces the off-by-one this exists to prevent, which is why the
- * public entry point below converts to a calendar date FIRST and steps second.
+ * is what produces the off-by-one this exists to prevent, which is why
+ * `isoDateDaysBeforeInTimeZone` converts to a calendar date FIRST and steps
+ * second.
+ *
+ * Use this directly when the input is ALREADY a calendar date with no instant
+ * behind it — a GSC reporting day, a rollup's `tsHour` date. Those have no
+ * clock reading, so there is no zone to resolve and
+ * `isoDateDaysBeforeInTimeZone` would be asking a question the value cannot
+ * answer.
  *
  * A value that is not a calendar date comes back untouched, so a degraded
  * upstream reading degrades once rather than turning into a wrong date.
  */
-function shiftIsoCalendarDate(isoDate: string, days: number): string {
+export function shiftIsoCalendarDate(isoDate: string, days: number): string {
   if (!Number.isFinite(days)) return isoDate
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate)
   if (!match?.[1] || !match[2] || !match[3]) return isoDate

--- a/packages/contracts/src/google.ts
+++ b/packages/contracts/src/google.ts
@@ -103,7 +103,13 @@ export const gscPerformanceDailyDtoSchema = z.object({
     days: z.number(),
   }),
   daily: z.array(gscPerformanceDailyPointSchema),
-  window: gscWindowRangeSchema,
+  /**
+   * Optional because a server older than this field omits it. Both the web and
+   * the CLI guard for that skew; declaring it required here would tell a
+   * generated consumer it may dereference the field safely against a legacy
+   * response, which is exactly the crash those guards exist to prevent.
+   */
+  window: gscWindowRangeSchema.optional(),
 })
 export type GscPerformanceDailyDto = z.infer<typeof gscPerformanceDailyDtoSchema>
 

--- a/packages/contracts/src/google.ts
+++ b/packages/contracts/src/google.ts
@@ -65,6 +65,28 @@ export const gscPerformanceDailyPointSchema = z.object({
 })
 export type GscPerformanceDailyPoint = z.infer<typeof gscPerformanceDailyPointSchema>
 
+/**
+ * The date range a labelled window resolved to, and the reporting lag that
+ * decided it.
+ *
+ * Search Console publishes on a two-to-three day delay, so a window anchored at
+ * today spends its most recent days on dates that cannot hold data. The range
+ * is therefore anchored on the last published day (what Google's own UI does),
+ * and reported here so a caller can label the period it actually got instead of
+ * the period it asked for.
+ */
+export const gscWindowRangeSchema = z.object({
+  /** Inclusive lower bound, or `null` for the `all` window. */
+  startDate: z.string().nullable(),
+  /** Inclusive upper bound: the last date the property published. */
+  endDate: z.string().nullable(),
+  /** `MAX(date)` across the project's GSC data, ignoring the window. */
+  latestDataDate: z.string().nullable(),
+  /** Calendar days between `latestDataDate` and today. `null` with no data. */
+  reportingLagDays: z.number().nullable(),
+})
+export type GscWindowRange = z.infer<typeof gscWindowRangeSchema>
+
 export const gscPerformanceDailyDtoSchema = z.object({
   totals: z.object({
     clicks: z.number(),
@@ -73,6 +95,7 @@ export const gscPerformanceDailyDtoSchema = z.object({
     days: z.number(),
   }),
   daily: z.array(gscPerformanceDailyPointSchema),
+  window: gscWindowRangeSchema,
 })
 export type GscPerformanceDailyDto = z.infer<typeof gscPerformanceDailyDtoSchema>
 

--- a/packages/contracts/src/google.ts
+++ b/packages/contracts/src/google.ts
@@ -82,8 +82,16 @@ export const gscWindowRangeSchema = z.object({
   endDate: z.string().nullable(),
   /** `MAX(date)` across the project's GSC data, ignoring the window. */
   latestDataDate: z.string().nullable(),
-  /** Calendar days between `latestDataDate` and today. `null` with no data. */
-  reportingLagDays: z.number().nullable(),
+  /**
+   * Calendar days since the last day with recorded traffic, on GSC's Pacific
+   * calendar. `null` with no data.
+   *
+   * NOT Google's publication lag: Search Analytics omits zero-data days, so a
+   * quiet tail is indistinguishable from an unpublished one and inflates this
+   * number. Render it as "data through <endDate>", never as "Search Console is
+   * N days behind".
+   */
+  daysSinceLatestData: z.number().nullable(),
 })
 export type GscWindowRange = z.infer<typeof gscWindowRangeSchema>
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -3563,6 +3563,25 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `ALTER TABLE traffic_sources ADD COLUMN queue_backlog_observed_at TEXT`,
     ],
   },
+  {
+    version: 137,
+    name: 'gsc-data-watermark',
+    // The furthest GSC reporting date this project has EVER observed.
+    //
+    // `MAX(date)` over the stored rows is not a frontier: Search Analytics
+    // returns no row for a day with no data, so a quiet tail makes the observed
+    // max walk BACKWARD and drags every anchored window back with it. This
+    // column is monotonic — a sync may only advance it — so a zero-traffic
+    // stretch can never move the frontier the wrong way.
+    statements: [
+      `CREATE TABLE IF NOT EXISTS gsc_data_watermarks (
+        project_id          TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+        data_through_date   TEXT NOT NULL,
+        synced_through_date TEXT,
+        updated_at          TEXT NOT NULL
+      )`,
+    ],
+  },
 ]
 
 function addRunsMeasurementPlanVersionForeignKey(tx: MigrationDb): void {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -562,6 +562,27 @@ export const gscSearchData = sqliteTable('gsc_search_data', {
 // equal Google's property total. This table stores the un-dimensioned daily
 // figure (`dimensions: ['date']`) so the headline totals + daily trend match
 // the GSC UI. Per-query / per-page breakdowns still read `gsc_search_data`.
+/**
+ * The furthest GSC reporting date a project has EVER observed, plus how far the
+ * last sync asked.
+ *
+ * `MAX(date)` over the stored rows is NOT a frontier. Search Analytics omits
+ * days with no data, so on a quiet property the observed max walks backward and
+ * drags every anchored window back with it — a 30-day window silently slides
+ * into the previous month and its totals move. `dataThroughDate` is monotonic
+ * (a sync may only advance it), which is what makes it usable as an anchor.
+ *
+ * `syncedThroughDate` records the ceiling the last sync actually requested, so
+ * the gap between the two is attributable: days in
+ * `(dataThroughDate, syncedThroughDate]` were asked for and came back empty.
+ */
+export const gscDataWatermarks = sqliteTable('gsc_data_watermarks', {
+  projectId: text('project_id').primaryKey().references(() => projects.id, { onDelete: 'cascade' }),
+  dataThroughDate: text('data_through_date').notNull(),
+  syncedThroughDate: text('synced_through_date'),
+  updatedAt: text('updated_at').notNull(),
+})
+
 export const gscDailyTotals = sqliteTable('gsc_daily_totals', {
   id: text('id').primaryKey(),
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),

--- a/packages/integration-google/src/constants.ts
+++ b/packages/integration-google/src/constants.ts
@@ -9,6 +9,17 @@ export const GSC_API_BASE = 'https://www.googleapis.com/webmasters/v3'
 export const URL_INSPECTION_API = 'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect'
 export const GSC_MAX_ROWS_PER_REQUEST = 25000
 /**
+ * The timezone Search Console buckets its reporting days by.
+ *
+ * Search analytics dates are Pacific Time, not UTC. Deriving "today" from the
+ * UTC calendar names a different day for the eight hours between 00:00 UTC and
+ * 08:00 UTC (16:00-00:00 PT the previous day), which is when a scheduled sync
+ * most often runs — so a UTC "today" would put the fetch ceiling and the
+ * measured freshness a full day out for a third of the clock.
+ */
+export const GSC_REPORTING_TIME_ZONE = 'America/Los_Angeles'
+
+/**
  * Google's typical search-analytics publishing delay, in days.
  *
  * Use it to PAD the start of a fetch window so a `days`-day request still

--- a/packages/integration-google/src/constants.ts
+++ b/packages/integration-google/src/constants.ts
@@ -8,6 +8,17 @@ export const INDEXING_SCOPE = 'https://www.googleapis.com/auth/indexing'
 export const GSC_API_BASE = 'https://www.googleapis.com/webmasters/v3'
 export const URL_INSPECTION_API = 'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect'
 export const GSC_MAX_ROWS_PER_REQUEST = 25000
+/**
+ * Google's typical search-analytics publishing delay, in days.
+ *
+ * Use it to PAD the start of a fetch window so a `days`-day request still
+ * yields `days` days of published data. Never use it as the window's END:
+ * the real delay varies (it is commonly two days and occasionally one), so a
+ * fixed ceiling of `today - 3` refuses to ask for days Google has already
+ * published and leaves stored data permanently a day behind the Search
+ * Console UI. Ask through today instead; the API returns what exists and
+ * simply omits the rest.
+ */
 export const GSC_DATA_LAG_DAYS = 3
 export const URL_INSPECTION_DAILY_LIMIT = 2000
 export const INDEXING_API_BASE = 'https://indexing.googleapis.com/v3'

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.160.0",
+  "version": "4.161.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.160.0",
+  "version": "4.161.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.160.0",
+  "version": "4.161.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## What

Canonry's 30-day GSC window reported **fewer** impressions than Search Console's 28-day one (1,174 vs 1.36K on canonry.ai). A wider window returning a smaller total is indistinguishable from a real decline, so this was worth tracing.

Three places, all the same mistake: assuming where Google's data ends instead of asking.

### 1. The read windows are anchored to the clock

`windowCutoff` returns `now - N days`. Google publishes search analytics on a delay, so the most recent days of every window are dates that can never hold data. The window silently delivers fewer days than its label, and the shortfall is worst on the window operators check most often.

Measured against the live canonry.ai database on 2026-08-12 (published through 08-09):

| Label | Days delivered | Impressions |
|---|---|---|
| 7d | 5 | 295 |
| 30d | 28 | 1,174 |
| 90d | 88 | 2,423 |

It also breaks monotonicity, which is what produced the original anomaly. Canonry's `30d` covered 07-13..08-09; Google's `28 days` covered 07-14..08-10. Neither range contains the other, so the wider window reported the smaller number.

Windows now resolve against the last published day, which is what Search Console's own UI does. `30d` means thirty days of data, a wider label is always a superset of a narrower one, and the two surfaces become comparable.

### 2. The sync never asks for the newest published day

`gsc-sync` hard-coded its ceiling at `today - GSC_DATA_LAG_DAYS` (3). Google's real delay varies and is commonly 2 days, so on 2026-08-12 Search Console had published 08-10 while the sync only ever asked through 08-09. Stored data therefore sat a day behind the UI on every run, permanently.

The ceiling is now today. The API returns the days that exist and omits the rest. The lag constant still pads the *start* of the window, which is the job it can actually do.

### 3. The per-query suggestion window had its own copy of the bug

`buildSuggestedQueriesFromGsc` hard-codes a 28-day cutoff to mirror Google's default, computed from `Date.now()`. This is the worst place to leave it: the surface ranks by impressions **and gates a 10-impression eligibility floor**, so the missing days do not merely shrink a number. A query that clears the floor across the true window falls under it and is withheld from the basket entirely.

On canonry.ai the now-anchored window surfaced 7 queries over the floor; anchored it surfaces 8. The suppressed one was **"new york ai marketing agency" (16 impressions)** — exactly the kind of term the basket exists to find.

## Result

| Label | Days before | Days after | Impressions before | Impressions after |
|---|---|---|---|---|
| 7d | 5 | 7 | 295 | 385 |
| 30d | 28 | 30 | 1,174 | 1,244 |
| 90d | 88 | 90 | 2,423 | 2,423 |

90d is unchanged because stored history, not the window, is the binding limit there.

## Also

`GET /google/gsc/performance/daily` now returns a `window` block (`startDate`, `endDate`, `latestDataDate`, `reportingLagDays`). The dashboard and `canonry google performance-daily` render the real range and say when Search Console is behind, so a lagging tail cannot read as a drop.

## Notes for review

- **`report.ts` already did this correctly** (`windowStartDate(maxDate, windowDays)` at line 218, anchored on the max date across both tables). The dashboard routes were the outliers, and this brings them in line with the report rather than inventing a new convention.
- **The query TABLE at `/performance` was already fine** and is deliberately unchanged beyond the window. It returns raw dimensioned rows and the UI keys them by `date:query:page` without aggregating, so there is no page-dimension fan-out at that grain. The fan-out only bites where rows get summed per query, which is the suggestion path in item 3.
- `resolveGscWindowRange` / `resolveGscWindowDays` are pure and take an injected `today`, following the `gbp-summary` precedent. `shiftIsoCalendarDate` was already in contracts as a private helper and is now exported, with a note on when to use it over the timezone-aware variant.
- `readLatestGscDataDate` takes the max across `gsc_daily_totals` and `gsc_search_data`. The property table is preferred everywhere else, but a project synced before it existed has only dimensioned rows, and anchoring behind data the endpoint is about to return would cut it off.
- **This changes client-report numbers.** `canonry report --period N` reads these windows, so reported totals go up. The direction is correct (they were under-counting), but it is a visible change for anyone comparing against an older report.
- Interacts with `ax/gsc-performance-chart`, which touches the same daily DTO and route. Whichever lands second needs a small rebase.

## Validation

- 8188/8188 tests pass, `typecheck` and `lint` clean, `plugin:check` green
- 15 tests on the resolvers, including monotonicity across lags of 0 to 30 days, inclusive-span exactness per label, month and leap-day boundaries, agreement between the labelled and day-count forms, and the empty-project fallback
- 2 end-to-end route tests reproducing the canonry.ai scenario
- 1 sync test pinning the fetch ceiling to today
- Every before/after figure above was measured by querying the live local database directly, not derived from the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)