### PR TITLE
Show GSC trend changes as percentages

### DIFF
--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -23,7 +23,7 @@ import {
   formatChartDateTick,
   type TrendChartSeries,
 } from '../shared/ChartPrimitives.js'
-import { calendarDateRange } from '@ainyc/canonry-contracts'
+import { calendarDateRange, relativeChangeRatio } from '@ainyc/canonry-contracts'
 import { formatTimestamp, formatBooleanState, SearchMetric, SEARCH_METRIC_LABELS } from '../../lib/format-helpers.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
@@ -112,6 +112,60 @@ const GSC_CHART_METRICS = [
 type GscChartMetric = (typeof GSC_CHART_METRICS)[number]['key']
 const COVERAGE_PAGE_SIZE = 25
 const GOOGLE_OAUTH_COMPLETE_MESSAGE = 'canonry:google-oauth-complete'
+
+const GSC_TREND_PERCENT_FORMATTER = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 1,
+})
+
+/**
+ * Express the fitted line's start-to-end movement relative to its start.
+ *
+ * The fit is unconstrained, so a non-negative metric can still produce a
+ * zero or negative endpoint. That is not a meaningful percentage baseline;
+ * report the absence instead of dividing by zero or presenting a synthetic
+ * percentage. Position reverses only the desirability arrow, not the math.
+ */
+function formatGscTrendChange(
+  trend: {
+    slope: number
+    start: number
+    end: number
+    startIndex?: number
+    endIndex?: number
+  },
+  inverted: boolean | undefined,
+  fallbackDays: number,
+): string {
+  const { startIndex, endIndex } = trend
+  const spanDays = startIndex !== undefined
+    && endIndex !== undefined
+    && Number.isInteger(startIndex)
+    && Number.isInteger(endIndex)
+    && startIndex >= 0
+    && endIndex >= startIndex
+    ? endIndex - startIndex + 1
+    : fallbackDays
+  if (
+    !Number.isFinite(trend.start)
+    || !Number.isFinite(trend.end)
+    || trend.start <= 0
+    || trend.end < 0
+  ) {
+    return '— no percentage baseline'
+  }
+  if (trend.slope === 0) return `→ 0% over ${spanDays}d`
+
+  const ratio = relativeChangeRatio(trend.end, trend.start)
+  if (ratio === null) return '— no percentage baseline'
+  const percent = Math.abs(ratio * 100)
+  // The fit preserves tiny slopes, but separately rounded endpoints can be
+  // equal at six significant figures. A real non-zero trend must not read 0%.
+  const formatted = percent < 0.1
+    ? '<0.1%'
+    : `${GSC_TREND_PERCENT_FORMATTER.format(percent)}%`
+  const improving = inverted ? trend.slope < 0 : trend.slope > 0
+  return `${improving ? '↑' : '↓'} ${formatted} over ${spanDays}d`
+}
 
 function sitemapDiscoveredUrlCount(sitemap: ApiGscSitemap): number {
   return sitemap.contents?.reduce((total, content) => total + Number(content.submitted || 0), 0) ?? 0
@@ -1059,7 +1113,7 @@ export function GscSection({
                     <p className="eyebrow eyebrow-soft">Performance</p>
                     <div className="flex items-center gap-1.5">
                       <h3>Search performance</h3>
-                      <InfoTooltip text={`Click any day to filter the table below to that date. Query and page filters match case-insensitive substrings and run on Apply filters. Filtering and sorting examine up to ${EXPANDED_PERFORMANCE_LIMIT.toLocaleString()} matching rows while the table shows ${DEFAULT_TABLE_PAGE_SIZE} per page.`} />
+                      <InfoTooltip text={`Tile percentages show the fitted trend's relative change from its first measured day to its last. Click any day to filter the table below to that date. Query and page filters match case-insensitive substrings and run on Apply filters. Filtering and sorting examine up to ${EXPANDED_PERFORMANCE_LIMIT.toLocaleString()} matching rows while the table shows ${DEFAULT_TABLE_PAGE_SIZE} per page.`} />
                     </div>
                     {/* The window ends where Google's data ends, not today.
                         Naming the real range is what stops a lagging tail
@@ -1181,9 +1235,7 @@ export function GscSection({
                                 <span className="block text-[11px] tabular-nums text-muted">
                                   {/* Position improves downward, so the arrow
                                       tracks BETTER/WORSE, not up/down. */}
-                                  {trend.slope === 0
-                                    ? '→ flat'
-                                    : `${(m.inverted ? trend.slope < 0 : trend.slope > 0) ? '↑' : '↓'} ${m.format(Math.abs(trend.end - trend.start))} over ${totals.days}d`}
+                                  {formatGscTrendChange(trend, m.inverted, totals.days)}
                                 </span>
                               )}
                             </button>

--- a/apps/web/test/gsc-performance-chart.test.tsx
+++ b/apps/web/test/gsc-performance-chart.test.tsx
@@ -122,18 +122,51 @@ test('renders all four Search Console metrics as tiles, with clicks and impressi
   expect(tile('Avg position').textContent).toContain('10.5')
 })
 
