### PR TITLE
test(mcp): budget the stdio handshake for suite-level CPU contention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.165.0",
+  "version": "4.165.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.165.0",
+  "version": "4.165.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -12,44 +12,56 @@ const repoRoot = path.resolve(packageRoot, '..', '..')
 const tsxCli = path.join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs')
 const mcpCli = path.join(packageRoot, 'src', 'mcp', 'cli.ts')
 
+/**
+ * Budget for spawn through the `initialize` response, which is where the two
+ * subprocess cases below spend nearly all of their time. Each one starts
+ * `node tsx src/mcp/cli.ts`, and that child transpiles the whole CLI import
+ * graph — the API client plus the 188-entry tool registry — before it can write
+ * its first frame. Measured: ~1.2-1.9s of handshake on an idle 12-core box,
+ * ~10s at 7x CPU oversubscription, against tens of milliseconds for every
+ * assertion that follows.
+ *
+ * That fits inside vitest's 5000ms default only while the machine is idle. Run
+ * as part of `pnpm run test` (658 files, one worker per core) both cases timed
+ * out in roughly 1 run in 3 — always at the handshake, never with an assertion
+ * diff, which is why the failures read as "no output" rather than as a bug.
+ *
+ * So the ceiling is raised where the cost actually is. There is no sleep to
+ * tune: `startMcpClient` waits on the `initialize` response itself, and this
+ * budget exists only so a child that never answers reports why.
+ */
+const HANDSHAKE_TIMEOUT_MS = 30_000
+
+/**
+ * Per-case ceiling. Deliberately above `HANDSHAKE_TIMEOUT_MS` so a subprocess
+ * that hangs loses the race to the handshake's own error — which names the
+ * phase and carries the child's stderr — instead of to vitest's generic "Test
+ * timed out" pointing at the `it()`.
+ */
+const SUBPROCESS_CASE_TIMEOUT_MS = 45_000
+
 describe('canonry-mcp stdio', () => {
   const clients: Client[] = []
   const servers: Array<{ close: () => Promise<void> }> = []
 
+  // Same contention applies to teardown: killing the child and awaiting its
+  // exit is fast, but not against the default 10s hook budget on a loaded box.
   afterEach(async () => {
     await Promise.all(clients.splice(0).map(client => client.close()))
     await Promise.all(servers.splice(0).map(server => server.close()))
-  })
+  }, HANDSHAKE_TIMEOUT_MS)
 
   it('initializes, lists tools, and calls stubbed read/write tools through stdio frames', async () => {
     const api = await startStubApi()
     servers.push(api)
 
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-mcp-stdio-'))
-    fs.writeFileSync(path.join(configDir, 'config.yaml'), [
-      `apiUrl: ${api.origin}`,
-      'database: /tmp/canonry-mcp-stdio.sqlite',
-      'apiKey: cnry_test',
-      '',
-    ].join('\n'))
-
-    const stderrChunks: string[] = []
-    const transport = new StdioClientTransport({
-      command: process.execPath,
-      args: [tsxCli, mcpCli],
-      cwd: packageRoot,
-      env: {
-        ...stringEnv(),
-        CANONRY_CONFIG_DIR: configDir,
-        CANONRY_BASE_PATH: '',
-      },
-      stderr: 'pipe',
+    const { client, stderr } = await startMcpClient({
+      apiOrigin: api.origin,
+      configPrefix: 'canonry-mcp-stdio-',
+      database: '/tmp/canonry-mcp-stdio.sqlite',
+      clientName: 'canonry-mcp-test',
     })
-    transport.stderr?.on('data', chunk => stderrChunks.push(String(chunk)))
-
-    const client = new Client({ name: 'canonry-mcp-test', version: '0.0.0' })
     clients.push(client)
-    await client.connect(transport)
 
     const list = await client.listTools()
     expect(list.tools).toHaveLength(12)
@@ -133,8 +145,8 @@ describe('canonry-mcp stdio', () => {
     expect(trafficSync.isError).not.toBe(true)
     expect(jsonText(trafficSync)).toMatchObject({ runId: 'run-traffic-1', sourceId: 'src-1' })
 
-    expect(stderrChunks.join('')).toBe('')
-  })
+    expect(stderr()).toBe('')
+  }, SUBPROCESS_CASE_TIMEOUT_MS)
 
   it('docs/mcp.md documents the same pipelining error wording the SDK emits', () => {
     const docsPath = path.resolve(repoRoot, 'docs', 'mcp.md')
@@ -146,29 +158,14 @@ describe('canonry-mcp stdio', () => {
     const api = await startStubApi()
     servers.push(api)
 
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-mcp-eager-'))
-    fs.writeFileSync(path.join(configDir, 'config.yaml'), [
-      `apiUrl: ${api.origin}`,
-      'database: /tmp/canonry-mcp-eager.sqlite',
-      'apiKey: cnry_test',
-      '',
-    ].join('\n'))
-
-    const transport = new StdioClientTransport({
-      command: process.execPath,
-      args: [tsxCli, mcpCli, '--eager'],
-      cwd: packageRoot,
-      env: {
-        ...stringEnv(),
-        CANONRY_CONFIG_DIR: configDir,
-        CANONRY_BASE_PATH: '',
-      },
-      stderr: 'pipe',
+    const { client } = await startMcpClient({
+      apiOrigin: api.origin,
+      configPrefix: 'canonry-mcp-eager-',
+      database: '/tmp/canonry-mcp-eager.sqlite',
+      clientName: 'canonry-mcp-eager-test',
+      args: ['--eager'],
     })
-
-    const client = new Client({ name: 'canonry-mcp-eager-test', version: '0.0.0' })
     clients.push(client)
-    await client.connect(transport)
 
     const list = await client.listTools()
     // 188 API tools + 2 meta-tools (canonry_help, canonry_load_toolkit).
@@ -289,8 +286,80 @@ describe('canonry-mcp stdio', () => {
         details: { httpStatus: 412 },
       },
     })
-  })
+  }, SUBPROCESS_CASE_TIMEOUT_MS)
 })
+
+/**
+ * Spawn the `canonry-mcp` stdio adapter and return a client that has completed
+ * the MCP handshake.
+ *
+ * The wait is on the `initialize` response — `client.connect()` resolves on that
+ * frame, so readiness is observed rather than guessed at with a sleep. The race
+ * against `HANDSHAKE_TIMEOUT_MS` only bounds a child that never answers, and
+ * reports the phase plus whatever the child wrote to stderr; without it, a
+ * subprocess that dies during startup surfaces as a bare protocol error with the
+ * reason discarded.
+ */
+async function startMcpClient(options: {
+  apiOrigin: string
+  configPrefix: string
+  database: string
+  clientName: string
+  args?: readonly string[]
+}): Promise<{ client: Client; stderr: () => string }> {
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), options.configPrefix))
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), [
+    `apiUrl: ${options.apiOrigin}`,
+    `database: ${options.database}`,
+    'apiKey: cnry_test',
+    '',
+  ].join('\n'))
+
+  const stderrChunks: string[] = []
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [tsxCli, mcpCli, ...(options.args ?? [])],
+    cwd: packageRoot,
+    env: {
+      ...stringEnv(),
+      CANONRY_CONFIG_DIR: configDir,
+      CANONRY_BASE_PATH: '',
+    },
+    stderr: 'pipe',
+  })
+  // Drain stderr on both paths: it is an assertion in the first case, the only
+  // diagnostic in a failed handshake, and an unread pipe the child can block on.
+  transport.stderr?.on('data', chunk => stderrChunks.push(String(chunk)))
+
+  const client = new Client({ name: options.clientName, version: '0.0.0' })
+  let timer: NodeJS.Timeout | undefined
+  try {
+    await Promise.race([
+      client.connect(transport),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          const stderr = stderrChunks.join('').trim()
+          reject(new Error(
+            `canonry-mcp did not answer initialize within ${HANDSHAKE_TIMEOUT_MS}ms`
+            + `${stderr ? `; stderr: ${stderr}` : ' (no stderr output)'}`,
+          ))
+        }, HANDSHAKE_TIMEOUT_MS)
+      }),
+    ])
+  } catch (error) {
+    // The caller never received the client, so nothing else can reap the child.
+    await client.close().catch(() => {})
+    const stderr = stderrChunks.join('').trim()
+    if (error instanceof Error && stderr && !error.message.includes(stderr)) {
+      error.message = `${error.message}; canonry-mcp stderr: ${stderr}`
+    }
+    throw error
+  } finally {
+    clearTimeout(timer)
+  }
+
+  return { client, stderr: () => stderrChunks.join('') }
+}
 
 async function startStubApi(): Promise<{ origin: string; close: () => Promise<void> }> {
   const server = createServer(handleRequest)

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.165.0",
+  "version": "4.165.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.165.0",
+  "version": "4.165.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.165.0",
+  "version": "4.165.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Problem

`packages/canonry/test/mcp-stdio.test.ts` fails roughly 1 run in 3 under the full
workspace suite — always the same two subprocess cases, always with no assertion
diff, and never when the file is run alone:

- `initializes, lists tools, and calls stubbed read/write tools through stdio frames`
- `loads every toolkit at startup when --eager is passed`

## Root cause

Reproduced by running the file under CPU oversubscription, which yields the exact
reported failure:

```
× initializes, lists tools, and calls stubbed read/write tools through stdio frames  → Test timed out in 5000ms.
× loads every toolkit at startup when --eager is passed                              → Test timed out in 5000ms.
```

Instrumenting the phases shows the cost is entirely subprocess startup. Both cases
spawn `node tsx src/mcp/cli.ts`, and that child transpiles the whole CLI import
graph — the API client plus the tool registry — before it writes its first frame:

| phase | idle (12 cores) | 7× oversubscribed |
|---|---|---|
| `connect()` — spawn → `initialize` response | 1.2–1.9s | ~10s |
| every assertion after it | 10–70ms | 60–415ms |

That fits vitest's 5000ms default only while the machine is idle. The failures were
the default timeout firing during startup — not a race, and not a bad assertion.

## Fix

The wait was already correct: `client.connect()` resolves on the `initialize`
response, so there was no sleep or fixed delay to replace. The budget was the
problem, so it is raised where the cost actually is.

- **Per-case timeouts** on the two subprocess cases only. The filesystem-only docs
  case keeps the strict 5s default. `afterEach` gets the same treatment — teardown
  has identical exposure against the default 10s hook budget.
- **The handshake is bounded separately**, below the case timeout, so a child that
  never answers reports the phase it died in instead of losing the race to vitest's
  generic "Test timed out".
- **Stderr is drained and attached to handshake failures.** The eager case
  previously piped stderr with no reader, so a subprocess dying at startup surfaced
  as a bare `Connection closed` with the reason discarded.
- Duplicated spawn boilerplate folds into one `startMcpClient` helper as it moves.

Test-only change; no runtime behavior is touched.

## Verification

- Reproduced the original failure under load, then confirmed the same load now
  passes (15.6s and 14.3s against the 45s budget — 3× headroom at a contention
  level well past what the real suite generates).
- Exercised both new failure paths rather than assuming they work, by forcing a
  crashing child and a 1ms handshake budget:
  ```
  McpError: MCP error -32000: Connection closed; canonry-mcp stderr: node:internal/modules/run_main:107 …
  Error: canonry-mcp did not answer initialize within 1ms (no stderr output)
  ```
- Full workspace suite run 5× consecutively on the pre-rebase branch, green each
  time (656 files / 8542 tests).
- `pnpm verify` green on this branch: `gen:check`, `plugin:check`, `typecheck`,
  `lint` (0 errors), `test` (660 files / 8602 tests).

## Version

`4.165.1` — patch, per the >100-changed-line rule (165). Chosen against
`origin/main` tip (`4.165.0`) and npm latest (`4.164.1`) at branch time, per the
version-race note in `AGENTS.md`; `pnpm plugin:sync` propagated it to the three
plugin manifests. **Worth re-checking immediately before merge** — that guidance
exists because the correct number changes as `main` moves.

## Note

The comment above the eager case's tool-count assertion still reads
`188 API tools + 2 meta-tools`, which no longer adds up to the current `191`. That
is pre-existing on `main` (#1009 added a tool) and not a line this change touches,
so it was left out rather than folded in as unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
