### PR TITLE
docs(traffic): Cloudflare setup guide and route sizing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Canonry is API-first. The API is the source of truth, the CLI is the standard op
 | [`bing-webmaster-setup.md`](bing-webmaster-setup.md) | current | operators | Bing Webmaster Tools API key setup and usage |
 | [`google-analytics-setup.md`](google-analytics-setup.md) | current | operators | Google Analytics 4 service account setup and usage |
 | [`wordpress-setup.md`](wordpress-setup.md) | current | operators | WordPress REST + Application Password setup, staging diffs, and manual handoff workflows |
+| [`cloudflare-traffic-setup.md`](cloudflare-traffic-setup.md) | current | operators | Cloudflare Queue-pull server-side traffic: token scopes, queue + HTTP pull consumer, request-volume sizing, asset-exclusion and fail-open routes |
 | [`server-side-traffic.md`](../skills/canonry/references/server-side-traffic.md) | current | operators | Cloudflare direct-push or Queue-pull and Cloud Run, WordPress, and Vercel pull-source setup, smoke tests, rollback, and troubleshooting |
 
 ## Implementation Records

--- a/docs/cloudflare-traffic-setup.md
+++ b/docs/cloudflare-traffic-setup.md
@@ -1,0 +1,243 @@
+# Cloudflare Server-Side Traffic Setup
+
+Canonry runs a small Worker on your zone to capture **server-side** evidence that AI crawlers and AI referrals reached your site. This is the only source that sees a crawler at all: a bot that never executes JavaScript is invisible to Google Analytics, so without this you are guessing about whether GPTBot, ClaudeBot or PerplexityBot actually fetch your pages.
+
+Two delivery modes exist. This guide covers **Queue pull**, which keeps the API token server-side in Canonry so your zone holds no Canonry credential. For direct push, see `skills/canonry/references/server-side-traffic.md`.
+
+---
+
+## Before you start: size the request volume
+
+**Do this first.** A Worker route runs for *every* matching request, and the Worker's filter does not reduce invocations — it only reduces what gets queued. On a JavaScript app a catch-all route will exceed the Workers Free allowance (100,000 requests/day, account-wide) several times over.
+
+The arithmetic:
+
+```
+sessions/day  ×  pageviews/session  ×  same-origin requests/pageview
+```
+
+Only **same-origin** requests count. Assets on a third-party CDN never reach your zone, so they never invoke the Worker.
+
+Count same-origin requests on one real page:
+
+```bash
+curl -s https://example.com/ \
+  | grep -oE '(src|href)="/[^"]+\.(js|css|woff2?|png|jpg|svg)"' \
+  | wc -l
+```
+
+A worked example from a real Nuxt storefront on Shopify:
+
+| | |
+|---|---|
+| Sessions/day (GA4, 90d average) | 7,238 |
+| Same-origin assets per page | 27 (all `/_nuxt/*`) |
+| Images | 0 — served from `cdn.shopify.com`, never hit the zone |
+| **Projected** | **~200k–400k/day** |
+| Workers Free allowance | 100,000/day |
+
+Measured after deploy: **958 invocations in 4 minutes**, about 345k/day. The estimate was right, and the free allowance would have been exhausted in roughly seven hours.
+
+You have three options:
+
+1. **Exclude static assets from the route** (below). On the example above this removed 27 of every 28 requests and brought it to ~14,500/day. No data is lost: crawlers request pages, not JS bundles.
+2. **Workers Paid**, $5/month for 10M requests.
+3. Accept the cap with **Fail open** set, and lose data once it trips.
+
+Option 1 is usually right.
+
+---
+
+## Step 1 — Create an API token
+
+`https://dash.cloudflare.com/profile/api-tokens` → **Create Token** → **Create Custom Token**.
+
+| Scope | Permission | Level |
+|---|---|---|
+| Account | Queues | Edit |
+| Account | Workers Scripts | Edit |
+| Zone | Workers Routes | Edit |
+
+Account Resources: include the target account. Zone Resources: include the target zone.
+
+Set the first dropdown in each row to **Account** or **Zone** before its permissions appear in the second — zone permissions stay hidden until a Zone row exists.
+
+Store it outside your shell history:
+
+```bash
+echo 'TOKEN' > ~/.canonry/cf-token && chmod 600 ~/.canonry/cf-token
+```
+
+Editing a token's permissions later does **not** change its value, so nothing needs re-pasting. Changes take up to ~30 seconds to propagate.
+
+---
+
+## Step 2 — Create the Queue
+
+```bash
+export CLOUDFLARE_API_TOKEN=$(cat ~/.canonry/cf-token)
+export CLOUDFLARE_ACCOUNT_ID=<account-id>
+
+npx wrangler queues create example-events
+```
+
+Note the returned `queue_id`.
+
+Then enable HTTP pull. Canonry pulls over the Queues HTTP API, which is not the default consumer type:
+
+```bash
+npx wrangler queues consumer http add example-events
+```
+
+Retention defaults to 345600 seconds (4 days). Record whatever the queue actually reports and pass the same number to Canonry — it is used for configuration-drift checks, so a value that disagrees with Cloudflare is worse than no value.
+
+```bash
+curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/queues/<queue-id>" \
+  | jq '.result.settings.message_retention_period'
+```
+
+---
+
+## Step 3 — Connect the source
+
+```bash
+canonry traffic connect cloudflare <project> --delivery-mode queue-pull \
+  --zone-id <zone-id> \
+  --account-id <account-id> \
+  --queue-id <queue-id> \
+  --queue-name example-events \
+  --api-token-file ~/.canonry/cf-token \
+  --retention-seconds 345600
+```
+
+This writes `worker.js` and `wrangler.toml` into `./canonry-cloudflare-<project>/`. Both are secret-free — the Worker gets only a Queue producer binding, and the API token stays in `~/.canonry/config.yaml`. Confirm before deploying:
+
+```bash
+grep -iE 'bearer|secret|token|hmac' canonry-cloudflare-<project>/worker.js
+```
+
+The only matches should be the AI-referrer matching list.
+
+---
+
+## Step 4 — Deploy the Worker
+
+```bash
+cd canonry-cloudflare-<project>
+npx wrangler deploy
+```
+
+Deploying does **not** attach a route. The Worker is inert until Step 5.
+
+---
+
+## Step 5 — Routes
+
+Two routes are needed: one that runs the Worker, one that keeps it off your static assets.
+
+### The trap
+
+The Worker's own **Domains and Routes** tab can only attach routes **to that Worker**. There is no way to create a route with no Worker from that screen, so adding your asset path there does the opposite of what you want — it routes assets *into* the Worker and doubles the load.
+
+Asset exclusion is a **zone-level** operation: `dash.cloudflare.com` → your zone → **Workers Routes**, or the API below.
+
+### Via API
+
+```bash
+ZONE=<zone-id>
+TOKEN=$(cat ~/.canonry/cf-token)
+
+# List what exists
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/workers/routes" | jq '.result[]'
+
+# Catch-all -> the Worker, with fail-open ON
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  --data '{"pattern":"example.com/*","script":"canonry-traffic-<source-id>","request_limit_fail_open":true}' \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/workers/routes"
+
+# Assets -> NO worker. Omitting "script" is what disables it.
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  --data '{"pattern":"example.com/_nuxt/*"}' \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/workers/routes"
+```
+
+Cloudflare applies the **most specific** matching route, so the asset route wins on those paths.
+
+Common asset prefixes: `/_nuxt/*` (Nuxt), `/_next/*` (Next.js), `/assets/*`, `/static/*`, `/build/*`.
+
+### Fail open is not the default
+
+`request_limit_fail_open` defaults to **`false`**, and it is set **per route**. Left off, a Worker error or an exhausted request allowance returns 5xx for every request on that route — the entire site, since this is a catch-all.
+
+Verify explicitly:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/workers/routes" \
+  | jq '.result[] | {pattern, script, request_limit_fail_open}'
+```
+
+---
+
+## Step 6 — Activate and schedule
+
+```bash
+canonry traffic activate <project> --source <source-id>
+canonry schedule set <project> --kind traffic-sync --cron "*/15 * * * *" --source <source-id>
+```
+
+Connecting a source syncs it once; it does not schedule it. Without the schedule the watermark drifts and a later pull becomes unbounded.
+
+**Use a 15-minute cadence, not daily.** Retention bounds how much a failed sync can recover: at `*/15` a sync can fail repeatedly and still catch up inside a 4-day window; at daily, one failure risks the gap. Cadence costs no extra queue operations, since operations scale with message count rather than pull count.
+
+---
+
+## Step 7 — Verify
+
+```bash
+canonry traffic sync <project> --source <source-id>
+canonry doctor --project <project> --check 'traffic.*'
+```
+
+A healthy first sync:
+
+```
+Pulled events:    42
+Crawler hits:     38  (12 hourly buckets)
+AI referral hits: 0
+Unknown hits:     4
+```
+
+`Unknown` is ordinary human traffic. `Crawler hits` is the signal this integration exists for.
+
+Confirm the site is unaffected:
+
+```bash
+for p in / /about /some/product; do
+  curl -s -o /dev/null -w "$p %{http_code}\n" "https://example.com$p"
+done
+```
+
+`traffic.source.recent-data` fails and `traffic.source.sync-lag` warns until the first successful sync carries data. Both clear on their own.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Authentication error` on a Workers API call | Token lacks that permission, or the edit has not propagated yet. Wait ~30s and retry. |
+| Route added but no events | Route attached to the Worker's Domains tab only, or the Worker was never deployed. |
+| Site returns 5xx after attaching | `request_limit_fail_open` is `false`. Set it to `true`. |
+| Worker invocations far above expectations | No asset-exclusion route. Check for `/_nuxt/*`, `/_next/*`, `/assets/*`. |
+| `queues consumer http add` fails | Token needs Queues: Edit at account scope. |
+| Events pulled but all `Unknown` | Normal. Crawler and AI-referral classification needs actual bot traffic. |
+
+---
+
+## See also
+
+- `skills/canonry/references/server-side-traffic.md` — adapter internals, direct-push mode, classification rules
+- `docs/data-model.md` — where rollups land

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.165.1",
+  "version": "4.165.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.165.1",
+  "version": "4.165.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.165.1",
+  "version": "4.165.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.165.1",
+  "version": "4.165.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.165.1",
+  "version": "4.165.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/skills/canonry/references/server-side-traffic.md
+++ b/plugins/canonry/skills/canonry/references/server-side-traffic.md
@@ -230,9 +230,19 @@ flowchart LR
    the site route; Queue pull needs a pre-created Queue and HTTP pull consumer.
 3. Authenticate Wrangler with the Cloudflare account that owns the zone.
 4. Inspect existing Worker routes for the exact canonical hostname.
