### PR TITLE
test(gsc): make the copy-placement assertions falsifiable, and unnest the tooltips

### DIFF
--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -1057,10 +1057,10 @@ export function GscSection({
                 <div className="section-head section-head-inline">
                   <div>
                     <p className="eyebrow eyebrow-soft">Performance</p>
-                    <h3 className="flex items-center gap-1.5">
-                      Search performance
+                    <div className="flex items-center gap-1.5">
+                      <h3>Search performance</h3>
                       <InfoTooltip text={`Click any day to filter the table below to that date. Query and page filters match case-insensitive substrings and run on Apply filters. Filtering and sorting examine up to ${EXPANDED_PERFORMANCE_LIMIT.toLocaleString()} matching rows while the table shows ${DEFAULT_TABLE_PAGE_SIZE} per page.`} />
-                    </h3>
+                    </div>
                     {/* The window ends where Google's data ends, not today.
                         Naming the real range is what stops a lagging tail
                         reading as a drop, and lets this be compared against
@@ -1383,10 +1383,10 @@ export function GscSection({
                 <div className="section-head section-head-inline">
                   <div>
                     <p className="eyebrow eyebrow-soft">Coverage</p>
-                    <h3 className="flex items-center gap-1.5">
-                      Index coverage
+                    <div className="flex items-center gap-1.5">
+                      <h3>Index coverage</h3>
                       <InfoTooltip text="Google's Indexing API is intended for eligible JobPosting and BroadcastEvent pages. Sitemap resubmission is the general-site bulk path." />
-                    </h3>
+                    </div>
                   </div>
                   <div className="flex items-center gap-2">
                     {coverage && coverage.notIndexed.length > 0 && (
@@ -1736,10 +1736,10 @@ export function GscSection({
                 <div className="section-head section-head-inline">
                   <div>
                     <p className="eyebrow eyebrow-soft">Sitemaps</p>
-                    <h3 className="flex items-center gap-1.5">
-                      Sitemap operations
+                    <div className="flex items-center gap-1.5">
+                      <h3>Sitemap operations</h3>
                       <InfoTooltip text="Submitting asks Google to refetch these sitemaps. Indexing is not guaranteed." />
-                    </h3>
+                    </div>
                   </div>
                   <Button
                     type="button"
@@ -2024,10 +2024,10 @@ export function GscSection({
                       <div className="section-head">
                         <div>
                           <p className="eyebrow eyebrow-soft">Property</p>
-                          <h3 className="flex items-center gap-1.5">
-                      Pick the Search Console property
-                      <InfoTooltip text="The selected property is used for future syncs and URL inspections for this project." />
-                    </h3>
+                          <div className="flex items-center gap-1.5">
+                            <h3>Pick the Search Console property</h3>
+                            <InfoTooltip text="The selected property is used for future syncs and URL inspections for this project." />
+                          </div>
                         </div>
                       </div>
                       <div className="mt-3 space-y-2">

--- a/apps/web/test/gsc-copy-placement.test.tsx
+++ b/apps/web/test/gsc-copy-placement.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// Recharts is irrelevant here and expensive to render; this suite is about
+// WHERE explanatory copy lives, not about the chart.
+vi.mock('recharts', () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+  return {
+    ResponsiveContainer: passthrough,
+    ComposedChart: passthrough,
+    Line: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    Tooltip: () => null,
+    CartesianGrid: () => null,
+  }
+})
+
+// The not-yet-connected state links to Settings, and a real `Link` needs a
+// router context this suite has no reason to build.
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-router')>()),
+  Link: ({ to, children }: { to: string; children?: React.ReactNode }) => <a href={to}>{children}</a>,
+}))
+
+import { GscSection } from '../src/components/project/GscSection.js'
+import { jsonResponse, mockFetch, pathOf } from './mock-fetch.js'
+
+afterEach(() => {
+  cleanup()
+})
+
+/**
+ * The copy under test lives in THREE different render states, and a test that
+ * only ever arranges one of them is unfalsifiable for the other two:
+ *
+ *   - the data sections render when a connection exists
+ *   - the property picker is inside a COLLAPSED "Setup & Configuration"
+ *     disclosure, so it is absent until something clicks it open
+ *   - the connect-state line renders only with NO connection and NO configured
+ *     OAuth app
+ *
+ * Asserting "this paragraph is gone" against a state that never rendered it
+ * passes identically before and after the change.
+ */
+function renderSection({ connected, googleConfigured = true }: { connected: boolean; googleConfigured?: boolean }) {
+  const restoreFetch = mockFetch((url) => {
+    const path = pathOf(url)
+    if (path === '/api/v1/settings') {
+      return jsonResponse({
+        providers: [], providerCatalog: [],
+        google: { configured: googleConfigured }, bing: { configured: false },
+      })
+    }
+    if (path.endsWith('/google/connections')) {
+      return jsonResponse(connected
+        ? [{
+            id: 'gsc-1', domain: 'example.com', connectionType: 'gsc',
+            propertyId: 'sc-domain:example.com', sitemapUrl: 'https://example.com/sitemap.xml',
+            scopes: [], createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-04T00:00:00.000Z',
+          }]
+        : [])
+    }
+    if (path.includes('/google/properties')) {
+      return jsonResponse({ sites: [{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }] })
+    }
+    if (path.includes('/google/gsc/performance/daily')) {
+      return jsonResponse({
+        totals: { clicks: 0, impressions: 0, ctr: 0, position: null, positionDays: 0, days: 0 },
+        daily: [],
+        trends: { clicks: null, impressions: null, ctr: null, position: null },
+      })
+    }
+    if (path.includes('/google/gsc/performance')) {
+      return jsonResponse({ rows: [], totalMatching: 0, truncated: false, latestAvailableDate: null })
+    }
+    if (path.includes('/google/gsc/sitemaps')) {
+      return jsonResponse({ sitemaps: [], summary: { total: 0, indexes: 0, files: 0 }, preferredSubmissionUrls: [] })
+    }
+    if (path.includes('/google/gsc/inspections')) return jsonResponse([])
+    if (path.includes('/google/gsc/deindexed')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage/history')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage')) return jsonResponse(null)
+    throw new Error(`Unexpected fetch: ${path}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GscSection projectName="test-project" refreshNonce={0} />
+    </QueryClientProvider>,
+  )
+}
+
+/**
+ * Copy that EXPLAINS, so the rule sends it to a tooltip.
+ *
+ * `phrase` is anchored on wording common to the OLD paragraph and the NEW
+ * tooltip, which is what makes the negative assertion mean anything: the
+ * sitemap sentence was reworded on the way into the tooltip ("Google is asked
+ * to refetch" -> "Submitting asks Google to refetch"), so a negative written
+ * against the new phrasing was already null on `main` and could not have
+ * detected the paragraph coming back.
+ */
+const MOVED = [
+  { heading: 'Index coverage', phrase: /Indexing API is intended for eligible JobPosting/ },
+  { heading: 'Sitemap operations', phrase: /refetch these sitemaps/ },
+] as const
+
+test('explanatory copy is a tooltip trigger, not body prose', async () => {
+  renderSection({ connected: true })
+  await waitFor(() => expect(screen.queryByText('Index coverage')).not.toBeNull())
+
+  for (const { phrase } of MOVED) {
+    expect(screen.queryByText(phrase), `${phrase} must not be body copy`).toBeNull()
+    expect(screen.getByRole('button', { name: phrase })).not.toBeNull()
+  }
+})
+
+test('each tooltip is a SIBLING of its heading, so it stays out of the heading name', async () => {
+  // apps/web/AGENTS.md: "an InfoTooltip is placed as a SIBLING of a heading,
+  // never a child, or its help text joins the heading's accessible name and
+  // any aria-labelledby landmark that points at it."
+  renderSection({ connected: true })
+  await waitFor(() => expect(screen.queryByText('Index coverage')).not.toBeNull())
+
+  for (const heading of ['Search performance', ...MOVED.map((m) => m.heading)]) {
+    const el = screen.getByRole('heading', { name: heading })
+    // Exact match: a nested trigger folds its aria-label into the name, so the
+    // heading would read as the heading PLUS a paragraph of help text.
+    expect(el.textContent?.trim(), `${heading} accessible name`).toBe(heading)
+    expect(el.querySelector('button'), `${heading} must not contain the trigger`).toBeNull()
+  }
+})
+
+test('the property picker moved its explanation too, asserted with the card OPEN', async () => {
+  renderSection({ connected: true })
+  await waitFor(() => expect(screen.queryByText('Search performance')).not.toBeNull())
+
+  // Prove the disclosure starts closed, so the expansion below is what puts
+  // the card on the page and the assertions are not passing on absence.
+  expect(screen.queryByText('Pick the Search Console property')).toBeNull()
+  fireEvent.click(screen.getByText(/Setup & Configuration/))
+  await waitFor(() => expect(screen.queryByText('Pick the Search Console property')).not.toBeNull())
+
+  expect(screen.queryByText(/used for future syncs and URL inspections/)).toBeNull()
+  expect(screen.getByRole('button', { name: /used for future syncs and URL inspections/ })).not.toBeNull()
+  const heading = screen.getByRole('heading', { name: 'Pick the Search Console property' })
+  expect(heading.textContent?.trim()).toBe('Pick the Search Console property')
+})
+
+test('the connect-state line stays inline, asserted in the state that renders it', async () => {
+  // Onboarding states are exempt from the tooltip rule: this line is the only
+  // content of the not-yet-connected card, and the reader needs it where they
+  // are looking. It renders ONLY with no connection AND no configured OAuth
+  // app, so a connected fixture cannot tell "kept inline" from "not rendered".
+  renderSection({ connected: false, googleConfigured: false })
+  await waitFor(() => expect(screen.queryByText('Domain authorization')).not.toBeNull())
+
+  expect(screen.getByText(/shared across all projects/)).not.toBeNull()
+  expect(screen.queryByRole('button', { name: /shared across all projects/ })).toBeNull()
+})

--- a/apps/web/test/gsc-performance-chart.test.tsx
+++ b/apps/web/test/gsc-performance-chart.test.tsx
@@ -273,33 +273,7 @@ test('plots one row per calendar day, so a quiet gap is not compressed', async (
   expect(within(group).getAllByRole('button')).toHaveLength(4)
 })
 
-test('explanatory copy lives on headings, not as body prose', async () => {
-  // The repo rule: "if a sentence explains or justifies rather than labels or
-  // names, it goes in a tooltip." These four explained; each is now the
-  // accessible name of a heading trigger instead of a paragraph on the page.
-  renderSection()
-  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
-
-  // The property-picker heading only renders when no property is selected yet,
-  // which this fixture is past, so its tooltip is not asserted here.
-  for (const phrase of [
-    /match case-insensitive substrings/,
-    /Indexing API is intended for eligible JobPosting/,
-    /asks Google to refetch these sitemaps/,
-  ]) {
-    expect(screen.queryByText(phrase), `${phrase} should not be body copy`).toBeNull()
-    expect(screen.getByRole('button', { name: phrase })).not.toBeNull()
-  }
-})
-
-test('keeps the copy the rule exempts inline', async () => {
-  // Not everything short is tooltip material. An onboarding state must
-  // instruct where the reader is looking, and a metric value is a value.
-  renderSection()
-  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
-  // The connect-state line is the only content of that state; burying it in a
-  // tooltip would make setup worse, which is what the carve-out is for.
-  expect(screen.queryByRole('button', { name: /shared across all projects/ })).toBeNull()
-  // And the picker's explanation is not body prose anywhere in this render.
-  expect(screen.queryByText(/used for future syncs and URL inspections/)).toBeNull()
-})
+// Where the rest of the section's explanatory copy lives is asserted in
+// `gsc-copy-placement.test.tsx`, which arranges the three render states those
+// paragraphs actually appeared in. This suite keeps only the filter
+// explanation, which belongs to the chart's own filter row.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.163.0",
+  "version": "4.163.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.163.0",
+  "version": "4.163.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.163.0",
+  "version": "4.163.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.163.0",
+  "version": "4.163.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.163.0",
+  "version": "4.163.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## What

Three of the tests #997 shipped to guard its copy move were vacuous, and #998's tooltip-placement rule was violated by the same code. Both fixed here.

### The vacuous tests

#997 moved four explanatory paragraphs out of the GSC section and onto their headings. Three of its assertions targeted a render state the copy never appeared in, so they passed identically before and after the change:

| Assertion | Why it could not fail |
|---|---|
| property picker's explanation is not body prose | the card is inside a **collapsed** "Setup & Configuration" disclosure the fixture never opened |
| connect-state line stayed inline | that line renders only with **no** connection AND **no** configured OAuth app; the fixture had both |
| sitemap paragraph is gone | the sentence was reworded on the way into the tooltip (`Google is asked to refetch` → `Submitting asks Google to refetch`), so a negative anchored on the new phrasing was already null on `main` |

A fourth entry duplicated an assertion an adjacent test already made.

The assertions now live in `apps/web/test/gsc-copy-placement.test.tsx`, which arranges each state — clicks the disclosure open and proves it started closed, supplies a disconnected/unconfigured fixture — and anchors negatives on wording common to the old paragraph and the new tooltip.

**Verified by mutation.** Each of the four was checked by reverting the thing it guards:

| Mutation | Tests failed |
|---|---|
| sitemap paragraph restored, original pre-#997 wording | 1 (`explanatory copy is a tooltip trigger`) |
| Index coverage tooltip nested back inside its `h3` | 1 (`each tooltip is a SIBLING of its heading`) |
| connect-state line turned into a tooltip | 1 (`the connect-state line stays inline`) |
| property-picker paragraph restored | 1 (`the property picker moved its explanation too`) |

Each mutation kills exactly the test that claims to guard it, and no others.

### The tooltip nesting

#998 documented the rule in `apps/web/AGENTS.md`: an `InfoTooltip` is a **sibling** of a heading, never a child, or its help text joins the heading's accessible name and any `aria-labelledby` landmark pointing at it. All four of these tooltips were children of `<h3 className="flex items-center gap-1.5">`, so each heading read as its title plus a paragraph of help text.

They are now siblings inside a wrapper div carrying the flex classes, with a test asserting each heading's accessible name is the heading text exactly. The conversion also fixes the property-picker block's indentation, which sat 4 columns short of its surroundings.

## Verification

`pnpm verify` clean — 8542 tests across 656 files.