-test('reads the trend direction from BETTER/WORSE, not from the sign of the slope', async () => {
+test('renders fitted movement as a relative percentage with better/worse direction', async () => {
   renderSection()
   await waitFor(() => expect(tile('Clicks')).not.toBeNull())
 
-  // Clicks rising is an improvement.
-  expect(tile('Clicks').textContent).toContain('↑')
-  // Impressions falling is a decline.
-  expect(tile('Impressions').textContent).toContain('↓')
+  // Relative fitted changes, not raw clicks, impressions, percentage points,
+  // or position points.
+  expect(tile('Clicks').textContent).toContain('↑ 300% over 4d')
+  expect(tile('Impressions').textContent).toContain('↓ 60% over 4d')
+  expect(tile('CTR').textContent).toContain('↑ 1,800% over 4d')
   // Position FALLING is an improvement — the one metric where a negative
   // slope is good news, and the case a naive `slope > 0` arrow gets backwards.
-  expect(tile('Avg position').textContent).toContain('↑')
-  expect(tile('Avg position').textContent).toContain('3.0')
+  expect(tile('Avg position').textContent).toContain('↑ 25% over 4d')
+})
+
+test('renders flat movement as zero percent and withholds invalid fitted baselines', async () => {
+  renderSection(performanceDaily({
+    trends: {
+      clicks: { slope: 0, intercept: 10, r2: 1, start: 10, end: 10, n: 4, startIndex: 0, endIndex: 3 },
+      impressions: { slope: 0, intercept: 0, r2: 1, start: 0, end: 0, n: 4, startIndex: 0, endIndex: 3 },
+      ctr: { slope: -0.01, intercept: 0.02, r2: 1, start: 0.02, end: -0.01, n: 4, startIndex: 0, endIndex: 3 },
+      position: { slope: -1, intercept: 12, r2: 1, start: 12, end: 9, n: 4, startIndex: 0, endIndex: 3 },
+    },
+  }))
+
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+  expect(tile('Clicks').textContent).toContain('→ 0% over 4d')
+  expect(tile('Impressions').textContent).toContain('— no percentage baseline')
+  expect(tile('CTR').textContent).toContain('— no percentage baseline')
+  expect(tile('Impressions').textContent).not.toMatch(/Infinity|NaN/)
+  expect(tile('CTR').textContent).not.toMatch(/Infinity|NaN/)
+})
+
+test('preserves tiny movement and marks a rising average position as worse', async () => {
+  renderSection(performanceDaily({
+    trends: {
+      clicks: { slope: 0.000001, intercept: 1_000_000, r2: 1, start: 1_000_000, end: 1_000_000, n: 4, startIndex: 0, endIndex: 3 },
+      impressions: null,
+      ctr: null,
+      position: { slope: 2 / 3, intercept: 8, r2: 1, start: 8, end: 10, n: 4, startIndex: 0, endIndex: 3 },
+    },
+  }))
+
+  await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+  expect(tile('Clicks').textContent).toContain('↑ <0.1% over 4d')
+  expect(tile('Avg position').textContent).toContain('↓ 25% over 4d')
 })
 
 test('toggles a metric on and off but refuses to leave the chart empty', async () => {
@@ -208,6 +241,7 @@ test('the filter explanation is a tooltip, not a paragraph on the page', async (
   // assistive tech or for tests that look it up by accessible name.
   const trigger = screen.getByRole('button', { name: /case-insensitive substrings/ })
   expect(trigger).not.toBeNull()
+  expect(trigger.getAttribute('aria-label')).toMatch(/Tile percentages show the fitted trend's relative change/)
   expect(trigger.getAttribute('aria-label')).toMatch(/Click any day to filter/)
 })
 
@@ -267,6 +301,7 @@ test('plots one row per calendar day, so a quiet gap is not compressed', async (
   }))
 
   await waitFor(() => expect(tile('Clicks')).not.toBeNull())
+  expect(tile('Clicks').textContent).toContain('↓ 30% over 10d')
   // The drill controls stay on the MEASURED days — an empty day is nothing to
   // drill into — which is how we can tell the two series apart.
   const group = screen.getByRole('group', { name: /Filter the table to a single day/ })

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -3,7 +3,7 @@ import { eq, desc, and, sql } from 'drizzle-orm'
 import type { SQL, SQLWrapper } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaDailyTotals, gaAiReferrals, gaSocialReferrals, gaAcquisitionDaily, gaLeadEventsDaily, gaMeasurementSyncStates, runs } from '@ainyc/canonry-db'
-import { classifyAiReferralTrafficClass, validationError, notFound, forbidden, quotaExceeded, providerError, AppError, RunKinds, RunStatuses, RunTriggers, resolveDateRange, normalizeUrlPath } from '@ainyc/canonry-contracts'
+import { classifyAiReferralTrafficClass, deltaPercent, validationError, notFound, forbidden, quotaExceeded, providerError, AppError, RunKinds, RunStatuses, RunTriggers, resolveDateRange, normalizeUrlPath } from '@ainyc/canonry-contracts'
 import type { GA4ChannelBreakdownDto, ResolvedDateRange } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import { assertNotProjectScoped } from './auth.js'
@@ -1564,8 +1564,6 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     const current30d = sumSocial(daysAgo(30), fmt(today))
     const prev30d = sumSocial(daysAgo(60), daysAgo(30))
 
-    const pct = (cur: number, prev: number) => prev === 0 ? null : Math.round(((cur - prev) / prev) * 100)
-
     // Biggest mover: source with largest absolute session change in 7d vs prev 7d
     const sourceCurrent = app.db
       .select({
@@ -1607,7 +1605,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
           source: row.source,
           sessions7d: row.sessions,
           sessionsPrev7d: prev,
-          changePct: pct(row.sessions, prev) ?? (row.sessions > 0 ? 100 : 0),
+          changePct: deltaPercent(row.sessions, prev) ?? (row.sessions > 0 ? 100 : 0),
         }
       }
     }
@@ -1615,10 +1613,10 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     return {
       socialSessions7d: current7d?.sessions ?? 0,
       socialSessionsPrev7d: prev7d?.sessions ?? 0,
-      trend7dPct: pct(current7d?.sessions ?? 0, prev7d?.sessions ?? 0),
+      trend7dPct: deltaPercent(current7d?.sessions ?? 0, prev7d?.sessions ?? 0),
       socialSessions30d: current30d?.sessions ?? 0,
       socialSessionsPrev30d: prev30d?.sessions ?? 0,
-      trend30dPct: pct(current30d?.sessions ?? 0, prev30d?.sessions ?? 0),
+      trend30dPct: deltaPercent(current30d?.sessions ?? 0, prev30d?.sessions ?? 0),
       biggestMover,
     }
   })