-5. Run the local Cloudflare connect command with `--deploy`.
-6. Attach the printed route in Cloudflare and set it to **Fail open**.
-7. Send the smoke requests and run the Canonry doctor.
+5. **Size the request volume** (see below) and decide whether an
+   asset-exclusion route is needed.
+6. Run the local Cloudflare connect command with `--deploy`.
+7. Attach the printed route in Cloudflare and set it to **Fail open** — it
+   defaults to OFF.
+8. Attach the asset-exclusion route if step 5 called for one.
+9. Activate the source and set a `traffic-sync` schedule. Connect syncs once
+   and does not schedule; use `*/15 * * * *`, not daily, so a failed sync can
+   still recover inside the queue's retention window.
+10. Send the smoke requests and run the Canonry doctor.
+
+A full operator walkthrough with copy-paste commands lives in
+`docs/cloudflare-traffic-setup.md`.
 
 ### Current support boundary
 
@@ -316,6 +326,68 @@ a fragment to this URL.
    Worker instead of attaching a second Worker.
 10. Review the account request volume. A route invokes the Worker for every
    matching request. The filter does not reduce Worker invocations.
+
+### Sizing the route before you attach it
+
+"Review the account request volume" is not a judgement call. Compute it:
+
+```
+sessions/day  x  pageviews/session  x  SAME-ORIGIN requests/pageview
+```
+
+Only same-origin requests count. Assets on a third-party CDN never reach the
+zone and never invoke the Worker. Count them on one real page:
+
+```bash
+curl -s https://<host>/ \
+  | grep -oE '(src|href)="/[^"]+\.(js|css|woff2?|png|jpg|svg)"' | wc -l
+```
+
+A JavaScript app will exceed the Workers Free allowance (100,000 requests/day,
+account-wide) by a wide margin, because the HTML is one request and the bundle
+is dozens. Measured on a Nuxt storefront: 7,238 sessions/day and 27 same-origin
+`/_nuxt/*` assets per page projected 200k-400k/day, and the deployed Worker
+logged 958 invocations in 4 minutes (~345k/day). Images were on
+`cdn.shopify.com` and cost nothing.
+
+Attach an asset-exclusion route unless the site is server-rendered with few
+same-origin assets, or the account is on Workers Paid.
+
+### Excluding static assets from the route
+
+A route with NO script disables Workers on that path, and Cloudflare applies
+the most specific match. This removes the bundle without losing any crawler
+evidence, because crawlers request pages, not JS chunks.
+
+```bash
+# assets -> no worker. Omitting "script" is what disables it.
+curl -s -X POST -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+  --data '{"pattern":"<host>/_nuxt/*"}' \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/workers/routes"
+```
+
+Prefixes by framework: `/_nuxt/*` Nuxt, `/_next/*` Next.js, plus `/assets/*`,
+`/static/*`, `/build/*`.
+
+**The Worker's own "Domains and Routes" tab cannot do this.** That screen only
+attaches routes TO that Worker, so adding the asset path there routes assets
+INTO the Worker and doubles the load. Asset exclusion is zone-level: the zone's
+Workers Routes page, or the API above.
+
+### Fail open defaults to OFF
+
+`request_limit_fail_open` is per route and defaults to `false`. Left off, a
+Worker error or an exhausted request allowance returns 5xx for every request on
+that route, which on a catch-all is the whole site. Setting it is not optional
+and it is not the default, so verify rather than assume:
+
+```bash
+curl -s -H "Authorization: Bearer $CF_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/workers/routes" \
+  | jq '.result[] | {pattern, script, request_limit_fail_open}'
+```
+
+Both route operations need `Zone | Workers Routes | Edit` on the token.
 
 ```bash
 npm install -g wrangler@latest

--- a/skills/canonry/references/server-side-traffic.md
+++ b/skills/canonry/references/server-side-traffic.md
@@ -230,9 +230,19 @@ flowchart LR
    the site route; Queue pull needs a pre-created Queue and HTTP pull consumer.
 3. Authenticate Wrangler with the Cloudflare account that owns the zone.
 4. Inspect existing Worker routes for the exact canonical hostname.
-5. Run the local Cloudflare connect command with `--deploy`.
-6. Attach the printed route in Cloudflare and set it to **Fail open**.
-7. Send the smoke requests and run the Canonry doctor.
+5. **Size the request volume** (see below) and decide whether an
+   asset-exclusion route is needed.
+6. Run the local Cloudflare connect command with `--deploy`.
+7. Attach the printed route in Cloudflare and set it to **Fail open** — it
+   defaults to OFF.
+8. Attach the asset-exclusion route if step 5 called for one.
+9. Activate the source and set a `traffic-sync` schedule. Connect syncs once
+   and does not schedule; use `*/15 * * * *`, not daily, so a failed sync can
+   still recover inside the queue's retention window.
+10. Send the smoke requests and run the Canonry doctor.
+
+A full operator walkthrough with copy-paste commands lives in
+`docs/cloudflare-traffic-setup.md`.
 
 ### Current support boundary
 
@@ -316,6 +326,68 @@ a fragment to this URL.
    Worker instead of attaching a second Worker.
 10. Review the account request volume. A route invokes the Worker for every
    matching request. The filter does not reduce Worker invocations.
+
+### Sizing the route before you attach it
+
+"Review the account request volume" is not a judgement call. Compute it:
+
+```
+sessions/day  x  pageviews/session  x  SAME-ORIGIN requests/pageview
+```
+
+Only same-origin requests count. Assets on a third-party CDN never reach the
+zone and never invoke the Worker. Count them on one real page:
+
+```bash
+curl -s https://<host>/ \
+  | grep -oE '(src|href)="/[^"]+\.(js|css|woff2?|png|jpg|svg)"' | wc -l
+```
+
+A JavaScript app will exceed the Workers Free allowance (100,000 requests/day,
+account-wide) by a wide margin, because the HTML is one request and the bundle
+is dozens. Measured on a Nuxt storefront: 7,238 sessions/day and 27 same-origin
+`/_nuxt/*` assets per page projected 200k-400k/day, and the deployed Worker
+logged 958 invocations in 4 minutes (~345k/day). Images were on
+`cdn.shopify.com` and cost nothing.
+
+Attach an asset-exclusion route unless the site is server-rendered with few
+same-origin assets, or the account is on Workers Paid.
+
+### Excluding static assets from the route
+
+A route with NO script disables Workers on that path, and Cloudflare applies
+the most specific match. This removes the bundle without losing any crawler
+evidence, because crawlers request pages, not JS chunks.
+
+```bash
+# assets -> no worker. Omitting "script" is what disables it.
+curl -s -X POST -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+  --data '{"pattern":"<host>/_nuxt/*"}' \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/workers/routes"
+```
+
+Prefixes by framework: `/_nuxt/*` Nuxt, `/_next/*` Next.js, plus `/assets/*`,
+`/static/*`, `/build/*`.
+
+**The Worker's own "Domains and Routes" tab cannot do this.** That screen only
+attaches routes TO that Worker, so adding the asset path there routes assets
+INTO the Worker and doubles the load. Asset exclusion is zone-level: the zone's
+Workers Routes page, or the API above.
+
+### Fail open defaults to OFF
+
+`request_limit_fail_open` is per route and defaults to `false`. Left off, a
+Worker error or an exhausted request allowance returns 5xx for every request on
+that route, which on a catch-all is the whole site. Setting it is not optional
+and it is not the default, so verify rather than assume:
+
+```bash
+curl -s -H "Authorization: Bearer $CF_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/workers/routes" \
+  | jq '.result[] | {pattern, script, request_limit_fail_open}'
+```
+
+Both route operations need `Zone | Workers Routes | Edit` on the token.
 
 ```bash
 npm install -g wrangler@latest


### PR DESCRIPTION
There was no Cloudflare setup doc at all, while Bing, GA4, GSC and WordPress each have one. The skill covered the adapter internals but left three things implicit that cost a live client a round trip each.

## Changes

- **`docs/cloudflare-traffic-setup.md`** — full Queue-pull walkthrough: token scopes, queue + HTTP pull consumer, connect, deploy, routes, activate, schedule, verify, troubleshooting table.
- **Request-volume sizing as arithmetic**, replacing "review the account request volume": `sessions × pageviews × SAME-ORIGIN requests/page`. A JavaScript app blows the 100k/day free allowance because the HTML is one request and the bundle is dozens, while third-party CDN assets cost nothing. Worked example from a real Nuxt storefront with the measured rate beside the estimate.
- **The asset-exclusion route** — a route with no `script`, most-specific-wins — plus the trap that the Worker's own *Domains and Routes* tab cannot create one. Adding the asset path there routes assets **into** the Worker and doubles the load.
- **`request_limit_fail_open` defaults to `false`** and is per route. The skill said to set Fail open but not that it is off by default, so a catch-all can 5xx the entire site on a Worker error or an exhausted allowance.
- Records why `traffic-sync` is 15 minutes rather than daily: a failed sync can still recover inside the queue's retention window, at no extra queue-operation cost.

## Numbers

All measured, not estimated:

| | |
|---|---|
| Sessions/day | 7,238 |
| Same-origin assets/page | 27 (`/_nuxt/*`) |
| Projected | 200k–400k/day |
| **Measured after deploy** | **958 invocations / 4 min ≈ 345k/day** |
| Free allowance | 100k/day |
| After asset exclusion | ~14.5k/day |

## Notes

Version bumped to **4.165.2**. Although the diff is documentation, the **native-plugin exception** applies: a change to `skills/canonry/` must bump Canonry and all three plugin manifests even when small, because clients discover updates by manifest version. `pnpm plugin:sync` run; `plugin:check` clean. Added to the `docs/README.md` map alongside the other setup guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)