### PR TITLE
CI: shard Vitest suite across four runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,37 @@ jobs:
             tsbuildinfo-${{ runner.os }}-
       - run: pnpm run typecheck
 
+  test_shards:
+    name: test shard ${{ matrix.shard }}/4
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm run test --shard=${{ matrix.shard }}/4
+
   test:
+    name: test
+    needs: test_shards
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
-      - run: pnpm run test
+      - name: Verify all test shards succeeded
+        env:
+          SHARD_RESULT: ${{ needs.test_shards.result }}
+        run: |
+          if [ "$SHARD_RESULT" != "success" ]; then
+            echo "One or more test shards failed"
+            exit 1
+          fi
+          echo "All test shards passed"
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview

Split the full Vitest suite across four GitHub-hosted runners while preserving the existing `test` gate.

- Run deterministic Vitest shards with `pnpm run test --shard=i/4`
- Keep all shards running after one fails so diagnostics are complete
- Aggregate shard results into the existing `test` job consumed by `validate`

## Result

The live GitHub Actions experiment passed completely.

- Previous PR #999 test job: ~10m30s (`vitest`: 10m18s)
- Sharded `test` gate: 3m56s
- Entire CI workflow: 4m08s
- Vitest shard steps: 2m20s, 2m38s, 3m30s, 2m36s

This cuts the test gate by about 62% and confirms that all four matrix jobs run concurrently on separate hosted runners.

## Validation

- GitHub Actions: all four shards, aggregate `test`, and `validate` passed
- Four-shard local run: 656/656 files, 8,562/8,562 tests passed in 92s
- Three-shard local comparison: 656/656 files, 8,562/8,562 tests passed in 124s
- Workflow YAML parses successfully
- `git diff --check` passes