### PR TITLE
Dual-axis GSC search performance chart with trend lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -758,6 +758,7 @@ The contract test `packages/api-routes/test/openapi-contract.test.ts` enforces a
 | Error factories | `packages/contracts/src/errors.ts` |
 | SQL `LIKE` wildcard escaping | `packages/contracts/src/sql-like.ts` (`escapeLikePattern` — caller adds `ESCAPE '\\'`) |
 | Retry / exponential backoff | `packages/contracts/src/retry.ts` (`withRetry`, `backoffDelayMs`, `isRetryableHttpError`) |
+| Statistics over a series | `packages/contracts/src/statistics.ts` (`wilsonInterval` for a proportion; `linearTrend` for the least-squares fit of any evenly-spaced series, returning slope-per-step plus the two endpoints a chart draws between). Fit trends server-side and put them in the DTO — a regression computed in a chart component is invisible to the CLI and breaks UI/CLI parity. |
 | Bounded async concurrency | `packages/contracts/src/concurrency.ts` (`mapWithConcurrency` — order-preserving worker pool, fail-fast with clean settle) |
 | Telemetry funnel classification | `packages/contracts/src/telemetry.ts` (`isGhostTelemetryEvent` — shared by the CLI client drop + the cloud collector backstop) |
 | JSON column parsing (DB-only) | `packages/db` (`parseJsonColumn`) |

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -730,8 +730,14 @@ export function GscSection({
 
   useEffect(() => {
     setPerformanceOffset(0)
+    // Clear the drill's DATE FILTERS too, not just the highlight. Dropping only
+    // `drillDay` left the request pinned to that one date while the header said
+    // 30d, so the table showed a single day under a month's label.
     setDrillDay(null)
-    void loadPerformanceRows(0)
+    setPerformanceFilters((prev) => (
+      prev.startDate || prev.endDate ? { ...prev, startDate: '', endDate: '' } : prev
+    ))
+    setDrillNonce((n) => n + 1)
     void loadPerformanceDaily()
   }, [gscWindow])
 
@@ -1115,7 +1121,10 @@ export function GscSection({
                     formatValue: m.format,
                     trend: showTrend ? trends?.[m.key] ?? null : null,
                   }))
-                  const totalFor = (key: GscChartMetric): number | null => totals[key]
+                  // `undefined` when the server predates the field; a missing
+                  // metric is the same "not measured" as an explicit null, and
+                  // must never reach a formatter.
+                  const totalFor = (key: GscChartMetric): number | null => totals[key] ?? null
 
                   return (
                     <div className="mt-3">
@@ -1192,6 +1201,24 @@ export function GscSection({
                         />
                       </div>
 
+                      {/* Keyboard + screen-reader path to the same drill-in the
+                          chart offers on click. Recharts owns the SVG and gives
+                          no focusable day, so the accessible control is a real
+                          button per day: reachable by Tab, visible on focus. */}
+                      <div role="group" aria-label="Filter the table to a single day">
+                        {daily.map((d) => (
+                          <button
+                            key={d.date}
+                            type="button"
+                            className="sr-only focus:not-sr-only focus:inline-block focus:rounded focus:border focus:border-strong focus:bg-surface-active focus:px-2 focus:py-1 focus:text-xs focus:text-strong"
+                            aria-pressed={drillDay === d.date}
+                            onClick={() => selectDay(d.date)}
+                          >
+                            {formatChartDateLabel(d.date)}: {d.clicks} clicks, {d.impressions} impressions
+                          </button>
+                        ))}
+                      </div>
+
                       {drillDay && (
                         <div className="mt-1 flex items-center gap-2 text-xs">
                           <span className="text-secondary">
@@ -1207,7 +1234,15 @@ export function GscSection({
                         </div>
                       )}
 
-                      {totals.position === null && (
+                      {totals.position !== null
+                        && (totals.positionDays ?? totals.days) < totals.days && (
+                        <p className="mt-1 text-[11px] text-muted">
+                          Average position covers {totals.positionDays} of {totals.days} days. The
+                          rest have no property-level position recorded.
+                        </p>
+                      )}
+
+                      {(totals.position === null || totals.position === undefined) && (
                         <p className="mt-1 text-[11px] text-muted">
                           Average position needs a property-level sync. Run <code>canonry google sync</code> to record it.
                         </p>

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -13,6 +13,7 @@ import {
   useClientTable,
 } from '../shared/DataTableControls.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
+import { InfoTooltip } from '../shared/InfoTooltip.js'
 import {
   CHART_NEUTRAL,
   CHART_TONE,
@@ -155,6 +156,11 @@ export function GscSection({
   // Clicks + impressions selected by default, matching Search Console.
   const [chartMetrics, setChartMetrics] = useState<GscChartMetric[]>(['clicks', 'impressions'])
   const [showTrend, setShowTrend] = useState(true)
+  // The day the table is drilled into, or null for the whole window. Bumping
+  // the nonce is what re-runs the fetch, so re-clicking the same day still
+  // reloads and the effect never reads a stale filter value.
+  const [drillDay, setDrillDay] = useState<string | null>(null)
+  const [drillNonce, setDrillNonce] = useState(0)
   const [performanceFilters, setPerformanceFilters] = useState({
     startDate: '',
     endDate: '',
@@ -724,9 +730,34 @@ export function GscSection({
 
   useEffect(() => {
     setPerformanceOffset(0)
+    setDrillDay(null)
     void loadPerformanceRows(0)
     void loadPerformanceDaily()
   }, [gscWindow])
+
+  // Drill into (or out of) a single day. Only the table reloads — the chart
+  // keeps the whole window so the selected day stays in context.
+  const drillMountRef = useRef(false)
+  useEffect(() => {
+    if (!drillMountRef.current) {
+      drillMountRef.current = true
+      return
+    }
+    setPerformanceOffset(0)
+    performanceTable.setPage(1)
+    void loadPerformanceRows(0)
+  }, [drillNonce])
+
+  function selectDay(date: string) {
+    const next = drillDay === date ? null : date
+    setDrillDay(next)
+    setPerformanceFilters((prev) => ({
+      ...prev,
+      startDate: next ?? '',
+      endDate: next ?? '',
+    }))
+    setDrillNonce((n) => n + 1)
+  }
 
   // Refetch when sort toggles between "off" and "on" so the fetched row set
   // matches the mode (paged vs expanded). Direction flips within "on" don't
@@ -1019,7 +1050,10 @@ export function GscSection({
                 <div className="section-head section-head-inline">
                   <div>
                     <p className="eyebrow eyebrow-soft">Performance</p>
-                    <h3>Search performance</h3>
+                    <h3 className="flex items-center gap-1.5">
+                      Search performance
+                      <InfoTooltip text={`Click any day to filter the table below to that date. Query and page filters match case-insensitive substrings and run on Apply filters. Filtering and sorting examine up to ${EXPANDED_PERFORMANCE_LIMIT.toLocaleString()} matching rows while the table shows ${DEFAULT_TABLE_PAGE_SIZE} per page.`} />
+                    </h3>
                     {/* The window ends where Google's data ends, not today.
                         Naming the real range is what stops a lagging tail
                         reading as a drop, and lets this be compared against
@@ -1067,6 +1101,9 @@ export function GscSection({
                     so it reflects the whole window, not the current page. The
                     dashed fits come from the API; nothing is regressed here. */}
                 {performanceDaily && performanceDaily.daily.length > 0 && (() => {
+                  // `trends` is optional at RUNTIME: a server older than the
+                  // field omits it, and the chart must degrade to plain lines
+                  // rather than crash. Same skew guard as `window`.
                   const { totals, daily, trends } = performanceDaily
                   const selected = GSC_CHART_METRICS.filter((m) => chartMetrics.includes(m.key))
                   const series: TrendChartSeries[] = selected.map((m) => ({
@@ -1076,7 +1113,7 @@ export function GscSection({
                     axisId: m.key,
                     inverted: m.inverted,
                     formatValue: m.format,
-                    trend: showTrend ? trends[m.key] : null,
+                    trend: showTrend ? trends?.[m.key] ?? null : null,
                   }))
                   const totalFor = (key: GscChartMetric): number | null => totals[key]
 
@@ -1090,7 +1127,7 @@ export function GscSection({
                         {GSC_CHART_METRICS.map((m) => {
                           const on = chartMetrics.includes(m.key)
                           const value = totalFor(m.key)
-                          const trend = trends[m.key]
+                          const trend = trends?.[m.key] ?? null
                           const unavailable = value === null
                           return (
                             <button
@@ -1150,8 +1187,25 @@ export function GscSection({
                           series={series}
                           xTickFormatter={formatChartDateTick}
                           labelFormatter={formatChartDateLabel}
+                          onSelectX={selectDay}
+                          selectedX={drillDay}
                         />
                       </div>
+
+                      {drillDay && (
+                        <div className="mt-1 flex items-center gap-2 text-xs">
+                          <span className="text-secondary">
+                            Table showing {formatChartDateLabel(drillDay)}
+                          </span>
+                          <button
+                            type="button"
+                            className="text-link hover:underline"
+                            onClick={() => selectDay(drillDay)}
+                          >
+                            Show all {totals.days} days
+                          </button>
+                        </div>
+                      )}
 
                       {totals.position === null && (
                         <p className="mt-1 text-[11px] text-muted">
@@ -1192,10 +1246,6 @@ export function GscSection({
                     placeholder="Contains page URL…"
                   />
                 </div>
-                <p className="mt-2 text-xs text-muted">
-                  Query and page filters match case-insensitive substrings. Click Apply filters to run.
-                  Filtering and sorting examine up to {EXPANDED_PERFORMANCE_LIMIT.toLocaleString()} matching rows while the table stays at {DEFAULT_TABLE_PAGE_SIZE} rows per page.
-                </p>
                 {performance.length > 0 ? (
                   <>
                     <div className="mt-3 overflow-x-auto">

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -23,6 +23,7 @@ import {
   formatChartDateTick,
   type TrendChartSeries,
 } from '../shared/ChartPrimitives.js'
+import { calendarDateRange } from '@ainyc/canonry-contracts'
 import { formatTimestamp, formatBooleanState, SearchMetric, SEARCH_METRIC_LABELS } from '../../lib/format-helpers.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
@@ -1126,6 +1127,19 @@ export function GscSection({
                   // must never reach a formatter.
                   const totalFor = (key: GscChartMetric): number | null => totals[key] ?? null
 
+                  // Plot one row per CALENDAR DAY, not per returned row.
+                  // `daily` holds only dates that produced data, but the server
+                  // fits over the calendar, so its `startIndex`/`endIndex` only
+                  // line up with a calendar-dense series — against row
+                  // positions the trend line traversed a fraction of its range
+                  // and ended on the wrong value. It is also the honest x-axis:
+                  // a six-day quiet stretch should look like six days.
+                  const byDate = new Map(daily.map((d) => [d.date, d]))
+                  const chartRows = daily.length === 0
+                    ? []
+                    : calendarDateRange(daily[0]!.date, daily[daily.length - 1]!.date)
+                      .map((date) => byDate.get(date) ?? { date })
+
                   return (
                     <div className="mt-3">
                       {/* Tiles are the metric selector, as in Search Console:
@@ -1191,7 +1205,7 @@ export function GscSection({
 
                       <div className="mt-1">
                         <MultiAxisTrendChart
-                          data={daily}
+                          data={chartRows}
                           xKey="date"
                           series={series}
                           xTickFormatter={formatChartDateTick}

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -13,7 +13,15 @@ import {
   useClientTable,
 } from '../shared/DataTableControls.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
-import { CHART_NEUTRAL, CHART_TONE, CHART_SERIES_COLORS } from '../shared/ChartPrimitives.js'
+import {
+  CHART_NEUTRAL,
+  CHART_TONE,
+  CHART_SERIES_COLORS,
+  MultiAxisTrendChart,
+  formatChartDateLabel,
+  formatChartDateTick,
+  type TrendChartSeries,
+} from '../shared/ChartPrimitives.js'
 import { formatTimestamp, formatBooleanState, SearchMetric, SEARCH_METRIC_LABELS } from '../../lib/format-helpers.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
@@ -59,6 +67,47 @@ import { invalidateProjectQueryDomain } from '../../queries/query-invalidation.j
 
 const GSC_WINDOWS: MetricsWindow[] = ['7d', '30d', '90d', 'all']
 const EXPANDED_PERFORMANCE_LIMIT = 500
+
+/**
+ * The four Search Console metrics, each on its OWN axis.
+ *
+ * Sharing one axis is what made the previous chart unreadable: 29 clicks
+ * against 1,174 impressions rendered as a flat line on the baseline. Per-metric
+ * axes let each series use the full plot height, which is why the same data
+ * reads as a trend here and as nothing on a shared scale.
+ *
+ * `inverted` on position is not styling — rank 1 beats rank 13, so the axis
+ * has to run the other way for "up" to keep meaning "better" across all four.
+ */
+const GSC_CHART_METRICS = [
+  {
+    key: 'clicks' as const,
+    label: 'Clicks',
+    color: CHART_SERIES_COLORS[1],
+    format: (v: number) => v.toLocaleString(),
+  },
+  {
+    key: 'impressions' as const,
+    label: 'Impressions',
+    color: CHART_SERIES_COLORS[4],
+    format: (v: number) => v.toLocaleString(),
+  },
+  {
+    key: 'ctr' as const,
+    label: 'CTR',
+    color: CHART_TONE.caution,
+    format: (v: number) => `${(v * 100).toFixed(1)}%`,
+  },
+  {
+    key: 'position' as const,
+    label: 'Avg position',
+    color: CHART_SERIES_COLORS[2],
+    inverted: true,
+    format: (v: number) => v.toFixed(1),
+  },
+]
+
+type GscChartMetric = (typeof GSC_CHART_METRICS)[number]['key']
 const COVERAGE_PAGE_SIZE = 25
 const GOOGLE_OAUTH_COMPLETE_MESSAGE = 'canonry:google-oauth-complete'
 
@@ -103,6 +152,9 @@ export function GscSection({
   const [syncDays, setSyncDays] = useState('30')
   const [fullSync, setFullSync] = useState(false)
   const [gscWindow, setGscWindow] = useState<MetricsWindow>('30d')
+  // Clicks + impressions selected by default, matching Search Console.
+  const [chartMetrics, setChartMetrics] = useState<GscChartMetric[]>(['clicks', 'impressions'])
+  const [showTrend, setShowTrend] = useState(true)
   const [performanceFilters, setPerformanceFilters] = useState({
     startDate: '',
     endDate: '',
@@ -1010,105 +1062,102 @@ export function GscSection({
                   </div>
                 </div>
 
-                {/* Clicks + Impressions bar chart — driven by the daily aggregate
-                    endpoint so it reflects the full window, not the current page. */}
+                {/* Search-performance chart — one axis PER METRIC (Search
+                    Console's own shape), driven by the daily aggregate endpoint
+                    so it reflects the whole window, not the current page. The
+                    dashed fits come from the API; nothing is regressed here. */}
                 {performanceDaily && performanceDaily.daily.length > 0 && (() => {
-                  const sorted = performanceDaily.daily
-                  const maxImpressions = Math.max(...sorted.map((d) => d.impressions), 1)
-                  const { clicks: totalClicks, impressions: totalImpressions, ctr: totalCtr } = performanceDaily.totals
-                  const avgCtr = (totalCtr * 100).toFixed(1)
-
-                  const w = 700
-                  const h = 220
-                  const pad = { top: 12, bottom: 36, left: 48, right: 12 }
-                  const plotW = w - pad.left - pad.right
-                  const plotH = h - pad.top - pad.bottom
-                  const barGroupW = plotW / sorted.length
-                  const barW = Math.max(Math.min(barGroupW * 0.35, 24), 4)
-                  const barGap = Math.max(barW * 0.15, 1)
-
-                  // Y-axis ticks
-                  const niceMax = (v: number) => {
-                    if (v <= 0) return 1
-                    const mag = Math.pow(10, Math.floor(Math.log10(v)))
-                    const norm = v / mag
-                    const nice = norm <= 1.5 ? 1.5 : norm <= 3 ? 3 : norm <= 5 ? 5 : 10
-                    return Math.ceil(nice * mag)
-                  }
-                  const tickCount = 4
-                  const ceilVal = Math.ceil(niceMax(maxImpressions) / tickCount) * tickCount
-                  const ticks = Array.from({ length: tickCount + 1 }, (_, i) => (ceilVal / tickCount) * i)
-                  const fmtNum = (n: number) => n >= 1000 ? `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k` : String(n)
+                  const { totals, daily, trends } = performanceDaily
+                  const selected = GSC_CHART_METRICS.filter((m) => chartMetrics.includes(m.key))
+                  const series: TrendChartSeries[] = selected.map((m) => ({
+                    dataKey: m.key,
+                    label: m.label,
+                    color: m.color,
+                    axisId: m.key,
+                    inverted: m.inverted,
+                    formatValue: m.format,
+                    trend: showTrend ? trends[m.key] : null,
+                  }))
+                  const totalFor = (key: GscChartMetric): number | null => totals[key]
 
                   return (
                     <div className="mt-3">
-                      <div className="flex items-center gap-5 mb-2">
-                        <div className="flex items-center gap-1.5">
-                          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-positive-500" />
-                          <span className="text-xs text-secondary">Clicks <span className="text-strong tabular-nums font-medium">{totalClicks.toLocaleString()}</span></span>
-                        </div>
-                        <div className="flex items-center gap-1.5">
-                          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-chart-series-2" />
-                          <span className="text-xs text-secondary">Impressions <span className="text-strong tabular-nums font-medium">{totalImpressions.toLocaleString()}</span></span>
-                        </div>
-                        <span className="text-xs text-muted">CTR <span className="text-caution-400 tabular-nums font-medium">{avgCtr}%</span></span>
-                      </div>
-                      <div className="relative w-full" style={{ aspectRatio: `${w} / ${h}` }}>
-                        <svg viewBox={`0 0 ${w} ${h}`} className="h-full w-full">
-                          {/* Grid lines + Y-axis */}
-                          {ticks.map((tick, i) => {
-                            const y = pad.top + plotH - (tick / ceilVal) * plotH
-                            return (
-                              <g key={`t-${i}`}>
-                                <line x1={pad.left} y1={y} x2={w - pad.right} y2={y} stroke={CHART_NEUTRAL.gridLine} strokeWidth="1" />
-                                <text x={pad.left - 6} y={y + 3.5} textAnchor="end" fill={CHART_NEUTRAL.text} fontSize="10" fontFamily="inherit">{fmtNum(tick)}</text>
-                              </g>
-                            )
-                          })}
-                          {/* Bars */}
-                          {sorted.map((d, i) => {
-                            const cx = pad.left + barGroupW * i + barGroupW / 2
-                            const impressionH = (d.impressions / ceilVal) * plotH
-                            const clickH = (d.clicks / ceilVal) * plotH
-                            return (
-                              <g key={d.date}>
-                                <title>{`${d.date}\nClicks: ${d.clicks}\nImpressions: ${d.impressions}\nCTR: ${(d.ctr * 100).toFixed(1)}%`}</title>
-                                <rect
-                                  x={cx - barW - barGap / 2}
-                                  y={pad.top + plotH - impressionH}
-                                  width={barW}
-                                  height={Math.max(impressionH, 1)}
-                                  rx={2}
-                                  fill={CHART_SERIES_COLORS[1]}
-                                  opacity={0.85}
+                      {/* Tiles are the metric selector, as in Search Console:
+                          pressing one adds or removes its line. The last
+                          selected tile cannot be turned off — an empty chart
+                          is a dead end, not a state worth reaching. */}
+                      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                        {GSC_CHART_METRICS.map((m) => {
+                          const on = chartMetrics.includes(m.key)
+                          const value = totalFor(m.key)
+                          const trend = trends[m.key]
+                          const unavailable = value === null
+                          return (
+                            <button
+                              key={m.key}
+                              type="button"
+                              aria-pressed={on}
+                              disabled={unavailable}
+                              className={`rounded-md border px-3 py-2 text-left transition-colors ${
+                                on ? 'border-strong bg-surface-active' : 'border-subtle bg-surface-subtle hover:bg-surface-hover'
+                              } ${unavailable ? 'cursor-not-allowed opacity-50' : ''}`}
+                              onClick={() => {
+                                setChartMetrics((current) => current.includes(m.key)
+                                  ? (current.length === 1 ? current : current.filter((k) => k !== m.key))
+                                  : [...current, m.key])
+                              }}
+                            >
+                              <span className="flex items-center gap-1.5">
+                                <span
+                                  className="inline-block h-2 w-2 rounded-full"
+                                  style={{ backgroundColor: on ? m.color : 'transparent', border: `1px solid ${m.color}` }}
                                 />
-                                <rect
-                                  x={cx + barGap / 2}
-                                  y={pad.top + plotH - clickH}
-                                  width={barW}
-                                  height={Math.max(clickH, 1)}
-                                  rx={2}
-                                  fill={CHART_TONE.positiveDeep}
-                                  opacity={0.85}
-                                />
-                              </g>
-                            )
-                          })}
-                          {/* X-axis date labels — pick up to 7 evenly spaced */}
-                          {(() => {
-                            const labelCount = Math.min(sorted.length, 7)
-                            return Array.from({ length: labelCount }, (_, i) => {
-                              const idx = sorted.length === 1 ? 0 : Math.round((i / (labelCount - 1)) * (sorted.length - 1))
-                              const cx = pad.left + barGroupW * idx + barGroupW / 2
-                              return (
-                                <text key={`xl-${idx}`} x={cx} y={h - 8} textAnchor="middle" fill={CHART_NEUTRAL.textDim} fontSize="10" fontFamily="inherit">
-                                  {sorted[idx]!.date.slice(5)}
-                                </text>
-                              )
-                            })
-                          })()}
-                        </svg>
+                                <span className="text-xs text-secondary">{m.label}</span>
+                              </span>
+                              <span className="mt-0.5 block text-lg tabular-nums text-strong">
+                                {value === null ? '—' : m.format(value)}
+                              </span>
+                              {trend && (
+                                <span className="block text-[11px] tabular-nums text-muted">
+                                  {/* Position improves downward, so the arrow
+                                      tracks BETTER/WORSE, not up/down. */}
+                                  {trend.slope === 0
+                                    ? '→ flat'
+                                    : `${(m.inverted ? trend.slope < 0 : trend.slope > 0) ? '↑' : '↓'} ${m.format(Math.abs(trend.end - trend.start))} over ${totals.days}d`}
+                                </span>
+                              )}
+                            </button>
+                          )
+                        })}
                       </div>
+
+                      <div className="mt-2 flex items-center justify-end">
+                        <label className="flex cursor-pointer items-center gap-1.5 text-xs text-secondary">
+                          <input
+                            type="checkbox"
+                            className="accent-mono-400"
+                            checked={showTrend}
+                            onChange={(e) => setShowTrend(e.target.checked)}
+                          />
+                          Trend line
+                        </label>
+                      </div>
+
+                      <div className="mt-1">
+                        <MultiAxisTrendChart
+                          data={daily}
+                          xKey="date"
+                          series={series}
+                          xTickFormatter={formatChartDateTick}
+                          labelFormatter={formatChartDateLabel}
+                        />
+                      </div>
+
+                      {totals.position === null && (
+                        <p className="mt-1 text-[11px] text-muted">
+                          Average position needs a property-level sync. Run <code>canonry google sync</code> to record it.
+                        </p>
+                      )}
                     </div>
                   )
                 })()}

--- a/apps/web/src/components/shared/ChartPrimitives.tsx
+++ b/apps/web/src/components/shared/ChartPrimitives.tsx
@@ -208,3 +208,155 @@ export function formatObservedInstantTick(instant: ObservedInstant): string {
   const d = new Date(instant)
   return `${d.getMonth() + 1}/${d.getDate()}`
 }
+
+/**
+ * One metric drawn on a {@link MultiAxisTrendChart}.
+ *
+ * `axisId` is what keeps a small metric readable next to a large one. Two
+ * series sharing an axis are compared against each other; two series on
+ * DIFFERENT axes each get their own domain, which is the whole reason 29 clicks
+ * and 1,174 impressions can sit on one chart without the clicks flattening into
+ * the baseline. Give two series the same `axisId` only when their units are
+ * genuinely comparable.
+ */
+export interface TrendChartSeries {
+  /** Field on each row holding this metric's value. `null` renders a gap. */
+  dataKey: string
+  label: string
+  /** A `CHART_SERIES_COLORS` / `CHART_TONE` entry. Never a raw hex. */
+  color: string
+  /** Series sharing an id share a scale. Distinct ids get independent scales. */
+  axisId: string
+  /**
+   * Endpoints of a precomputed straight fit, drawn as a dashed line across the
+   * full width. Pass the server's trend so the chart never fits its own.
+   */
+  trend?: { start: number; end: number } | null
+  /** Higher is worse (ranking position): reverses the axis so up means better. */
+  inverted?: boolean
+  formatValue?: (value: number) => string
+}
+
+/**
+ * Multi-metric time-series chart where each metric may carry its own scale and
+ * its own straight-line fit.
+ *
+ * Deliberately domain-free: it takes rows, an x key, and a series list, so any
+ * dated series (GSC clicks/impressions, sweep mention rate, traffic hits) uses
+ * it without the component learning what the numbers mean. It computes NO
+ * statistics — a caller passes `trend` endpoints that the API already fitted,
+ * which is what keeps the drawn line identical to the one the CLI reports.
+ *
+ * At most two axes render ticks (first left, second right); further axes still
+ * scale their series independently but stay hidden, because a third and fourth
+ * gutter of numbers costs more legibility than it buys.
+ */
+export function MultiAxisTrendChart({
+  data,
+  xKey,
+  series,
+  height = 260,
+  xTickFormatter,
+  labelFormatter,
+}: {
+  data: readonly Record<string, unknown>[]
+  xKey: string
+  series: readonly TrendChartSeries[]
+  height?: number
+  xTickFormatter?: (value: string) => string
+  labelFormatter?: (value: string) => string
+}) {
+  const axisIds = [...new Set(series.map((s) => s.axisId))]
+  const formatters = new Map(series.map((s) => [s.label, s.formatValue]))
+
+  // Recharts draws a line from row fields, so the fit is materialized as two
+  // synthetic fields interpolated across the row count. A straight segment
+  // needs only its endpoints, so this cannot drift from the server's fit.
+  const lastIndex = data.length - 1
+  const rows = data.map((row, index) => {
+    const withTrend: Record<string, unknown> = { ...row }
+    for (const s of series) {
+      if (!s.trend) continue
+      withTrend[`${s.dataKey}__trend`] = lastIndex <= 0
+        ? s.trend.start
+        : s.trend.start + ((s.trend.end - s.trend.start) * index) / lastIndex
+    }
+    return withTrend
+  })
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+        <CartesianGrid stroke={CHART_GRID_STROKE} strokeDasharray="3 3" vertical={false} />
+        <XAxis
+          dataKey={xKey}
+          tick={CHART_AXIS_TICK}
+          stroke={CHART_AXIS_STROKE}
+          tickFormatter={xTickFormatter}
+          minTickGap={24}
+        />
+        {axisIds.map((axisId, index) => {
+          const owner = series.find((s) => s.axisId === axisId)!
+          return (
+            <YAxis
+              key={axisId}
+              yAxisId={axisId}
+              orientation={index === 1 ? 'right' : 'left'}
+              hide={index > 1}
+              reversed={owner.inverted ?? false}
+              tick={CHART_AXIS_TICK}
+              stroke={CHART_AXIS_STROKE}
+              width={48}
+              // Recharts' default (decimals allowed) is required, not cosmetic:
+              // forcing integer ticks snaps a fractional domain like CTR's
+              // 0–0.05 up to 0–1, which flattens the series onto the baseline —
+              // the exact bug per-metric axes exist to prevent.
+              tickFormatter={owner.formatValue}
+            />
+          )
+        })}
+        <RechartsTooltip
+          {...CHART_TOOLTIP_STYLE}
+          labelFormatter={(label) => (labelFormatter ? labelFormatter(String(label)) : String(label))}
+          formatter={(value, name) => {
+            const key = String(name ?? '')
+            if (typeof value !== 'number') return [String(value ?? ''), key]
+            return [formatters.get(key)?.(value) ?? value.toLocaleString(), key]
+          }}
+        />
+        {/* Fits render first so a real series is never hidden behind its own trend. */}
+        {series.filter((s) => s.trend).map((s) => (
+          <Line
+            key={`${s.dataKey}-trend`}
+            yAxisId={s.axisId}
+            dataKey={`${s.dataKey}__trend`}
+            name={`${s.label} trend`}
+            stroke={s.color}
+            strokeWidth={1.5}
+            strokeDasharray="5 4"
+            strokeOpacity={0.55}
+            dot={false}
+            activeDot={false}
+            isAnimationActive={false}
+            legendType="none"
+            tooltipType="none"
+          />
+        ))}
+        {series.map((s) => (
+          <Line
+            key={s.dataKey}
+            yAxisId={s.axisId}
+            dataKey={s.dataKey}
+            name={s.label}
+            stroke={s.color}
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 3 }}
+            connectNulls={false}
+            isAnimationActive={false}
+          />
+        ))}
+      </ComposedChart>
+    </ResponsiveContainer>
+  )
+}

--- a/apps/web/src/components/shared/ChartPrimitives.tsx
+++ b/apps/web/src/components/shared/ChartPrimitives.tsx
@@ -258,6 +258,8 @@ export function MultiAxisTrendChart({
   height = 260,
   xTickFormatter,
   labelFormatter,
+  onSelectX,
+  selectedX,
 }: {
   data: readonly Record<string, unknown>[]
   xKey: string
@@ -265,6 +267,10 @@ export function MultiAxisTrendChart({
   height?: number
   xTickFormatter?: (value: string) => string
   labelFormatter?: (value: string) => string
+  /** Called with the row's x value when a point is clicked. Enables drill-in. */
+  onSelectX?: (value: string) => void
+  /** x value to mark as currently drilled into. */
+  selectedX?: string | null
 }) {
   const axisIds = [...new Set(series.map((s) => s.axisId))]
   const formatters = new Map(series.map((s) => [s.label, s.formatValue]))
@@ -286,8 +292,28 @@ export function MultiAxisTrendChart({
 
   return (
     <ResponsiveContainer width="100%" height={height}>
-      <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+      <ComposedChart
+        data={rows}
+        margin={{ top: 8, right: 8, bottom: 4, left: 0 }}
+        // Recharts reports the active row on the CHART, not per-dot, so a click
+        // anywhere in a day's column selects it — a 2px dot is not a target.
+        onClick={onSelectX ? (state: { activeLabel?: string | number }) => {
+          if (state?.activeLabel !== undefined) onSelectX(String(state.activeLabel))
+        } : undefined}
+        style={onSelectX ? { cursor: 'pointer' } : undefined}
+      >
         <CartesianGrid stroke={CHART_GRID_STROKE} strokeDasharray="3 3" vertical={false} />
+        {/* Marks the drilled-into day so the chart and the table below agree
+            about what is being shown. */}
+        {selectedX != null && (
+          <ReferenceLine
+            x={selectedX}
+            yAxisId={axisIds[0]}
+            stroke={CHART_NEUTRAL.text}
+            strokeDasharray="2 3"
+            strokeWidth={1}
+          />
+        )}
         <XAxis
           dataKey={xKey}
           tick={CHART_AXIS_TICK}

--- a/apps/web/src/components/shared/ChartPrimitives.tsx
+++ b/apps/web/src/components/shared/ChartPrimitives.tsx
@@ -228,10 +228,15 @@ export interface TrendChartSeries {
   /** Series sharing an id share a scale. Distinct ids get independent scales. */
   axisId: string
   /**
-   * Endpoints of a precomputed straight fit, drawn as a dashed line across the
-   * full width. Pass the server's trend so the chart never fits its own.
+   * Endpoints of a precomputed straight fit, plus the index range it covers.
+   * Pass the server's trend so the chart never fits its own.
+   *
+   * The line is drawn ONLY across `startIndex..endIndex`. Spanning the full
+   * width instead would paint a fitted claim over leading or trailing dates the
+   * metric was never measured on — most visibly for position, which many days
+   * lack entirely.
    */
-  trend?: { start: number; end: number } | null
+  trend?: { start: number; end: number; startIndex?: number; endIndex?: number } | null
   /** Higher is worse (ranking position): reverses the axis so up means better. */
   inverted?: boolean
   formatValue?: (value: number) => string
@@ -278,14 +283,21 @@ export function MultiAxisTrendChart({
   // Recharts draws a line from row fields, so the fit is materialized as two
   // synthetic fields interpolated across the row count. A straight segment
   // needs only its endpoints, so this cannot drift from the server's fit.
-  const lastIndex = data.length - 1
   const rows = data.map((row, index) => {
     const withTrend: Record<string, unknown> = { ...row }
     for (const s of series) {
       if (!s.trend) continue
-      withTrend[`${s.dataKey}__trend`] = lastIndex <= 0
+      const from = s.trend.startIndex ?? 0
+      const to = s.trend.endIndex ?? data.length - 1
+      // Outside the measured range the fit is undefined, not zero. `null`
+      // leaves a gap; `connectNulls` is off, so the dash simply stops.
+      if (index < from || index > to) {
+        withTrend[`${s.dataKey}__trend`] = null
+        continue
+      }
+      withTrend[`${s.dataKey}__trend`] = to <= from
         ? s.trend.start
-        : s.trend.start + ((s.trend.end - s.trend.start) * index) / lastIndex
+        : s.trend.start + ((s.trend.end - s.trend.start) * (index - from)) / (to - from)
     }
     return withTrend
   })
@@ -330,6 +342,10 @@ export function MultiAxisTrendChart({
               orientation={index === 1 ? 'right' : 'left'}
               hide={index > 1}
               reversed={owner.inverted ?? false}
+              // Rank 0 does not exist. Letting the axis run to 0 reserves a
+              // whole band for an impossible value and squashes the real range
+              // into the top half of the plot.
+              domain={owner.inverted ? [1, 'auto'] : [0, 'auto']}
               tick={CHART_AXIS_TICK}
               stroke={CHART_AXIS_STROKE}
               width={48}

--- a/apps/web/test/gsc-performance-chart.test.tsx
+++ b/apps/web/test/gsc-performance-chart.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 
 // Recharts is stubbed out: this suite is about the metric selector and the
 // values on the tiles, which are the parts a person actually operates. The
@@ -41,13 +41,13 @@ const DAILY = [
 
 function performanceDaily(overrides: Record<string, unknown> = {}) {
   return {
-    totals: { clicks: 50, impressions: 2800, ctr: 50 / 2800, position: 10.5, days: 4 },
+    totals: { clicks: 50, impressions: 2800, ctr: 50 / 2800, position: 10.5, positionDays: 4, days: 4 },
     daily: DAILY,
     trends: {
-      clicks: { slope: 5, intercept: 5, r2: 1, start: 5, end: 20, n: 4 },
-      impressions: { slope: -200, intercept: 1000, r2: 1, start: 1000, end: 400, n: 4 },
-      ctr: { slope: 0.015, intercept: 0.0025, r2: 0.97, start: 0.0025, end: 0.0475, n: 4 },
-      position: { slope: -1, intercept: 12, r2: 1, start: 12, end: 9, n: 4 },
+      clicks: { slope: 5, intercept: 5, r2: 1, start: 5, end: 20, n: 4, startIndex: 0, endIndex: 3 },
+      impressions: { slope: -200, intercept: 1000, r2: 1, start: 1000, end: 400, n: 4, startIndex: 0, endIndex: 3 },
+      ctr: { slope: 0.015, intercept: 0.0025, r2: 0.97, start: 0.0025, end: 0.0475, n: 4, startIndex: 0, endIndex: 3 },
+      position: { slope: -1, intercept: 12, r2: 1, start: 12, end: 9, n: 4, startIndex: 0, endIndex: 3 },
     },
     ...overrides,
   }
@@ -154,12 +154,12 @@ test('toggles a metric on and off but refuses to leave the chart empty', async (
 
 test('disables the position tile and explains the gap when no property sync has run', async () => {
   renderSection(performanceDaily({
-    totals: { clicks: 50, impressions: 2800, ctr: 50 / 2800, position: null, days: 4 },
+    totals: { clicks: 50, impressions: 2800, ctr: 50 / 2800, position: null, positionDays: 0, days: 4 },
     daily: DAILY.map((d) => ({ ...d, position: null })),
     trends: {
-      clicks: { slope: 5, intercept: 5, r2: 1, start: 5, end: 20, n: 4 },
-      impressions: { slope: -200, intercept: 1000, r2: 1, start: 1000, end: 400, n: 4 },
-      ctr: { slope: 0.015, intercept: 0.0025, r2: 0.97, start: 0.0025, end: 0.0475, n: 4 },
+      clicks: { slope: 5, intercept: 5, r2: 1, start: 5, end: 20, n: 4, startIndex: 0, endIndex: 3 },
+      impressions: { slope: -200, intercept: 1000, r2: 1, start: 1000, end: 400, n: 4, startIndex: 0, endIndex: 3 },
+      ctr: { slope: 0.015, intercept: 0.0025, r2: 0.97, start: 0.0025, end: 0.0475, n: 4, startIndex: 0, endIndex: 3 },
       position: null,
     },
   }))
@@ -209,4 +209,38 @@ test('the filter explanation is a tooltip, not a paragraph on the page', async (
   const trigger = screen.getByRole('button', { name: /case-insensitive substrings/ })
   expect(trigger).not.toBeNull()
   expect(trigger.getAttribute('aria-label')).toMatch(/Click any day to filter/)
+})
+
+test('survives a response from a server that predates position/trends/window', async () => {
+  // The three fields are new in this change. An older server omits them, and a
+  // formatter must never receive `undefined` — it would take down the section.
+  renderSection({
+    totals: { clicks: 50, impressions: 2800, ctr: 50 / 2800, days: 4 },
+    daily: DAILY.map(({ position: _p, ...rest }) => rest),
+  } as unknown as Record<string, unknown>)
+
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+  expect(tile('Clicks').textContent).toContain('50')
+  // Absent reads exactly like "not measured", never as a formatted zero.
+  expect(tile('Avg position').disabled).toBe(true)
+  expect(tile('Avg position').textContent).toContain('—')
+})
+
+test('says so when the position figure covers only part of the window', async () => {
+  renderSection(performanceDaily({
+    totals: { clicks: 50, impressions: 2800, ctr: 50 / 2800, position: 10.5, positionDays: 2, days: 4 },
+  }))
+  await waitFor(() => expect(tile('Avg position')).not.toBeNull())
+  expect(screen.getByText(/covers 2 of 4 days/)).not.toBeNull()
+})
+
+test('exposes a keyboard-reachable control for every day the chart can drill into', async () => {
+  // Recharts owns the SVG and gives no focusable day, so the accessible path is
+  // a real button per day inside a labelled group.
+  renderSection()
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+  const group = screen.getByRole('group', { name: /Filter the table to a single day/ })
+  const dayButtons = within(group).getAllByRole('button')
+  expect(dayButtons).toHaveLength(DAILY.length)
+  expect(dayButtons[0]!.getAttribute('aria-pressed')).toBe('false')
 })

--- a/apps/web/test/gsc-performance-chart.test.tsx
+++ b/apps/web/test/gsc-performance-chart.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// Recharts is stubbed out: this suite is about the metric selector and the
+// values on the tiles, which are the parts a person actually operates. The
+// chart's own rendering is Recharts' problem.
+vi.mock('recharts', () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+  return {
+    ResponsiveContainer: passthrough,
+    ComposedChart: passthrough,
+    Line: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    Tooltip: () => null,
+    CartesianGrid: () => null,
+  }
+})
+
+import { GscSection } from '../src/components/project/GscSection.js'
+import { jsonResponse, mockFetch, pathOf } from './mock-fetch.js'
+
+afterEach(() => {
+  cleanup()
+})
+
+/**
+ * Four days of property-level data with the same disagreement in magnitude the
+ * real dashboard hit: a handful of clicks against four figures of impressions.
+ * Clicks climb 5 -> 20 (+5/day), impressions fall 1000 -> 400, position
+ * improves 12 -> 9.
+ */
+const DAILY = [
+  { date: '2026-07-01', clicks: 5, impressions: 1000, ctr: 0.005, position: 12 },
+  { date: '2026-07-02', clicks: 10, impressions: 800, ctr: 0.0125, position: 11 },
+  { date: '2026-07-03', clicks: 15, impressions: 600, ctr: 0.025, position: 10 },
+  { date: '2026-07-04', clicks: 20, impressions: 400, ctr: 0.05, position: 9 },
+]
+
+function performanceDaily(overrides: Record<string, unknown> = {}) {
+  return {
+    totals: { clicks: 50, impressions: 2800, ctr: 50 / 2800, position: 10.5, days: 4 },
+    daily: DAILY,
+    trends: {
+      clicks: { slope: 5, intercept: 5, r2: 1, start: 5, end: 20, n: 4 },
+      impressions: { slope: -200, intercept: 1000, r2: 1, start: 1000, end: 400, n: 4 },
+      ctr: { slope: 0.015, intercept: 0.0025, r2: 0.97, start: 0.0025, end: 0.0475, n: 4 },
+      position: { slope: -1, intercept: 12, r2: 1, start: 12, end: 9, n: 4 },
+    },
+    ...overrides,
+  }
+}
+
+function renderSection(daily: Record<string, unknown> = performanceDaily()) {
+  const restoreFetch = mockFetch((url) => {
+    const path = pathOf(url)
+    if (path === '/api/v1/settings') {
+      return jsonResponse({
+        providers: [],
+        providerCatalog: [],
+        google: { configured: true },
+        bing: { configured: false },
+      })
+    }
+    if (path.endsWith('/google/connections')) {
+      return jsonResponse([{
+        id: 'gsc-1',
+        domain: 'example.com',
+        connectionType: 'gsc',
+        propertyId: 'sc-domain:example.com',
+        sitemapUrl: 'https://example.com/sitemap.xml',
+        scopes: [],
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-04T00:00:00.000Z',
+      }])
+    }
+    if (path.includes('/google/properties')) {
+      return jsonResponse({ sites: [{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }] })
+    }
+    if (path.includes('/google/gsc/performance/daily')) return jsonResponse(daily)
+    if (path.includes('/google/gsc/performance')) {
+      return jsonResponse({ rows: [], totalMatching: 0, truncated: false, latestAvailableDate: '2026-07-04' })
+    }
+    if (path.includes('/google/gsc/sitemaps')) {
+      return jsonResponse({ sitemaps: [], summary: { total: 0, indexes: 0, files: 0 }, preferredSubmissionUrls: [] })
+    }
+    if (path.includes('/google/gsc/inspections')) return jsonResponse([])
+    if (path.includes('/google/gsc/deindexed')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage/history')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage')) return jsonResponse(null)
+    throw new Error(`Unexpected fetch: ${path}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GscSection projectName="test-project" refreshNonce={0} />
+    </QueryClientProvider>,
+  )
+}
+
+function tile(label: string): HTMLButtonElement {
+  return screen.getByRole('button', { name: new RegExp(`^${label}`) }) as HTMLButtonElement
+}
+
+test('renders all four Search Console metrics as tiles, with clicks and impressions selected', async () => {
+  renderSection()
+
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+  expect(tile('Clicks').getAttribute('aria-pressed')).toBe('true')
+  expect(tile('Impressions').getAttribute('aria-pressed')).toBe('true')
+  expect(tile('CTR').getAttribute('aria-pressed')).toBe('false')
+  expect(tile('Avg position').getAttribute('aria-pressed')).toBe('false')
+
+  // Window totals, formatted per metric.
+  expect(tile('Clicks').textContent).toContain('50')
+  expect(tile('Impressions').textContent).toContain('2,800')
+  expect(tile('CTR').textContent).toContain('1.8%')
+  expect(tile('Avg position').textContent).toContain('10.5')
+})
+
+test('reads the trend direction from BETTER/WORSE, not from the sign of the slope', async () => {
+  renderSection()
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+
+  // Clicks rising is an improvement.
+  expect(tile('Clicks').textContent).toContain('↑')
+  // Impressions falling is a decline.
+  expect(tile('Impressions').textContent).toContain('↓')
+  // Position FALLING is an improvement — the one metric where a negative
+  // slope is good news, and the case a naive `slope > 0` arrow gets backwards.
+  expect(tile('Avg position').textContent).toContain('↑')
+  expect(tile('Avg position').textContent).toContain('3.0')
+})
+
+test('toggles a metric on and off but refuses to leave the chart empty', async () => {
+  renderSection()
+  await waitFor(() => expect(tile('CTR')).not.toBeNull())
+
+  fireEvent.click(tile('CTR'))
+  expect(tile('CTR').getAttribute('aria-pressed')).toBe('true')
+  fireEvent.click(tile('CTR'))
+  expect(tile('CTR').getAttribute('aria-pressed')).toBe('false')
+
+  // Turn off everything that can be turned off; the last one must survive.
+  fireEvent.click(tile('Impressions'))
+  expect(tile('Impressions').getAttribute('aria-pressed')).toBe('false')
+  fireEvent.click(tile('Clicks'))
+  expect(tile('Clicks').getAttribute('aria-pressed')).toBe('true')
+})
+
+test('disables the position tile and explains the gap when no property sync has run', async () => {
+  renderSection(performanceDaily({
+    totals: { clicks: 50, impressions: 2800, ctr: 50 / 2800, position: null, days: 4 },
+    daily: DAILY.map((d) => ({ ...d, position: null })),
+    trends: {
+      clicks: { slope: 5, intercept: 5, r2: 1, start: 5, end: 20, n: 4 },
+      impressions: { slope: -200, intercept: 1000, r2: 1, start: 1000, end: 400, n: 4 },
+      ctr: { slope: 0.015, intercept: 0.0025, r2: 0.97, start: 0.0025, end: 0.0475, n: 4 },
+      position: null,
+    },
+  }))
+
+  await waitFor(() => expect(tile('Avg position')).not.toBeNull())
+  // An unmeasured metric is shown as absent and cannot be charted — never as 0,
+  // which would read as an impossibly good rank.
+  expect(tile('Avg position').disabled).toBe(true)
+  expect(tile('Avg position').textContent).toContain('—')
+  expect(screen.getByText(/Average position needs a property-level sync/)).not.toBeNull()
+})
+
+test('drops the fitted lines when the trend toggle is cleared', async () => {
+  renderSection()
+  const toggle = await waitFor(() => screen.getByRole('checkbox', { name: /Trend line/ }) as HTMLInputElement)
+
+  expect(toggle.checked).toBe(true)
+  fireEvent.click(toggle)
+  expect(toggle.checked).toBe(false)
+  // The tiles keep reporting the trend even when the line is hidden — the fit
+  // is a fact about the window, not a property of the chart.
+  expect(tile('Clicks').textContent).toContain('↑')
+})

--- a/apps/web/test/gsc-performance-chart.test.tsx
+++ b/apps/web/test/gsc-performance-chart.test.tsx
@@ -244,3 +244,31 @@ test('exposes a keyboard-reachable control for every day the chart can drill int
   expect(dayButtons).toHaveLength(DAILY.length)
   expect(dayButtons[0]!.getAttribute('aria-pressed')).toBe('false')
 })
+
+test('plots one row per calendar day, so a quiet gap is not compressed', async () => {
+  // Four dates across a ten-day span. The server fits over the CALENDAR, so the
+  // chart has to plot the calendar too — against the four measured rows the
+  // trend line traversed a third of its range and ended on the wrong value.
+  const sparse = [
+    { date: '2026-04-01', clicks: 10, impressions: 100, ctr: 0.1, position: 5 },
+    { date: '2026-04-02', clicks: 9, impressions: 90, ctr: 0.1, position: 5 },
+    { date: '2026-04-03', clicks: 8, impressions: 80, ctr: 0.1, position: 5 },
+    { date: '2026-04-10', clicks: 7, impressions: 70, ctr: 0.1, position: 5 },
+  ]
+  renderSection(performanceDaily({
+    daily: sparse,
+    totals: { clicks: 34, impressions: 340, ctr: 0.1, position: 5, positionDays: 4, days: 4 },
+    trends: {
+      clicks: { slope: -0.3, intercept: 10, r2: 1, start: 10, end: 7, n: 4, startIndex: 0, endIndex: 9 },
+      impressions: { slope: -3, intercept: 100, r2: 1, start: 100, end: 70, n: 4, startIndex: 0, endIndex: 9 },
+      ctr: null,
+      position: null,
+    },
+  }))
+
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+  // The drill controls stay on the MEASURED days — an empty day is nothing to
+  // drill into — which is how we can tell the two series apart.
+  const group = screen.getByRole('group', { name: /Filter the table to a single day/ })
+  expect(within(group).getAllByRole('button')).toHaveLength(4)
+})

--- a/apps/web/test/gsc-performance-chart.test.tsx
+++ b/apps/web/test/gsc-performance-chart.test.tsx
@@ -183,3 +183,30 @@ test('drops the fitted lines when the trend toggle is cleared', async () => {
   // is a fact about the window, not a property of the chart.
   expect(tile('Clicks').textContent).toContain('↑')
 })
+
+test('clicking a day drills the table into that date, and clicking it again clears', async () => {
+  // Recharts is stubbed, so drive the handler the chart would call. What is
+  // under test is the wiring: does a day selection reach the table's filters,
+  // and is it reversible.
+  const { container } = renderSection()
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+
+  // No drill state until a day is chosen.
+  expect(screen.queryByText(/Table showing/)).toBeNull()
+
+  const dateInputs = container.querySelectorAll('input[type="date"]')
+  expect(dateInputs.length).toBeGreaterThanOrEqual(2)
+})
+
+test('the filter explanation is a tooltip, not a paragraph on the page', async () => {
+  renderSection()
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+
+  // The prose used to sit under the filter row. It must not be body copy.
+  expect(screen.queryByText(/match case-insensitive substrings/)).toBeNull()
+  // It survives on the heading's tooltip trigger, so nothing is lost for
+  // assistive tech or for tests that look it up by accessible name.
+  const trigger = screen.getByRole('button', { name: /case-insensitive substrings/ })
+  expect(trigger).not.toBeNull()
+  expect(trigger.getAttribute('aria-label')).toMatch(/Click any day to filter/)
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.161.0",
+  "version": "4.162.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2509,6 +2509,7 @@ export type GscPerformanceDailyDto = {
         clicks: number;
         impressions: number;
         ctr: number;
+        position: number | null;
         days: number;
     };
     daily: Array<{
@@ -2516,12 +2517,47 @@ export type GscPerformanceDailyDto = {
         clicks: number;
         impressions: number;
         ctr: number;
+        position: number | null;
     }>;
     window?: {
         startDate: string | null;
         endDate: string | null;
         latestDataDate: string | null;
         daysSinceLatestData: number | null;
+    };
+    trends?: {
+        clicks: {
+            slope: number;
+            intercept: number;
+            r2: number;
+            start: number;
+            end: number;
+            n: number;
+        } | null;
+        impressions: {
+            slope: number;
+            intercept: number;
+            r2: number;
+            start: number;
+            end: number;
+            n: number;
+        } | null;
+        ctr: {
+            slope: number;
+            intercept: number;
+            r2: number;
+            start: number;
+            end: number;
+            n: number;
+        } | null;
+        position: {
+            slope: number;
+            intercept: number;
+            r2: number;
+            start: number;
+            end: number;
+            n: number;
+        } | null;
     };
 };
 

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2510,6 +2510,7 @@ export type GscPerformanceDailyDto = {
         impressions: number;
         ctr: number;
         position: number | null;
+        positionDays: number;
         days: number;
     };
     daily: Array<{
@@ -2533,6 +2534,8 @@ export type GscPerformanceDailyDto = {
             start: number;
             end: number;
             n: number;
+            startIndex: number;
+            endIndex: number;
         } | null;
         impressions: {
             slope: number;
@@ -2541,6 +2544,8 @@ export type GscPerformanceDailyDto = {
             start: number;
             end: number;
             n: number;
+            startIndex: number;
+            endIndex: number;
         } | null;
         ctr: {
             slope: number;
@@ -2549,6 +2554,8 @@ export type GscPerformanceDailyDto = {
             start: number;
             end: number;
             n: number;
+            startIndex: number;
+            endIndex: number;
         } | null;
         position: {
             slope: number;
@@ -2557,6 +2564,8 @@ export type GscPerformanceDailyDto = {
             start: number;
             end: number;
             n: number;
+            startIndex: number;
+            endIndex: number;
         } | null;
     };
 };

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -15,7 +15,7 @@ import {
   gscPerformanceOrderBySchema,
   formatIsoDateInTimeZone,
   linearTrend,
-  shiftIsoCalendarDate,
+  calendarDateRange,
 } from '@ainyc/canonry-contracts'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from './gbp-summary.js'
@@ -1006,15 +1006,11 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     // falling 100 -> 80 then one day at 70 a week later reads as -10/day
     // compressed and -2.8/day on the real calendar.
     const byDate = new Map(daily.map((d) => [d.date, d]))
-    const denseDates: string[] = []
-    if (daily.length > 0) {
-      const firstDate = daily[0]!.date
-      const lastDate = daily[daily.length - 1]!.date
-      for (let cursor = firstDate; cursor <= lastDate; cursor = shiftIsoCalendarDate(cursor, 1)) {
-        denseDates.push(cursor)
-        if (denseDates.length > 800) break // 90d is the widest label; a guard, not a limit
-      }
-    }
+    // `calendarDateRange` is shared with the chart so both derive the SAME index
+    // space. They used to compute it separately and disagree.
+    const denseDates = daily.length === 0
+      ? []
+      : calendarDateRange(daily[0]!.date, daily[daily.length - 1]!.date)
     const densify = (pick: (d: (typeof daily)[number]) => number | null): (number | null)[] =>
       denseDates.map((date) => {
         const row = byDate.get(date)

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -15,6 +15,7 @@ import {
   gscPerformanceOrderBySchema,
   formatIsoDateInTimeZone,
   linearTrend,
+  shiftIsoCalendarDate,
 } from '@ainyc/canonry-contracts'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from './gbp-summary.js'
@@ -996,12 +997,42 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       positionWeighted += d.position * d.impressions
     }
 
+    // Fit over one entry PER CALENDAR DAY, with `null` where a day has no row.
+    //
+    // `daily` contains only dates that produced data, and Search Analytics omits
+    // zero-data days entirely, so consecutive entries are not consecutive dates.
+    // Feeding that straight to a fit whose x is the array index compresses every
+    // quiet stretch into a single step and overstates the slope: three days
+    // falling 100 -> 80 then one day at 70 a week later reads as -10/day
+    // compressed and -2.8/day on the real calendar.
+    const byDate = new Map(daily.map((d) => [d.date, d]))
+    const denseDates: string[] = []
+    if (daily.length > 0) {
+      const firstDate = daily[0]!.date
+      const lastDate = daily[daily.length - 1]!.date
+      for (let cursor = firstDate; cursor <= lastDate; cursor = shiftIsoCalendarDate(cursor, 1)) {
+        denseDates.push(cursor)
+        if (denseDates.length > 800) break // 90d is the widest label; a guard, not a limit
+      }
+    }
+    const densify = (pick: (d: (typeof daily)[number]) => number | null): (number | null)[] =>
+      denseDates.map((date) => {
+        const row = byDate.get(date)
+        return row ? pick(row) : null
+      })
+
     return {
       totals: {
         clicks: totalClicks,
         impressions: totalImpressions,
         ctr: totalImpressions > 0 ? totalClicks / totalImpressions : 0,
         position: positionWeight > 0 ? positionWeighted / positionWeight : null,
+        /**
+         * How many days actually carried a property-level position. Below
+         * `days`, the position figure describes a SUBSET of the window, and a
+         * surface must say so rather than present it as the window's average.
+         */
+        positionDays: daily.filter((d) => d.position !== null).length,
         days: daily.length,
       },
       daily,
@@ -1018,12 +1049,12 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       window: resolveReportedWindow(resolvedWindow, startDate, endDate),
       // Fitted server-side so the dashboard, the CLI, and the report all draw
       // the SAME line (UI/CLI parity — a chart-only regression is invisible to
-      // an agent).
+      // an agent), and fitted over the CALENDAR, not over the rows.
       trends: {
-        clicks: linearTrend(daily.map((d) => d.clicks)),
-        impressions: linearTrend(daily.map((d) => d.impressions)),
-        ctr: linearTrend(daily.map((d) => d.ctr)),
-        position: linearTrend(daily.map((d) => d.position)),
+        clicks: linearTrend(densify((d) => d.clicks)),
+        impressions: linearTrend(densify((d) => d.impressions)),
+        ctr: linearTrend(densify((d) => d.ctr)),
+        position: linearTrend(densify((d) => d.position)),
       },
     }
   })

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -14,6 +14,7 @@ import {
   gscSubmitSitemapsRequestDtoSchema,
   gscPerformanceOrderBySchema,
   formatIsoDateInTimeZone,
+  linearTrend,
 } from '@ainyc/canonry-contracts'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from './gbp-summary.js'
@@ -960,6 +961,11 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       .orderBy(gscSearchData.date)
       .all()
 
+    // Position exists ONLY on the property-level rows. The dimensioned fallback
+    // has no property position to offer (a mean of per-row positions is not the
+    // property's mean), so those dates report `null` rather than a `0` that
+    // would read as rank #0 on an inverted axis.
+    const propertyDates = new Set(dailyTotals.map((d) => d.date))
     const daily = mergeGscDailyTotalsWithFallback(
       dailyTotals,
       dimensionedRows.map((r) => ({
@@ -973,14 +979,29 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       clicks: d.clicks,
       impressions: d.impressions,
       ctr: d.impressions > 0 ? d.clicks / d.impressions : 0,
+      position: propertyDates.has(d.date) ? d.position : null,
     }))
     const totalClicks = daily.reduce((sum, d) => sum + d.clicks, 0)
     const totalImpressions = daily.reduce((sum, d) => sum + d.impressions, 0)
+
+    // Impression-weighted, because position is non-additive: a day with one
+    // impression must not pull the window mean as hard as a day with a thousand.
+    // Days with no property position, and days with no impressions to weight by,
+    // are excluded from both the numerator and the denominator.
+    let positionWeight = 0
+    let positionWeighted = 0
+    for (const d of daily) {
+      if (d.position === null || d.impressions <= 0) continue
+      positionWeight += d.impressions
+      positionWeighted += d.position * d.impressions
+    }
+
     return {
       totals: {
         clicks: totalClicks,
         impressions: totalImpressions,
         ctr: totalImpressions > 0 ? totalClicks / totalImpressions : 0,
+        position: positionWeight > 0 ? positionWeighted / positionWeight : null,
         days: daily.length,
       },
       daily,
@@ -995,6 +1016,15 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       // dropped rather than reported reversed: an absent bound is honest about
       // being unspecified, a reversed pair is not.
       window: resolveReportedWindow(resolvedWindow, startDate, endDate),
+      // Fitted server-side so the dashboard, the CLI, and the report all draw
+      // the SAME line (UI/CLI parity — a chart-only regression is invisible to
+      // an agent).
+      trends: {
+        clicks: linearTrend(daily.map((d) => d.clicks)),
+        impressions: linearTrend(daily.map((d) => d.impressions)),
+        ctr: linearTrend(daily.map((d) => d.ctr)),
+        position: linearTrend(daily.map((d) => d.position)),
+      },
     }
   })
 

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -1615,13 +1615,13 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     expect(body.daily.map(d => d.date)).toEqual(['2026-01-05', '2026-01-06'])
 
     // 2026-01-05: 2+3+5=10 clicks, 100+200+50=350 impressions, CTR = 10/350
-    expect(body.daily[0]).toEqual({ date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350 })
+    expect(body.daily[0]).toEqual({ date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350, position: null })
     // 2026-01-06: 4+1+5=10 clicks, 200+100+700=1000 impressions, CTR = 10/1000 = 0.01
-    expect(body.daily[1]).toEqual({ date: '2026-01-06', clicks: 10, impressions: 1000, ctr: 0.01 })
+    expect(body.daily[1]).toEqual({ date: '2026-01-06', clicks: 10, impressions: 1000, ctr: 0.01, position: null })
 
     // Window totals: aggregate of all rows, NOT averaged from per-day CTRs
     // Total clicks 20, total impressions 1350, ctr = 20/1350 (not (10/350 + 10/1000) / 2)
-    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, days: 2 })
+    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, position: null, days: 2 })
     // Sanity: averaged per-day CTR would be ~0.019, the bug we're protecting against
     expect(body.totals.ctr).not.toBeCloseTo((10 / 350 + 10 / 1000) / 2, 5)
   })
@@ -1684,12 +1684,14 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     })
     expect(res.statusCode).toBe(200)
     const body = res.json() as GscPerformanceDailyDto
-    expect(body.totals).toEqual({ clicks: 0, impressions: 0, ctr: 0, days: 0 })
+    expect(body.totals).toEqual({ clicks: 0, impressions: 0, ctr: 0, position: null, days: 0 })
     expect(body.daily).toEqual([])
+    // A window with no days has no series to fit.
+    expect(body.trends).toEqual({ clicks: null, impressions: null, ctr: null, position: null })
     // An explicit startDate wins over the label, and the upper bound is the
     // last published day, so the caller can label the period it actually got.
-    expect(body.window.startDate).toBe('2030-01-01')
-    expect(body.window.latestDataDate).toBe('2026-01-06')
+    expect(body.window!.startDate).toBe('2030-01-01')
+    expect(body.window!.latestDataDate).toBe('2026-01-06')
   })
 
   it('returns 404 for an unknown project', async () => {
@@ -1796,10 +1798,12 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
 
     // Property totals — NOT the dimensioned sum (20 / 1350).
     expect(body.daily).toEqual([
-      { date: '2026-01-05', clicks: 25, impressions: 300, ctr: 25 / 300 },
-      { date: '2026-01-06', clicks: 31, impressions: 900, ctr: 31 / 900 },
+      { date: '2026-01-05', clicks: 25, impressions: 300, ctr: 25 / 300, position: 4 },
+      { date: '2026-01-06', clicks: 31, impressions: 900, ctr: 31 / 900, position: 6 },
     ])
-    expect(body.totals).toEqual({ clicks: 56, impressions: 1200, ctr: 56 / 1200, days: 2 })
+    // Position is impression-WEIGHTED: (4*300 + 6*900) / 1200 = 5.5. An
+    // unweighted mean of the two days would read 5.0.
+    expect(body.totals).toEqual({ clicks: 56, impressions: 1200, ctr: 56 / 1200, position: 5.5, days: 2 })
   })
 
   it('falls back to summing gsc_search_data by date when no gsc_daily_totals rows exist in the window', async () => {
@@ -1812,11 +1816,13 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     expect(res.statusCode).toBe(200)
     const body = res.json() as { totals: { clicks: number; impressions: number; ctr: number; days: number }; daily: Array<{ date: string; clicks: number; impressions: number; ctr: number }> }
 
+    // The dimensioned sum cannot produce a property position, so every date
+    // reports `null` rather than the `0` the merge helper carries internally.
     expect(body.daily).toEqual([
-      { date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350 },
-      { date: '2026-01-06', clicks: 10, impressions: 1000, ctr: 0.01 },
+      { date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350, position: null },
+      { date: '2026-01-06', clicks: 10, impressions: 1000, ctr: 0.01, position: null },
     ])
-    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, days: 2 })
+    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, position: null, days: 2 })
   })
 
   it('uses daily totals per date without dropping dimensioned fallback dates from the same window', async () => {
@@ -1838,11 +1844,58 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     expect(res.statusCode).toBe(200)
     const body = res.json() as { totals: { clicks: number; impressions: number; ctr: number; days: number }; daily: Array<{ date: string; clicks: number; impressions: number; ctr: number }> }
 
+    // Only 2026-01-06 came from the property table, so only it carries a
+    // position — and it alone weights the window mean.
     expect(body.daily).toEqual([
-      { date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350 },
-      { date: '2026-01-06', clicks: 31, impressions: 900, ctr: 31 / 900 },
+      { date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350, position: null },
+      { date: '2026-01-06', clicks: 31, impressions: 900, ctr: 31 / 900, position: 6 },
     ])
-    expect(body.totals).toEqual({ clicks: 41, impressions: 1250, ctr: 41 / 1250, days: 2 })
+    expect(body.totals).toEqual({ clicks: 41, impressions: 1250, ctr: 41 / 1250, position: 6, days: 2 })
+  })
+
+  it('fits a least-squares trend per metric over the window', async () => {
+    // Property rows over four days. Clicks 10 -> 40 (+10/day exactly),
+    // impressions flat at 100, position 8 -> 5 (improving by 1/day).
+    const now = '2026-01-01T00:00:00.000Z'
+    context.db.insert(gscDailyTotals).values([
+      { id: crypto.randomUUID(), projectId, date: '2026-03-01', clicks: 10, impressions: 100, position: '8', createdAt: now },
+      { id: crypto.randomUUID(), projectId, date: '2026-03-02', clicks: 20, impressions: 100, position: '7', createdAt: now },
+      { id: crypto.randomUUID(), projectId, date: '2026-03-03', clicks: 30, impressions: 100, position: '6', createdAt: now },
+      { id: crypto.randomUUID(), projectId, date: '2026-03-04', clicks: 40, impressions: 100, position: '5', createdAt: now },
+    ]).run()
+
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily?startDate=2026-03-01&endDate=2026-03-04',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as GscPerformanceDailyDto
+
+    // Slope is PER DAY, and start/end are the endpoints a chart draws between.
+    expect(body.trends.clicks).toEqual({ slope: 10, intercept: 10, r2: 1, start: 10, end: 40, n: 4 })
+    // A flat series is a perfect flat fit, not an undefined one.
+    expect(body.trends.impressions).toEqual({ slope: 0, intercept: 100, r2: 1, start: 100, end: 100, n: 4 })
+    // Position falls as ranking IMPROVES, so the slope is negative.
+    expect(body.trends.position).toEqual({ slope: -1, intercept: 8, r2: 1, start: 8, end: 5, n: 4 })
+    // CTR rises with clicks against constant impressions: 0.1 -> 0.4.
+    expect(body.trends.ctr!.slope).toBeCloseTo(0.1, 6)
+
+    // The fitted endpoints span the window, so the whole-window change is
+    // slope * (days - 1) — the figure the tile and the CLI both report.
+    expect(body.trends.clicks!.end - body.trends.clicks!.start).toBe(10 * (body.totals.days - 1))
+  })
+
+  it('reports no position trend when every date came from the dimensioned fallback', async () => {
+    // beforeEach seeds only gsc_search_data, so position is null on every date
+    // and there is nothing to fit — while clicks and impressions still fit.
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as GscPerformanceDailyDto
+    expect(body.trends.position).toBeNull()
+    expect(body.trends.impressions).toEqual({ slope: 650, intercept: 350, r2: 1, start: 350, end: 1000, n: 2 })
   })
 
   it('can return date-only daily totals when no dimensioned rows exist for the window', async () => {
@@ -1863,12 +1916,14 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     })
     expect(res.statusCode).toBe(200)
     const body = res.json() as GscPerformanceDailyDto
-    expect(body.totals).toEqual({ clicks: 12, impressions: 500, ctr: 12 / 500, days: 1 })
-    expect(body.daily).toEqual([{ date: '2026-02-01', clicks: 12, impressions: 500, ctr: 12 / 500 }])
-    expect(body.window.startDate).toBe('2026-02-01')
-    expect(body.window.endDate).toBe('2026-02-01')
+    expect(body.totals).toEqual({ clicks: 12, impressions: 500, ctr: 12 / 500, position: 9, days: 1 })
+    expect(body.daily).toEqual([{ date: '2026-02-01', clicks: 12, impressions: 500, ctr: 12 / 500, position: 9 }])
+    // One day is not a line.
+    expect(body.trends).toEqual({ clicks: null, impressions: null, ctr: null, position: null })
+    expect(body.window!.startDate).toBe('2026-02-01')
+    expect(body.window!.endDate).toBe('2026-02-01')
     // MAX across BOTH tables: the property row here is later than the
     // dimensioned rows the surrounding fixture seeds.
-    expect(body.window.latestDataDate).toBe('2026-02-01')
+    expect(body.window!.latestDataDate).toBe('2026-02-01')
   })
 })

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -1621,7 +1621,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
 
     // Window totals: aggregate of all rows, NOT averaged from per-day CTRs
     // Total clicks 20, total impressions 1350, ctr = 20/1350 (not (10/350 + 10/1000) / 2)
-    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, position: null, days: 2 })
+    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, position: null, positionDays: 0, days: 2 })
     // Sanity: averaged per-day CTR would be ~0.019, the bug we're protecting against
     expect(body.totals.ctr).not.toBeCloseTo((10 / 350 + 10 / 1000) / 2, 5)
   })
@@ -1684,7 +1684,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     })
     expect(res.statusCode).toBe(200)
     const body = res.json() as GscPerformanceDailyDto
-    expect(body.totals).toEqual({ clicks: 0, impressions: 0, ctr: 0, position: null, days: 0 })
+    expect(body.totals).toEqual({ clicks: 0, impressions: 0, ctr: 0, position: null, positionDays: 0, days: 0 })
     expect(body.daily).toEqual([])
     // A window with no days has no series to fit.
     expect(body.trends).toEqual({ clicks: null, impressions: null, ctr: null, position: null })
@@ -1803,7 +1803,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     ])
     // Position is impression-WEIGHTED: (4*300 + 6*900) / 1200 = 5.5. An
     // unweighted mean of the two days would read 5.0.
-    expect(body.totals).toEqual({ clicks: 56, impressions: 1200, ctr: 56 / 1200, position: 5.5, days: 2 })
+    expect(body.totals).toEqual({ clicks: 56, impressions: 1200, ctr: 56 / 1200, position: 5.5, positionDays: 2, days: 2 })
   })
 
   it('falls back to summing gsc_search_data by date when no gsc_daily_totals rows exist in the window', async () => {
@@ -1822,7 +1822,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
       { date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350, position: null },
       { date: '2026-01-06', clicks: 10, impressions: 1000, ctr: 0.01, position: null },
     ])
-    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, position: null, days: 2 })
+    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, position: null, positionDays: 0, days: 2 })
   })
 
   it('uses daily totals per date without dropping dimensioned fallback dates from the same window', async () => {
@@ -1850,7 +1850,59 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
       { date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350, position: null },
       { date: '2026-01-06', clicks: 31, impressions: 900, ctr: 31 / 900, position: 6 },
     ])
-    expect(body.totals).toEqual({ clicks: 41, impressions: 1250, ctr: 41 / 1250, position: 6, days: 2 })
+    expect(body.totals).toEqual({ clicks: 41, impressions: 1250, ctr: 41 / 1250, position: 6, positionDays: 1, days: 2 })
+  })
+
+  it('fits over the CALENDAR, so a quiet gap does not overstate the slope', async () => {
+    // Search Analytics omits zero-data days, so `daily` holds only dates with
+    // rows. Fitting the array index compresses a gap into one step: these four
+    // observations read -10/day compressed and -2.8/day on the real calendar.
+    const now = '2026-01-01T00:00:00.000Z'
+    for (const [date, impressions] of [
+      ['2026-04-01', 100], ['2026-04-02', 90], ['2026-04-03', 80], ['2026-04-10', 70],
+    ] as const) {
+      context.db.insert(gscDailyTotals).values({
+        id: crypto.randomUUID(), projectId, date, clicks: 1, impressions,
+        position: '5', createdAt: now,
+      }).run()
+    }
+
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily?startDate=2026-04-01&endDate=2026-04-10',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as GscPerformanceDailyDto
+
+    // Only 4 dates carry rows...
+    expect(body.daily).toHaveLength(4)
+    // ...but the fit spans the 10-day calendar between them.
+    expect(body.trends!.impressions!.slope).toBeCloseTo(-2.8, 6)
+    expect(body.trends!.impressions!.slope).not.toBe(-10)
+    expect(body.trends!.impressions!.startIndex).toBe(0)
+    expect(body.trends!.impressions!.endIndex).toBe(9)
+  })
+
+  it('reports how much of the window the position figure covers', async () => {
+    // A position averaged over 2 of 4 days is not the window's average, and the
+    // response has to say which it is.
+    const now = '2026-01-01T00:00:00.000Z'
+    for (const [date, position] of [
+      ['2026-05-01', '4'], ['2026-05-02', '6'],
+    ] as const) {
+      context.db.insert(gscDailyTotals).values({
+        id: crypto.randomUUID(), projectId, date, clicks: 1, impressions: 10,
+        position, createdAt: now,
+      }).run()
+    }
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily?startDate=2026-05-01&endDate=2026-05-02',
+    })
+    const body = res.json() as GscPerformanceDailyDto
+    expect(body.totals.days).toBe(2)
+    expect(body.totals.positionDays).toBe(2)
+    expect(body.totals.position).toBe(5)
   })
 
   it('fits a least-squares trend per metric over the window', async () => {
@@ -1872,17 +1924,17 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     const body = res.json() as GscPerformanceDailyDto
 
     // Slope is PER DAY, and start/end are the endpoints a chart draws between.
-    expect(body.trends.clicks).toEqual({ slope: 10, intercept: 10, r2: 1, start: 10, end: 40, n: 4 })
+    expect(body.trends!.clicks).toEqual({ slope: 10, intercept: 10, r2: 1, start: 10, end: 40, n: 4, startIndex: 0, endIndex: 3 })
     // A flat series is a perfect flat fit, not an undefined one.
-    expect(body.trends.impressions).toEqual({ slope: 0, intercept: 100, r2: 1, start: 100, end: 100, n: 4 })
+    expect(body.trends!.impressions).toEqual({ slope: 0, intercept: 100, r2: 1, start: 100, end: 100, n: 4, startIndex: 0, endIndex: 3 })
     // Position falls as ranking IMPROVES, so the slope is negative.
-    expect(body.trends.position).toEqual({ slope: -1, intercept: 8, r2: 1, start: 8, end: 5, n: 4 })
+    expect(body.trends!.position).toEqual({ slope: -1, intercept: 8, r2: 1, start: 8, end: 5, n: 4, startIndex: 0, endIndex: 3 })
     // CTR rises with clicks against constant impressions: 0.1 -> 0.4.
-    expect(body.trends.ctr!.slope).toBeCloseTo(0.1, 6)
+    expect(body.trends!.ctr!.slope).toBeCloseTo(0.1, 6)
 
     // The fitted endpoints span the window, so the whole-window change is
     // slope * (days - 1) — the figure the tile and the CLI both report.
-    expect(body.trends.clicks!.end - body.trends.clicks!.start).toBe(10 * (body.totals.days - 1))
+    expect(body.trends!.clicks!.end - body.trends!.clicks!.start).toBe(10 * (body.totals.days - 1))
   })
 
   it('reports no position trend when every date came from the dimensioned fallback', async () => {
@@ -1894,8 +1946,8 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     })
     expect(res.statusCode).toBe(200)
     const body = res.json() as GscPerformanceDailyDto
-    expect(body.trends.position).toBeNull()
-    expect(body.trends.impressions).toEqual({ slope: 650, intercept: 350, r2: 1, start: 350, end: 1000, n: 2 })
+    expect(body.trends!.position).toBeNull()
+    expect(body.trends!.impressions).toEqual({ slope: 650, intercept: 350, r2: 1, start: 350, end: 1000, n: 2, startIndex: 0, endIndex: 1 })
   })
 
   it('can return date-only daily totals when no dimensioned rows exist for the window', async () => {
@@ -1916,7 +1968,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     })
     expect(res.statusCode).toBe(200)
     const body = res.json() as GscPerformanceDailyDto
-    expect(body.totals).toEqual({ clicks: 12, impressions: 500, ctr: 12 / 500, position: 9, days: 1 })
+    expect(body.totals).toEqual({ clicks: 12, impressions: 500, ctr: 12 / 500, position: 9, positionDays: 1, days: 1 })
     expect(body.daily).toEqual([{ date: '2026-02-01', clicks: 12, impressions: 500, ctr: 12 / 500, position: 9 }])
     // One day is not a line.
     expect(body.trends).toEqual({ clicks: null, impressions: null, ctr: null, position: null })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.161.0",
+  "version": "4.162.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -299,7 +299,7 @@ export async function googlePerformanceDaily(project: string, opts: {
   console.log(`  Clicks:      ${clicks.toLocaleString()}`)
   console.log(`  Impressions: ${impressions.toLocaleString()}`)
   console.log(`  CTR:         ${(ctr * 100).toFixed(2)}%`)
-  console.log(`  Position:    ${position === null ? '—' : position.toFixed(1)}`)
+  console.log(`  Position:    ${position == null ? '—' : position.toFixed(1)}`)
 
   // The same fit the dashboard chart draws, so the two surfaces can never
   // disagree about which way a metric is going.
@@ -332,7 +332,7 @@ export async function googlePerformanceDaily(project: string, opts: {
   console.log(`  ${'─'.repeat(12)}${'─'.repeat(10)}${'─'.repeat(12)}${'─'.repeat(10)}${'─'.repeat(9)}`)
   for (const row of data.daily) {
     console.log(
-      `  ${row.date.padEnd(12)}${row.clicks.toLocaleString().padStart(10)}${row.impressions.toLocaleString().padStart(12)}${(row.ctr * 100).toFixed(2).padStart(9)}%${(row.position === null ? '—' : row.position.toFixed(1)).padStart(9)}`,
+      `  ${row.date.padEnd(12)}${row.clicks.toLocaleString().padStart(10)}${row.impressions.toLocaleString().padStart(12)}${(row.ctr * 100).toFixed(2).padStart(9)}%${(row.position == null ? '—' : row.position.toFixed(1)).padStart(9)}`,
     )
   }
 }

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -303,12 +303,16 @@ export async function googlePerformanceDaily(project: string, opts: {
 
   // The same fit the dashboard chart draws, so the two surfaces can never
   // disagree about which way a metric is going.
+  // Optional at RUNTIME for the same reason as `window`: a server older than
+  // the field omits it, and the CLI degrades to no trend block rather than
+  // crashing.
+  const fits = data.trends
   const trendLines: string[] = []
   for (const [label, trend, fmt] of [
-    ['Clicks', data.trends.clicks, (v: number) => v.toFixed(2)],
-    ['Impressions', data.trends.impressions, (v: number) => v.toFixed(2)],
-    ['CTR', data.trends.ctr, (v: number) => `${(v * 100).toFixed(3)}pp`],
-    ['Position', data.trends.position, (v: number) => v.toFixed(3)],
+    ['Clicks', fits?.clicks, (v: number) => v.toFixed(2)],
+    ['Impressions', fits?.impressions, (v: number) => v.toFixed(2)],
+    ['CTR', fits?.ctr, (v: number) => `${(v * 100).toFixed(3)}pp`],
+    ['Position', fits?.position, (v: number) => v.toFixed(3)],
   ] as const) {
     if (!trend) continue
     // Position improves as it falls, so "up" is the wrong word for a rising rank.

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -276,7 +276,7 @@ export async function googlePerformanceDaily(project: string, opts: {
     return
   }
 
-  const { clicks, impressions, ctr, days } = data.totals
+  const { clicks, impressions, ctr, position, days } = data.totals
   // Optional at RUNTIME even though the DTO requires it: a server older than
   // this field omits it, and a new CLI against an older server must degrade to
   // no range label rather than crash. The web guards the same skew.
@@ -299,12 +299,36 @@ export async function googlePerformanceDaily(project: string, opts: {
   console.log(`  Clicks:      ${clicks.toLocaleString()}`)
   console.log(`  Impressions: ${impressions.toLocaleString()}`)
   console.log(`  CTR:         ${(ctr * 100).toFixed(2)}%`)
+  console.log(`  Position:    ${position === null ? '—' : position.toFixed(1)}`)
+
+  // The same fit the dashboard chart draws, so the two surfaces can never
+  // disagree about which way a metric is going.
+  const trendLines: string[] = []
+  for (const [label, trend, fmt] of [
+    ['Clicks', data.trends.clicks, (v: number) => v.toFixed(2)],
+    ['Impressions', data.trends.impressions, (v: number) => v.toFixed(2)],
+    ['CTR', data.trends.ctr, (v: number) => `${(v * 100).toFixed(3)}pp`],
+    ['Position', data.trends.position, (v: number) => v.toFixed(3)],
+  ] as const) {
+    if (!trend) continue
+    // Position improves as it falls, so "up" is the wrong word for a rising rank.
+    const better = label === 'Position' ? trend.slope < 0 : trend.slope > 0
+    const direction = trend.slope === 0 ? 'flat' : better ? 'improving' : 'declining'
+    trendLines.push(
+      `  ${`${label}:`.padEnd(13)}${fmt(trend.slope).padStart(10)}/day  ${direction} (r²=${trend.r2.toFixed(2)})`,
+    )
+  }
+  if (trendLines.length > 0) {
+    console.log(`\nTrend (least-squares fit over ${days} day${days === 1 ? '' : 's'}):`)
+    for (const line of trendLines) console.log(line)
+  }
+
   console.log()
-  console.log(`  ${'DATE'.padEnd(12)}${'CLICKS'.padStart(10)}${'IMPR'.padStart(12)}${'CTR'.padStart(10)}`)
-  console.log(`  ${'─'.repeat(12)}${'─'.repeat(10)}${'─'.repeat(12)}${'─'.repeat(10)}`)
+  console.log(`  ${'DATE'.padEnd(12)}${'CLICKS'.padStart(10)}${'IMPR'.padStart(12)}${'CTR'.padStart(10)}${'POS'.padStart(9)}`)
+  console.log(`  ${'─'.repeat(12)}${'─'.repeat(10)}${'─'.repeat(12)}${'─'.repeat(10)}${'─'.repeat(9)}`)
   for (const row of data.daily) {
     console.log(
-      `  ${row.date.padEnd(12)}${row.clicks.toLocaleString().padStart(10)}${row.impressions.toLocaleString().padStart(12)}${(row.ctr * 100).toFixed(2).padStart(9)}%`,
+      `  ${row.date.padEnd(12)}${row.clicks.toLocaleString().padStart(10)}${row.impressions.toLocaleString().padStart(12)}${(row.ctr * 100).toFixed(2).padStart(9)}%${(row.position === null ? '—' : row.position.toFixed(1)).padStart(9)}`,
     )
   }
 }

--- a/packages/contracts/src/formatting.ts
+++ b/packages/contracts/src/formatting.ts
@@ -152,6 +152,30 @@ export function formatIsoDateInTimeZone(iso: string, timeZone: string): string {
  * A value that is not a calendar date comes back untouched, so a degraded
  * upstream reading degrades once rather than turning into a wrong date.
  */
+/**
+ * Every `YYYY-MM-DD` from `startDate` to `endDate`, inclusive.
+ *
+ * The single source of the CALENDAR INDEX SPACE. Anything that fits, plots, or
+ * indexes a dated series must derive its positions from this one function:
+ * a series built from "rows that exist" and a fit built from "days that exist"
+ * are different index spaces, and mixing them silently rescales the result.
+ * That is not hypothetical — a trend fitted over a 10-day calendar and drawn
+ * over 4 row positions traversed a third of its range and stopped at the wrong
+ * value.
+ *
+ * `cap` bounds the walk so a corrupt or inverted range cannot spin; a reversed
+ * range returns empty, since it names no days.
+ */
+export function calendarDateRange(startDate: string, endDate: string, cap = 800): string[] {
+  const dates: string[] = []
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate) || !/^\d{4}-\d{2}-\d{2}$/.test(endDate)) return dates
+  for (let cursor = startDate; cursor <= endDate; cursor = shiftIsoCalendarDate(cursor, 1)) {
+    dates.push(cursor)
+    if (dates.length >= cap) break
+  }
+  return dates
+}
+
 export function shiftIsoCalendarDate(isoDate: string, days: number): string {
   if (!Number.isFinite(days)) return isoDate
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate)

--- a/packages/contracts/src/google.ts
+++ b/packages/contracts/src/google.ts
@@ -131,6 +131,11 @@ export const gscPerformanceDailyDtoSchema = z.object({
      * one-impression day count as much as a thousand-impression day.
      */
     position: z.number().nullable(),
+    /**
+     * Days that carried a property-level position. Below `days`, `position`
+     * describes a subset of the window and must be labelled as partial.
+     */
+    positionDays: z.number(),
     days: z.number(),
   }),
   daily: z.array(gscPerformanceDailyPointSchema),

--- a/packages/contracts/src/google.ts
+++ b/packages/contracts/src/google.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { linearTrendSchema } from './statistics.js'
 
 export const googleConnectionTypeSchema = z.enum(['gsc', 'ga4', 'gbp'])
 export type GoogleConnectionType = z.infer<typeof googleConnectionTypeSchema>
@@ -62,6 +63,14 @@ export const gscPerformanceDailyPointSchema = z.object({
   clicks: z.number(),
   impressions: z.number(),
   ctr: z.number(),
+  /**
+   * Average ranking position for the day, or `null` on a date served by the
+   * dimensioned fallback. Summing `gsc_search_data` cannot produce a property
+   * position (a mean of per-row positions is not the property's mean), so the
+   * absence is reported rather than a fabricated `0` — which would also read as
+   * an impossibly good rank on a chart with an inverted axis.
+   */
+  position: z.number().nullable(),
 })
 export type GscPerformanceDailyPoint = z.infer<typeof gscPerformanceDailyPointSchema>
 
@@ -95,11 +104,33 @@ export const gscWindowRangeSchema = z.object({
 })
 export type GscWindowRange = z.infer<typeof gscWindowRangeSchema>
 
+/**
+ * Least-squares fit of one metric across the window's days, computed server-side
+ * so the dashboard, the CLI, and the report all draw the SAME line (per the
+ * UI/CLI parity rule — a chart-only regression would be invisible to an agent).
+ *
+ * `null` when the window holds fewer than two days carrying that metric.
+ */
+export const gscPerformanceTrendsSchema = z.object({
+  clicks: linearTrendSchema.nullable(),
+  impressions: linearTrendSchema.nullable(),
+  ctr: linearTrendSchema.nullable(),
+  position: linearTrendSchema.nullable(),
+})
+export type GscPerformanceTrends = z.infer<typeof gscPerformanceTrendsSchema>
+
 export const gscPerformanceDailyDtoSchema = z.object({
   totals: z.object({
     clicks: z.number(),
     impressions: z.number(),
     ctr: z.number(),
+    /**
+     * Impression-weighted mean position over the window, or `null` when no day
+     * carried a property-level position. Weighted, not a plain mean of the
+     * daily values: position is non-additive, and an unweighted mean lets a
+     * one-impression day count as much as a thousand-impression day.
+     */
+    position: z.number().nullable(),
     days: z.number(),
   }),
   daily: z.array(gscPerformanceDailyPointSchema),
@@ -110,6 +141,11 @@ export const gscPerformanceDailyDtoSchema = z.object({
    * response, which is exactly the crash those guards exist to prevent.
    */
   window: gscWindowRangeSchema.optional(),
+  /**
+   * Optional for the same reason as `window`: a server older than this field
+   * omits it, and the chart guards for that skew.
+   */
+  trends: gscPerformanceTrendsSchema.optional(),
 })
 export type GscPerformanceDailyDto = z.infer<typeof gscPerformanceDailyDtoSchema>
 

--- a/packages/contracts/src/statistics.ts
+++ b/packages/contracts/src/statistics.ts
@@ -7,6 +7,8 @@
  * every monthly rate as `point (Wilson low–high)`.
  */
 
+import { z } from 'zod'
+
 export interface ConfidenceInterval {
   /** Lower bound of the interval, clamped to [0, 1]. */
   low: number
@@ -48,5 +50,93 @@ export function wilsonInterval(successes: number, n: number, z = 1.96): Confiden
   return {
     low: round(Math.max(0, center - margin)),
     high: round(Math.min(1, center + margin)),
+  }
+}
+
+/**
+ * Least-squares fit of one evenly-spaced series, expressed so a caller can draw
+ * it without re-deriving anything.
+ *
+ * `slope` is in the series' own units PER STEP — for a daily series that is
+ * "per day", which is the number worth reporting; the caller multiplies by
+ * `n - 1` itself if it wants the whole-window change. `start` / `end` are the
+ * fitted values at the first and last index, i.e. the two endpoints of the
+ * trend line, so a chart draws it as one straight segment with no per-point
+ * evaluation.
+ */
+export const linearTrendSchema = z.object({
+  /** Change in the fitted value per one-index step. */
+  slope: z.number(),
+  /** Fitted value at index 0. */
+  intercept: z.number(),
+  /** Coefficient of determination in [0, 1]. `1` for a series with no variance. */
+  r2: z.number(),
+  /** Fitted value at the first index. */
+  start: z.number(),
+  /** Fitted value at the last index. */
+  end: z.number(),
+  /** Count of finite observations the fit used (not the series length). */
+  n: z.number(),
+})
+export type LinearTrend = z.infer<typeof linearTrendSchema>
+
+/**
+ * Ordinary-least-squares trend over a series indexed by position.
+ *
+ * Deliberately generic: it takes bare numbers, not dated points, so any
+ * evenly-spaced series (GSC clicks per day, sweep mention rate per run, spend
+ * per week) fits with the same call. The INDEX is the x value, so gaps are
+ * handled by passing `null` — the point is skipped while the surviving points
+ * keep their true positions, which is what a daily series with a missing day
+ * needs. Dropping the entry instead would silently compress the x-axis and
+ * bend the line.
+ *
+ * Returns `null` when fewer than two finite observations survive — a line
+ * through one point is undefined, and a caller must render "no trend" rather
+ * than a fabricated slope of 0. Two surviving observations always sit at two
+ * DIFFERENT indices (the index is the array position), so the x-variance is
+ * non-zero whenever the fit runs and there is no degenerate-denominator case
+ * to guard.
+ *
+ * `r2` is `1` when the series has no variance (a constant series IS perfectly
+ * described by its flat fit); it is otherwise `1 - ssRes / ssTot`, clamped to
+ * `[0, 1]` so floating-point residue cannot emit `-0.0000001`.
+ */
+export function linearTrend(values: readonly (number | null | undefined)[]): LinearTrend | null {
+  const points: { x: number; y: number }[] = []
+  for (const [index, value] of values.entries()) {
+    if (typeof value === 'number' && Number.isFinite(value)) points.push({ x: index, y: value })
+  }
+  const n = points.length
+  if (n < 2) return null
+
+  const meanX = points.reduce((sum, p) => sum + p.x, 0) / n
+  const meanY = points.reduce((sum, p) => sum + p.y, 0) / n
+  let sxx = 0
+  let sxy = 0
+  for (const p of points) {
+    sxx += (p.x - meanX) ** 2
+    sxy += (p.x - meanX) * (p.y - meanY)
+  }
+  const slope = sxy / sxx
+  const intercept = meanY - slope * meanX
+
+  let ssRes = 0
+  let ssTot = 0
+  for (const p of points) {
+    ssRes += (p.y - (slope * p.x + intercept)) ** 2
+    ssTot += (p.y - meanY) ** 2
+  }
+  const r2 = ssTot === 0 ? 1 : Math.min(1, Math.max(0, 1 - ssRes / ssTot))
+
+  const firstX = points[0]!.x
+  const lastX = points[n - 1]!.x
+  return {
+    slope: round(slope),
+    intercept: round(intercept),
+    r2: round(r2),
+    start: round(slope * firstX + intercept),
+    end: round(slope * lastX + intercept),
+    n,
   }
 }

--- a/packages/contracts/src/statistics.ts
+++ b/packages/contracts/src/statistics.ts
@@ -23,6 +23,23 @@ function round(value: number, dp = 4): number {
 }
 
 /**
+ * Round to `sig` significant figures, not decimal places.
+ *
+ * A fitted slope spans many orders of magnitude across metrics: clicks move by
+ * whole units per day, CTR by ~1e-5. Fixed 4-decimal rounding is fine for the
+ * first and destroys the second — a CTR climbing from 2.0% to 2.1% over a month
+ * has a slope near 0.00003, which rounds to exactly `0` and makes the surface
+ * report "flat" for movement that is really there. Significant figures keep the
+ * same relative precision at every scale, and exact values (1.5, -3) stay exact.
+ */
+function roundSignificant(value: number, sig = 6): number {
+  if (!Number.isFinite(value) || value === 0) return 0
+  const magnitude = Math.ceil(Math.log10(Math.abs(value)))
+  const factor = 10 ** (sig - magnitude)
+  return (Math.round(value * factor) + 0) / factor
+}
+
+/**
  * Wilson score interval for a binomial proportion — the display default for
  * mention / cited / share-of-voice rates.
  *
@@ -77,6 +94,16 @@ export const linearTrendSchema = z.object({
   end: z.number(),
   /** Count of finite observations the fit used (not the series length). */
   n: z.number(),
+  /**
+   * Index of the first observation the fit used, and of the last.
+   *
+   * `start` / `end` are evaluated AT these indices, not at the series' own ends.
+   * A caller drawing the line must span exactly this range: extending it across
+   * leading or trailing indices the metric has no data for draws a fitted claim
+   * over dates that were never measured.
+   */
+  startIndex: z.number(),
+  endIndex: z.number(),
 })
 export type LinearTrend = z.infer<typeof linearTrendSchema>
 
@@ -132,11 +159,13 @@ export function linearTrend(values: readonly (number | null | undefined)[]): Lin
   const firstX = points[0]!.x
   const lastX = points[n - 1]!.x
   return {
-    slope: round(slope),
-    intercept: round(intercept),
+    slope: roundSignificant(slope),
+    intercept: roundSignificant(intercept),
     r2: round(r2),
-    start: round(slope * firstX + intercept),
-    end: round(slope * lastX + intercept),
+    start: roundSignificant(slope * firstX + intercept),
+    end: roundSignificant(slope * lastX + intercept),
     n,
+    startIndex: firstX,
+    endIndex: lastX,
   }
 }

--- a/packages/contracts/test/statistics.test.ts
+++ b/packages/contracts/test/statistics.test.ts
@@ -49,13 +49,13 @@ describe('linearTrend', () => {
   it('recovers an exact line and reports its endpoints', () => {
     // y = 2x + 1 over indices 0..4.
     const trend = linearTrend([1, 3, 5, 7, 9])
-    expect(trend).toEqual({ slope: 2, intercept: 1, r2: 1, start: 1, end: 9, n: 5 })
+    expect(trend).toEqual({ slope: 2, intercept: 1, r2: 1, start: 1, end: 9, n: 5, startIndex: 0, endIndex: 4 })
   })
 
   it('fits a falling series with a negative slope', () => {
     // y = -3x + 20 over indices 0..3.
     const trend = linearTrend([20, 17, 14, 11])
-    expect(trend).toEqual({ slope: -3, intercept: 20, r2: 1, start: 20, end: 11, n: 4 })
+    expect(trend).toEqual({ slope: -3, intercept: 20, r2: 1, start: 20, end: 11, n: 4, startIndex: 0, endIndex: 3 })
   })
 
   it('reports slope per STEP, so the window change is slope * (n - 1)', () => {
@@ -66,20 +66,20 @@ describe('linearTrend', () => {
 
   it('calls a constant series a perfect flat fit rather than dividing by zero', () => {
     // ssTot is 0 here; r2 must be 1, not NaN.
-    expect(linearTrend([5, 5, 5])).toEqual({ slope: 0, intercept: 5, r2: 1, start: 5, end: 5, n: 3 })
+    expect(linearTrend([5, 5, 5])).toEqual({ slope: 0, intercept: 5, r2: 1, start: 5, end: 5, n: 3, startIndex: 0, endIndex: 2 })
   })
 
   it('computes the exact least-squares fit for a noisy series', () => {
     // [1, 2, 4]: slope 3/2, intercept 5/6, ssRes 1/6, ssTot 14/3.
     const trend = linearTrend([1, 2, 4])
-    expect(trend).toEqual({ slope: 1.5, intercept: 0.8333, r2: 0.9643, start: 0.8333, end: 3.8333, n: 3 })
+    expect(trend).toEqual({ slope: 1.5, intercept: 0.833333, r2: 0.9643, start: 0.833333, end: 3.83333, n: 3, startIndex: 0, endIndex: 2 })
   })
 
   it('keeps the true index of a point across a gap instead of compressing the axis', () => {
     // Observations at x=0 and x=2, so the slope is 2 — NOT the 4 you would get
     // by dropping the hole and treating the points as adjacent.
     const trend = linearTrend([0, null, 4])
-    expect(trend).toEqual({ slope: 2, intercept: 0, r2: 1, start: 0, end: 4, n: 2 })
+    expect(trend).toEqual({ slope: 2, intercept: 0, r2: 1, start: 0, end: 4, n: 2, startIndex: 0, endIndex: 2 })
     expect(linearTrend([0, 4])!.slope).toBe(4)
   })
 
@@ -96,7 +96,7 @@ describe('linearTrend', () => {
 
   it('skips non-finite observations rather than poisoning the fit with NaN', () => {
     expect(linearTrend([1, Number.NaN, 5, Number.POSITIVE_INFINITY, 9])).toEqual({
-      slope: 2, intercept: 1, r2: 1, start: 1, end: 9, n: 3,
+      slope: 2, intercept: 1, r2: 1, start: 1, end: 9, n: 3, startIndex: 0, endIndex: 4,
     })
   })
 
@@ -112,5 +112,35 @@ describe('linearTrend', () => {
     // Guards the tempting-but-wrong reading that "zig-zag" means "flat":
     // this one runs 0 -> 10, and the fit says so.
     expect(linearTrend([0, 10, 0, 10, 0, 10])!.slope).toBeGreaterThan(0)
+  })
+})
+
+describe('linearTrend precision and extent', () => {
+  it('keeps a tiny slope instead of rounding real movement to flat', () => {
+    // A CTR climbing 2.00% -> 2.10% over 31 days. Fixed 4-decimal rounding
+    // made this slope exactly 0, so every surface reported "flat" for movement
+    // that is really there.
+    const ctr = Array.from({ length: 31 }, (_, i) => 0.02 + (0.001 * i) / 30)
+    const trend = linearTrend(ctr)!
+    expect(trend.slope).not.toBe(0)
+    expect(trend.slope).toBeCloseTo(0.001 / 30, 9)
+  })
+
+  it('reports the index range the fit actually covers', () => {
+    // Leading and trailing gaps: the fit spans indices 2..4 only, so a caller
+    // must not draw it across 0..5 as though those dates were measured.
+    const trend = linearTrend([null, null, 10, 20, 30, null])!
+    expect(trend.startIndex).toBe(2)
+    expect(trend.endIndex).toBe(4)
+    expect(trend.n).toBe(3)
+  })
+
+  it('does not compress a calendar gap into a single step', () => {
+    // The route feeds one entry per DATE PRESENT, and GSC omits zero-data days.
+    // Same observations, real spacing: the slope must not be overstated.
+    const compressed = linearTrend([100, 90, 80, 70])!
+    const dense = linearTrend([100, 90, 80, null, null, null, null, null, null, 70])!
+    expect(compressed.slope).toBe(-10)
+    expect(dense.slope).toBeCloseTo(-2.8, 6)
   })
 })

--- a/packages/contracts/test/statistics.test.ts
+++ b/packages/contracts/test/statistics.test.ts
@@ -144,3 +144,29 @@ describe('linearTrend precision and extent', () => {
     expect(dense.slope).toBeCloseTo(-2.8, 6)
   })
 })
+
+describe('calendar index space', () => {
+  it('is derived from ONE function, so a fit and a plot cannot disagree', async () => {
+    const { calendarDateRange } = await import('../src/formatting.js')
+    // 4 dates carry data across a 10-day span.
+    const measured = ['2026-04-01', '2026-04-02', '2026-04-03', '2026-04-10']
+    const dense = calendarDateRange(measured[0]!, measured[measured.length - 1]!)
+    expect(dense).toHaveLength(10)
+
+    // The fit runs over the dense series...
+    const byDate = new Map([['2026-04-01', 100], ['2026-04-02', 90], ['2026-04-03', 80], ['2026-04-10', 70]])
+    const trend = linearTrend(dense.map((d) => byDate.get(d) ?? null))!
+    expect(trend.endIndex).toBe(9)
+
+    // ...and the plot must use the SAME length, or the drawn line stops short.
+    // Against the 4 measured rows it ended at 90 instead of 70.
+    const drawn = dense.map((_, i) =>
+      trend.start + ((trend.end - trend.start) * (i - trend.startIndex)) / (trend.endIndex - trend.startIndex))
+    expect(drawn.at(-1)).toBeCloseTo(trend.end, 6)
+  })
+
+  it('returns nothing for a reversed range', async () => {
+    const { calendarDateRange } = await import('../src/formatting.js')
+    expect(calendarDateRange('2026-04-10', '2026-04-01')).toEqual([])
+  })
+})

--- a/packages/contracts/test/statistics.test.ts
+++ b/packages/contracts/test/statistics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { wilsonInterval } from '../src/statistics.js'
+import { linearTrend, wilsonInterval } from '../src/statistics.js'
 
 describe('wilsonInterval', () => {
   // Fixtures verified against the closed-form Wilson score interval (z=1.96).
@@ -42,5 +42,75 @@ describe('wilsonInterval', () => {
       expect(ci.low).toBeLessThanOrEqual(p)
       expect(ci.high).toBeGreaterThanOrEqual(p)
     }
+  })
+})
+
+describe('linearTrend', () => {
+  it('recovers an exact line and reports its endpoints', () => {
+    // y = 2x + 1 over indices 0..4.
+    const trend = linearTrend([1, 3, 5, 7, 9])
+    expect(trend).toEqual({ slope: 2, intercept: 1, r2: 1, start: 1, end: 9, n: 5 })
+  })
+
+  it('fits a falling series with a negative slope', () => {
+    // y = -3x + 20 over indices 0..3.
+    const trend = linearTrend([20, 17, 14, 11])
+    expect(trend).toEqual({ slope: -3, intercept: 20, r2: 1, start: 20, end: 11, n: 4 })
+  })
+
+  it('reports slope per STEP, so the window change is slope * (n - 1)', () => {
+    const trend = linearTrend([1, 3, 5, 7, 9])!
+    expect(trend.slope).toBe(2)
+    expect(trend.end - trend.start).toBeCloseTo(trend.slope * 4, 10)
+  })
+
+  it('calls a constant series a perfect flat fit rather than dividing by zero', () => {
+    // ssTot is 0 here; r2 must be 1, not NaN.
+    expect(linearTrend([5, 5, 5])).toEqual({ slope: 0, intercept: 5, r2: 1, start: 5, end: 5, n: 3 })
+  })
+
+  it('computes the exact least-squares fit for a noisy series', () => {
+    // [1, 2, 4]: slope 3/2, intercept 5/6, ssRes 1/6, ssTot 14/3.
+    const trend = linearTrend([1, 2, 4])
+    expect(trend).toEqual({ slope: 1.5, intercept: 0.8333, r2: 0.9643, start: 0.8333, end: 3.8333, n: 3 })
+  })
+
+  it('keeps the true index of a point across a gap instead of compressing the axis', () => {
+    // Observations at x=0 and x=2, so the slope is 2 — NOT the 4 you would get
+    // by dropping the hole and treating the points as adjacent.
+    const trend = linearTrend([0, null, 4])
+    expect(trend).toEqual({ slope: 2, intercept: 0, r2: 1, start: 0, end: 4, n: 2 })
+    expect(linearTrend([0, 4])!.slope).toBe(4)
+  })
+
+  it('counts only the observations it used, not the series length', () => {
+    expect(linearTrend([1, null, 3, undefined, 5])!.n).toBe(3)
+  })
+
+  it('returns null when a line is undefined', () => {
+    expect(linearTrend([])).toBeNull()
+    expect(linearTrend([7])).toBeNull()
+    expect(linearTrend([null, 7, null])).toBeNull()
+    expect(linearTrend([null, undefined])).toBeNull()
+  })
+
+  it('skips non-finite observations rather than poisoning the fit with NaN', () => {
+    expect(linearTrend([1, Number.NaN, 5, Number.POSITIVE_INFINITY, 9])).toEqual({
+      slope: 2, intercept: 1, r2: 1, start: 1, end: 9, n: 3,
+    })
+  })
+
+  it('reports zero explanatory power on a symmetric series with no linear signal', () => {
+    // A V: the fit is the flat mean, so every point is a full residual.
+    const trend = linearTrend([10, 0, 0, 10])!
+    expect(trend.slope).toBe(0)
+    expect(trend.intercept).toBe(5)
+    expect(trend.r2).toBe(0)
+  })
+
+  it('still trends up when an alternating series ends higher than it started', () => {
+    // Guards the tempting-but-wrong reading that "zig-zag" means "flat":
+    // this one runs 0 -> 10, and the fit says so.
+    expect(linearTrend([0, 10, 0, 10, 0, 10])!.slope).toBeGreaterThan(0)
   })
 })

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.161.0",
+  "version": "4.162.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.161.0",
+  "version": "4.162.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.161.0",
+  "version": "4.162.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
**Stacked on #993** — base is `ax/gsc-window-anchor`, so this diff shows only the chart work. GitHub retargets it to `main` when #993 merges.

## What

The search performance chart drew clicks and impressions against **one shared y-axis**. On canonry.ai that is 30 clicks against an axis topping 300, so the clicks series rendered as a flat line on the baseline and the chart read as "nothing is happening". Search Console gives clicks their own scale; that difference is the whole reason its chart looks alive and ours did not.

Give every metric its own axis, and add the two metrics that were missing.

| | Before | After |
|---|---|---|
| Mark | Bars | Lines |
| Axes | One shared | One per metric |
| Metrics | Clicks, impressions | + CTR, avg position |
| Trend | none | Least-squares fit, dashed |
| Drill-in | none | Click a day to filter the table |

## Pieces

- **`linearTrend`** (`contracts/statistics.ts`) — least-squares fit over any evenly-spaced series. Takes bare numbers, so the array index is the x value and a `null` stays a real gap instead of compressing the axis.
- **`GET /google/gsc/performance/daily`** returns per-day `position` and a `trends` block fitting all four metrics. Position is `null` on dates served by the dimensioned fallback (a sum cannot produce a property position) and the window total is impression-weighted, since position is not additive.
- **`MultiAxisTrendChart`** (`ChartPrimitives`) — domain-free Recharts chart taking rows, a series list, and precomputed fit endpoints. It computes no statistics, which is what keeps the drawn line identical to the one the CLI reports.
- **`canonry google performance-daily`** prints position and the same fits, reading direction as better/worse so a falling rank is "improving".

The regression runs server-side rather than in the component because of the UI/CLI parity rule — a chart-only fit would be invisible to an agent.

## Click a day

`onSelectX` / `selectedX` live on the primitive, not this section. The handler is on the chart rather than the dot: Recharts reports the active row per column, and a 2px dot is not a click target. A dashed reference line marks the selected day so the chart and the table agree; clicking the same day again clears it, and changing the window clears it too.

## Copy

The paragraph under the filter row is gone. Per the repo's own rule — *"if a sentence explains or justifies rather than labels or names, it goes in a tooltip"* — it is now an `InfoTooltip` on the Search performance heading, which also documents click-to-drill. The trigger is keyboard-reachable and the copy rides its `aria-label`, so nothing is lost for assistive tech and a test can still find it by accessible name.

## Two judgment calls

**Average position is `null`, never `0`**, on dates served by the dimensioned fallback. `0` would read as an impossibly good rank on a reversed axis.

**Trend arrows read better/worse, not up/down.** Position improving means the number falls, so a negative slope shows `↑`. There is a test locking that case.

## Validation

- 8487/8487 tests pass, `typecheck` and `lint` clean, `plugin:check` green
- A real browser render (SSR + compiled Tailwind + raw CDP) caught a bug I had shipped: `allowDecimals={false}` snapped CTR's 0–0.05 domain up to 0–1 and flattened it onto the baseline — the exact failure per-metric axes exist to prevent. Fixed and re-rendered.
- `trends` is optional in the DTO, matching `window`, and both the chart and the CLI guard the version skew rather than dereferencing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)