@@ -1633,8 +1631,6 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     const today = new Date()
     const fmt = (d: Date) => d.toISOString().split('T')[0]!
     const daysAgo = (n: number) => { const d = new Date(today); d.setDate(d.getDate() - n); return fmt(d) }
-    const pct = (cur: number, prev: number) => prev === 0 ? null : Math.round(((cur - prev) / prev) * 100)
-
     // --- Total sessions (from gaTrafficSnapshots) ---
     const sumTotal = (from: string, to: string) => app.db
       .select({ sessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.sessions}), 0)` })
@@ -1684,7 +1680,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       const p7 = sum(daysAgo(14), daysAgo(7))?.sessions ?? 0
       const c30 = sum(daysAgo(30), todayStr)?.sessions ?? 0
       const p30 = sum(daysAgo(60), daysAgo(30))?.sessions ?? 0
-      return { sessions7d: c7, sessionsPrev7d: p7, trend7dPct: pct(c7, p7), sessions30d: c30, sessionsPrev30d: p30, trend30dPct: pct(c30, p30) }
+      return { sessions7d: c7, sessionsPrev7d: p7, trend7dPct: deltaPercent(c7, p7), sessions30d: c30, sessionsPrev30d: p30, trend30dPct: deltaPercent(c30, p30) }
     }
 
     // --- Biggest movers (AI) — sessionSource-only to match the breakdown cell scope. ---
@@ -1724,7 +1720,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         const delta = Math.abs(row.sessions - p)
         if (delta > maxDelta) {
           maxDelta = delta
-          mover = { source: row.source, sessions7d: row.sessions, sessionsPrev7d: p, changePct: pct(row.sessions, p) ?? (row.sessions > 0 ? 100 : 0) }
+          mover = { source: row.source, sessions7d: row.sessions, sessionsPrev7d: p, changePct: deltaPercent(row.sessions, p) ?? (row.sessions > 0 ? 100 : 0) }
         }
       }
       return mover

--- a/packages/api-routes/src/gbp-summary.ts
+++ b/packages/api-routes/src/gbp-summary.ts
@@ -13,6 +13,8 @@
  *   - Empty input yields zeros / empty maps, never `NaN`.
  */
 
+import { deltaPercent } from '@ainyc/canonry-contracts'
+
 export interface DailyMetricInput {
   metric: string
   /** YYYY-MM-DD */
@@ -106,7 +108,7 @@ export function computeWindowDelta(rows: DailyMetricInput[], referenceDate: stri
     const prior = prior7d[metric] ?? 0
     recent7d[metric] = recent
     prior7d[metric] = prior
-    deltaPct[metric] = prior === 0 ? null : Math.round(((recent - prior) / prior) * 100)
+    deltaPct[metric] = deltaPercent(recent, prior)
   }
 
   return { recent7d, prior7d, deltaPct }

--- a/packages/api-routes/src/organic-evidence.ts
+++ b/packages/api-routes/src/organic-evidence.ts
@@ -17,6 +17,7 @@ import {
 import {
   AiReferralTrafficClasses,
   CitationStates,
+  deltaPercent,
   RunKinds,
   RunStatuses,
   VerificationStatuses,
@@ -125,7 +126,7 @@ function summarizeServer(
 
 function comparisonDetail(latest: number, prior: number): string {
   if (prior === 0) return `${latest} in the latest cohort versus 0 in the prior cohort`
-  const change = Math.round(((latest - prior) / prior) * 100)
+  const change = deltaPercent(latest, prior) ?? 0
   return `${latest} in the latest cohort versus ${prior} prior (${change >= 0 ? '+' : ''}${change}%)`
 }
 

--- a/packages/contracts/src/formatting.ts
+++ b/packages/contracts/src/formatting.ts
@@ -357,9 +357,21 @@ export interface DeltaWindow {
   deltaPct: number | null
 }
 
+/**
+ * Signed relative change from `baseline` to `current`, expressed as a ratio.
+ * Returns null when either value is non-finite or the baseline is not positive,
+ * because a relative change from zero or a negative baseline is undefined for
+ * the count and rate metrics that consume this helper.
+ */
+export function relativeChangeRatio(current: number, baseline: number): number | null {
+  if (!Number.isFinite(current) || !Number.isFinite(baseline) || baseline <= 0) return null
+  const ratio = (current - baseline) / baseline
+  return Number.isFinite(ratio) ? ratio : null
+}
+
 export function deltaPercent(current: number, prior: number): number | null {
-  if (prior <= 0) return null
-  return Math.round(((current - prior) / prior) * 100)
+  const ratio = relativeChangeRatio(current, prior)
+  return ratio === null ? null : Math.round(ratio * 100)
 }
 
 export type DeltaTone = 'positive' | 'negative' | 'neutral'

--- a/packages/contracts/test/formatting.test.ts
+++ b/packages/contracts/test/formatting.test.ts
@@ -15,6 +15,7 @@ import {
   formatWindowCountDelta,
   isoDateDaysBeforeInTimeZone,
   parseInclusiveEndMs,
+  relativeChangeRatio,
   startOfDayHourInTimeZone,
   startOfNextDayHourInTimeZone,
 } from '../src/formatting.js'
@@ -459,6 +460,21 @@ describe('formatDateRange', () => {
   test('only one side falls through to a single formatted date', () => {
     expect(formatDateRange('2026-05-01', '')).toBe('May 1, 2026')
     expect(formatDateRange('', '2026-05-08')).toBe('May 8, 2026')
+  })
+})
+
+describe('relativeChangeRatio', () => {
+  test('returns the signed unrounded change relative to a positive baseline', () => {
+    expect(relativeChangeRatio(150, 100)).toBe(0.5)
+    expect(relativeChangeRatio(50, 100)).toBe(-0.5)
+    expect(relativeChangeRatio(100.05, 100)).toBeCloseTo(0.0005, 10)
+  })
+
+  test('returns null for invalid values or a non-positive baseline', () => {
+    expect(relativeChangeRatio(100, 0)).toBeNull()
+    expect(relativeChangeRatio(50, -1)).toBeNull()
+    expect(relativeChangeRatio(Number.NaN, 100)).toBeNull()
+    expect(relativeChangeRatio(100, Number.POSITIVE_INFINITY)).toBeNull()
   })
 })
 

--- a/packages/intelligence/src/gbp-analyzer.ts
+++ b/packages/intelligence/src/gbp-analyzer.ts
@@ -1,4 +1,5 @@
 import type { InsightSeverity, InsightType } from './types.js'
+import { relativeChangeRatio } from '@ainyc/canonry-contracts'
 
 /**
  * Pure analyzers for Google Business Profile (local-AEO) signals. Take
@@ -237,7 +238,9 @@ function pickWorstKeywordDrop(loc: GbpLocationSignals): { keyword: string; dropP
   let worst: { keyword: string; dropPct: number; recent: number; prior: number } | null = null
   for (const point of loc.keywordPoints) {
     if (point.recent == null || point.prior == null || point.prior < GBP_KEYWORD_MIN_BASELINE) continue
-    const dropPct = Math.round(((point.prior - point.recent) / point.prior) * 100)
+    const changeRatio = relativeChangeRatio(point.recent, point.prior)
+    if (changeRatio === null) continue
+    const dropPct = Math.round(-changeRatio * 100)
     if (dropPct < GBP_KEYWORD_DROP_PCT) continue
     if (!worst || dropPct > worst.dropPct) {
       worst = { keyword: point.keyword, dropPct, recent: point.recent, prior: point.prior }


### PR DESCRIPTION
## Overview

Replace raw GSC trend-point deltas with relative percentages and centralize relative-change math.

## Changes

- Show fitted start-to-end percentage changes for all GSC metrics.
- Preserve lower-is-better direction for average position.
- Handle flat, tiny, sparse-window, and invalid-baseline trends.
- Add shared `relativeChangeRatio` and reuse it across existing delta calculations.
- Expand UI and contracts regression coverage.

## Validation

- 233 focused tests passed across web, contracts, API routes, and intelligence.
- Typechecks passed for all four affected packages.
- Changed-file lint passed with 0 errors.
- Web production build passed.
- `git diff --check` passed.