### PR TITLE
Add describeError and migrate the 168 hand-written copies of the idiom

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,7 +755,7 @@ The contract test `packages/api-routes/test/openapi-contract.test.ts` enforces a
 | Brand identity matching | `packages/contracts/src/brand-matching.ts` (exact approved aliases across case/spacing/punctuation variants; never fuzzy/edit-distance matching for metrics) |
 | Tracked-query text normalization | `packages/contracts/src/query-normalize.ts` (`normalizeQueryText` — trim + lowercase for dedup / FK-null text matching) |
 | Report action / opportunity dedup | `packages/contracts/src/report-dedup.ts` |
-| Error factories | `packages/contracts/src/errors.ts` |
+| Error factories, and rendering a caught `unknown` | `packages/contracts/src/errors.ts` (`describeError` — the one way to turn a `catch` binding into text; never hand-write `err instanceof Error ? err.message : String(err)`, whose `String()` branch prints `[object Object]` for a thrown object) |
 | SQL `LIKE` wildcard escaping | `packages/contracts/src/sql-like.ts` (`escapeLikePattern` — caller adds `ESCAPE '\\'`) |
 | Retry / exponential backoff | `packages/contracts/src/retry.ts` (`withRetry`, `backoffDelayMs`, `isRetryableHttpError`) |
 | Statistics over a series | `packages/contracts/src/statistics.ts` (`wilsonInterval` for a proportion; `linearTrend` for the least-squares fit of any evenly-spaced series, returning slope-per-step plus the two endpoints a chart draws between). Fit trends server-side and put them in the DTO — a regression computed in a chart component is invisible to the CLI and breaks UI/CLI parity. |

--- a/apps/web/src/components/project/CitationVisibilitySection.tsx
+++ b/apps/web/src/components/project/CitationVisibilitySection.tsx
@@ -7,6 +7,7 @@ import { heyClient } from '../../api.js'
 import { STATIC_VISIBILITY_STALE_MS } from '../../queries/query-client.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { ProviderBadge } from '../shared/ProviderBadge.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 export function CitationVisibilitySection({ projectName }: { projectName: string }) {
   const visibilityQuery = useQuery({
@@ -29,7 +30,7 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
             <h2>Citation + answer-mention coverage</h2>
           </div>
         </div>
-        <p className="text-sm text-negative-400">{error instanceof Error ? error.message : String(error)}</p>
+        <p className="text-sm text-negative-400">{describeError(error)}</p>
       </section>
     )
   }

--- a/apps/web/src/components/project/ProjectEngineSettingsSection.tsx
+++ b/apps/web/src/components/project/ProjectEngineSettingsSection.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { fetchSettings, isEmbed, type ApiProject } from '../../api.js'
 import { Button } from '../ui/button.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 type EngineProject = Pick<ApiProject, 'name' | 'providers' | 'providerModels'>
 type EngineSave = Pick<ApiProject, 'providers' | 'providerModels'>
@@ -143,7 +144,7 @@ export function ProjectEngineSettingsSection({
       setEditing(false)
       setNotice('Engine settings saved. They apply on the next sweep.')
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause))
+      setError(describeError(cause))
     } finally {
       setSaving(false)
     }

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useId, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { buildModelChangeNotice } from '@ainyc/canonry-contracts'
+import { buildModelChangeNotice, describeError } from '@ainyc/canonry-contracts'
 import type { BrandMetricsDto, MetricsWindow } from '@ainyc/canonry-contracts'
 import {
   CartesianGrid,
@@ -667,7 +667,7 @@ export function VisibilityTrendSection({
 
   let body: React.ReactNode
   if (error) {
-    body = <p className="text-sm text-negative-400">{error instanceof Error ? error.message : String(error)}</p>
+    body = <p className="text-sm text-negative-400">{describeError(error)}</p>
   } else if (metricsQuery.isLoading && !data) {
     body = <div className="visibility-trend-chart animate-pulse rounded-lg bg-bg-elevated/40" aria-hidden="true" />
   } else if (metric === 'mentionShare' && competitorCount === 0) {

--- a/apps/web/src/components/project/YamlApplyPanel.tsx
+++ b/apps/web/src/components/project/YamlApplyPanel.tsx
@@ -5,6 +5,7 @@ import { Button } from '../ui/button.js'
 import { applyProjectConfig, isEmbed } from '../../api.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 export function YamlApplyPanel({ onApplied }: { onApplied: () => void }) {
   const [yamlText, setYamlText] = useState('')
@@ -39,7 +40,7 @@ export function YamlApplyPanel({ onApplied }: { onApplied: () => void }) {
         const result = await applyProjectConfig(config)
         applied.push(`Applied "${result.displayName || result.name}" (revision ${result.configRevision})`)
       } catch (err) {
-        errs.push(`Document ${i + 1}: ${err instanceof Error ? err.message : String(err)}`)
+        errs.push(`Document ${i + 1}: ${describeError(err)}`)
       }
     }
 

--- a/apps/web/src/components/settings/CdpConfigCard.tsx
+++ b/apps/web/src/components/settings/CdpConfigCard.tsx
@@ -6,6 +6,7 @@ import { ToneBadge } from '../shared/ToneBadge.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
 import { fetchCdpStatus, configureCdp, type ApiCdpStatus } from '../../api.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 function shortCdpError(error: string): string {
   const summary = error.replace(/^Error:\s*/, '').replace(/\s+/g, ' ').trim()
@@ -28,7 +29,7 @@ export function CdpConfigCard() {
         setCdpStatusError(null)
       })
       .catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = describeError(err)
         if (!msg.includes('501')) setCdpStatusError(msg)
       })
   }, [])
@@ -113,7 +114,7 @@ export function CdpConfigCard() {
                 dedupeMode: 'replace',
               })
             } catch (err) {
-              setCdpStatusError(err instanceof Error ? err.message : String(err))
+              setCdpStatusError(describeError(err))
             } finally {
               setCdpSaving(false)
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.165.2",
+  "version": "4.166.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ads.ts
+++ b/packages/api-routes/src/ads.ts
@@ -48,6 +48,7 @@ import {
   RunStatuses,
   RunTriggers,
   runStatusSchema,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import type {
   AdsAdDto,
@@ -2236,7 +2237,7 @@ export async function adsRoutes(app: FastifyInstance, opts: AdsRoutesOptions): P
       try {
         account = await opts.verifyAdsAccount(parsed.data.apiKey)
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
+        const message = describeError(err)
         throw validationError(`OpenAI Ads API rejected the key: ${message}`)
       }
 

--- a/packages/api-routes/src/apply.ts
+++ b/packages/api-routes/src/apply.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { and, eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { projects, competitors, schedules, notifications } from '@ainyc/canonry-db'
-import { forbidden, normalizeProjectAliases, normalizeProjectDomain, projectConfigSchema, registrableDomain, resolveConfigSpecQueries, SchedulableRunKinds, validationError } from '@ainyc/canonry-contracts'
+import { forbidden, normalizeProjectAliases, normalizeProjectDomain, projectConfigSchema, registrableDomain, resolveConfigSpecQueries, SchedulableRunKinds, validationError, describeError } from '@ainyc/canonry-contracts'
 import type { ProviderAdapterInfo } from './settings.js'
 import { pruneProviderModelsForProviders, validateProviderModels } from './provider-models.js'
 import { writeAuditLog } from './helpers.js'
@@ -72,7 +72,7 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
         try {
           cronExpr = resolvePreset(schedSpec.preset)
         } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : String(err)
+          const msg = describeError(err)
           throw validationError(msg)
         }
       } else if (schedSpec.cron) {

--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { eq, and, desc } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { bingUrlInspections, bingCoverageSnapshots, runs } from '@ainyc/canonry-db'
-import { validationError, notFound, RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
+import { validationError, notFound, RunKinds, RunStatuses, RunTriggers, describeError } from '@ainyc/canonry-contracts'
 import { assertNotProjectScoped } from './auth.js'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
@@ -146,7 +146,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       sites = await getSites(apiKey)
       bingLog('info', 'connect.verify-key', { domain: project.canonicalDomain, siteCount: sites.length })
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
+      const msg = describeError(e)
       bingLog('error', 'connect.verify-key-failed', { domain: project.canonicalDomain, error: msg })
       throw validationError(`Failed to verify Bing API key: ${msg}`)
     }
@@ -530,7 +530,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
         } catch (e) {
           bingLog('warn', 'inspect-url.crawl-issues-lookup-failed', {
             domain: project.canonicalDomain,
-            error: e instanceof Error ? e.message : String(e),
+            error: describeError(e),
           })
         }
       }
@@ -569,7 +569,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
         discoveryDate,
       }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
+      const msg = describeError(e)
       bingLog('error', 'inspect-url.failed', { domain: project.canonicalDomain, url, error: msg })
       app.db.update(runs)
         .set({ status: RunStatuses.failed, error: msg, finishedAt: new Date().toISOString() })
@@ -689,7 +689,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
           }
           bingLog('info', 'index-submit.batch-ok', { domain: project.canonicalDomain, batchSize: batch.length, urls: batch })
         } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e)
+          const msg = describeError(e)
           const now = new Date().toISOString()
           for (const url of batch) {
             results.push({ url, status: 'error', submittedAt: now, error: msg })
@@ -705,7 +705,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
         results.push({ url, status: 'success', submittedAt: new Date().toISOString() })
         bingLog('info', 'index-submit.ok', { domain: project.canonicalDomain, url })
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e)
+        const msg = describeError(e)
         results.push({ url, status: 'error', submittedAt: new Date().toISOString(), error: msg })
         bingLog('error', 'index-submit.failed', { domain: project.canonicalDomain, url, error: msg })
       }

--- a/packages/api-routes/src/doctor/checks/bing-auth.ts
+++ b/packages/api-routes/src/doctor/checks/bing-auth.ts
@@ -2,6 +2,7 @@ import {
   CheckCategories,
   CheckScopes,
   CheckStatuses,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { getSites } from '@ainyc/canonry-integration-bing'
 import type { CheckDefinition } from '../types.js'
@@ -60,7 +61,7 @@ export const BING_AUTH_CHECKS: readonly CheckDefinition[] = [
           remediation: null,
         }
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
+        const message = describeError(err)
         return {
           status: CheckStatuses.fail,
           code: 'bing.auth.verification-failed',
@@ -149,7 +150,7 @@ export const BING_AUTH_CHECKS: readonly CheckDefinition[] = [
           remediation: null,
         }
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
+        const message = describeError(err)
         return {
           status: CheckStatuses.fail,
           code: 'bing.auth.site-check-failed',

--- a/packages/api-routes/src/doctor/checks/ga-auth.ts
+++ b/packages/api-routes/src/doctor/checks/ga-auth.ts
@@ -2,6 +2,7 @@ import {
   CheckCategories,
   CheckScopes,
   CheckStatuses,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import {
   verifyConnection,
@@ -34,7 +35,7 @@ async function checkServiceAccount(conn: NonNullable<ReturnType<NonNullable<Doct
   try {
     await verifyConnection(conn.clientEmail, conn.privateKey, conn.propertyId)
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = describeError(err)
     return {
       status: CheckStatuses.fail,
       code: 'ga.auth.verify-failed',
@@ -86,7 +87,7 @@ async function checkOAuthConnection(ctx: DoctorContext, projectName: string, con
     const tokens = await refreshAccessToken(auth.clientId, auth.clientSecret, conn.refreshToken)
     accessToken = tokens.access_token
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = describeError(err)
     return {
       status: CheckStatuses.fail,
       code: 'ga.auth.refresh-failed',
@@ -98,7 +99,7 @@ async function checkOAuthConnection(ctx: DoctorContext, projectName: string, con
   try {
     await verifyConnectionWithToken(accessToken, conn.propertyId)
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = describeError(err)
     return {
       status: CheckStatuses.fail,
       code: 'ga.auth.verify-failed',

--- a/packages/api-routes/src/doctor/checks/gbp-auth.ts
+++ b/packages/api-routes/src/doctor/checks/gbp-auth.ts
@@ -4,6 +4,7 @@ import {
   CheckCategories,
   CheckScopes,
   CheckStatuses,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { refreshAccessToken } from '@ainyc/canonry-integration-google'
 import { GBP_SCOPE, listAccounts, GbpApiError } from '@ainyc/canonry-integration-google-business-profile'
@@ -85,7 +86,7 @@ async function resolveGbpToken(
     const tokens = await refreshAccessToken(auth.clientId, auth.clientSecret, conn.refreshToken)
     return { ok: true, token: { accessToken: tokens.access_token, conn } }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = describeError(err)
     return {
       ok: false,
       output: {
@@ -222,7 +223,7 @@ const accountAccessCheck: CheckDefinition = {
           details: { reason: err.reason ?? undefined, status: err.status },
         }
       }
-      const message = err instanceof Error ? err.message : String(err)
+      const message = describeError(err)
       return {
         status: CheckStatuses.fail,
         code: 'gbp.account.list-failed',

--- a/packages/api-routes/src/doctor/checks/google-auth.ts
+++ b/packages/api-routes/src/doctor/checks/google-auth.ts
@@ -2,6 +2,7 @@ import {
   CheckCategories,
   CheckScopes,
   CheckStatuses,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import {
   GSC_SCOPE,
@@ -74,7 +75,7 @@ async function resolveAccessToken(ctx: DoctorContext): Promise<{ ok: true; token
     const tokens = await refreshAccessToken(auth.clientId, auth.clientSecret, conn.refreshToken)
     return { ok: true, token: { accessToken: tokens.access_token } }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = describeError(err)
     return {
       ok: false,
       output: {
@@ -169,7 +170,7 @@ const propertyAccessCheck: CheckDefinition = {
           details: { error: err.message },
         }
       }
-      const message = err instanceof Error ? err.message : String(err)
+      const message = describeError(err)
       return {
         status: CheckStatuses.fail,
         code: 'google.auth.list-sites-failed',

--- a/packages/api-routes/src/doctor/checks/traffic-source.ts
+++ b/packages/api-routes/src/doctor/checks/traffic-source.ts
@@ -6,6 +6,7 @@ import {
   CheckStatuses,
   TrafficSourceStatuses,
   TrafficSourceTypes,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import {
   aiReferralEventsHourly,
@@ -343,7 +344,7 @@ async function runValidator(
     }
     return { source, output: result }
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
+    const msg = describeError(e)
     return {
       source,
       output: {

--- a/packages/api-routes/src/doctor/checks/wordpress-publish.ts
+++ b/packages/api-routes/src/doctor/checks/wordpress-publish.ts
@@ -2,6 +2,7 @@ import {
   CheckCategories,
   CheckScopes,
   CheckStatuses,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { verifyWordpressConnection, WordpressApiError } from '@ainyc/canonry-integration-wordpress'
 import type { CheckDefinition } from '../types.js'
@@ -68,7 +69,7 @@ export const WORDPRESS_PUBLISH_CHECKS: readonly CheckDefinition[] = [
             details: { error: err.message },
           }
         }
-        const message = err instanceof Error ? err.message : String(err)
+        const message = describeError(err)
         return {
           status: CheckStatuses.fail,
           code: 'wordpress.publish.verification-failed',

--- a/packages/api-routes/src/doctor/runner.ts
+++ b/packages/api-routes/src/doctor/runner.ts
@@ -4,6 +4,7 @@ import {
   summarizeCheckResults,
   type CheckResultDto,
   type DoctorReportDto,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import type { CheckDefinition, DoctorContext, RunChecksOptions } from './types.js'
 
@@ -41,7 +42,7 @@ export async function runChecks(
     try {
       output = await definition.run(ctx)
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = describeError(err)
       output = {
         status: CheckStatuses.fail,
         code: `${definition.id}.runtime-error`,

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -3,7 +3,7 @@ import { eq, desc, and, sql } from 'drizzle-orm'
 import type { SQL, SQLWrapper } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaDailyTotals, gaAiReferrals, gaSocialReferrals, gaAcquisitionDaily, gaLeadEventsDaily, gaMeasurementSyncStates, runs } from '@ainyc/canonry-db'
-import { classifyAiReferralTrafficClass, deltaPercent, validationError, notFound, forbidden, quotaExceeded, providerError, AppError, RunKinds, RunStatuses, RunTriggers, resolveDateRange, normalizeUrlPath } from '@ainyc/canonry-contracts'
+import { classifyAiReferralTrafficClass, deltaPercent, validationError, notFound, forbidden, quotaExceeded, providerError, AppError, RunKinds, RunStatuses, RunTriggers, resolveDateRange, normalizeUrlPath, describeError } from '@ainyc/canonry-contracts'
 import type { GA4ChannelBreakdownDto, ResolvedDateRange } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import { assertNotProjectScoped } from './auth.js'
@@ -382,7 +382,7 @@ function ga4ErrorToAppError(err: unknown, context: string): AppError {
     return providerError(`${context}: ${err.message}`)
   }
 
-  return providerError(`${context}: ${err instanceof Error ? err.message : String(err)}`)
+  return providerError(`${context}: ${describeError(err)}`)
 }
 
 /**
@@ -485,7 +485,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         await verifyConnection(clientEmail, privateKey, propertyId)
         gaLog('info', 'connect.verified.service-account', { projectId: project.id, propertyId })
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e)
+        const msg = describeError(e)
         gaLog('error', 'connect.verify-failed', { projectId: project.id, propertyId, error: msg })
         throw validationError(`Failed to verify GA4 credentials: ${msg}`)
       }
@@ -542,7 +542,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       await verifyConnectionWithToken(accessToken, propertyId)
       gaLog('info', 'connect.verified.oauth', { projectId: project.id, propertyId })
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
+      const msg = describeError(e)
       gaLog('error', 'connect.verify-failed.oauth', { projectId: project.id, propertyId, error: msg })
       throw validationError(`Failed to verify GA4 access: ${msg}`)
     }
@@ -957,7 +957,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         component: 'acquisition' | 'leads',
         reason: unknown,
       ) => {
-        const message = reason instanceof Error ? reason.message : String(reason)
+        const message = describeError(reason)
         gaLog('warn', 'measurement.component-failed', {
           projectId: project.id,
           runId,
@@ -971,7 +971,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
             projectId: project.id,
             runId,
             component,
-            error: stateError instanceof Error ? stateError.message : String(stateError),
+            error: describeError(stateError),
           })
         }
         return { status: 'error' as const, days: component === 'acquisition' ? acquisitionDays : leadDays, rowCount: 0, error: message }
@@ -1069,7 +1069,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         ...(syncedComponents ? { syncedComponents } : {}),
       }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
+      const msg = describeError(e)
       gaLog('error', 'sync.fetch-failed', { projectId: project.id, runId, error: msg })
       app.db.update(runs)
         .set({ status: RunStatuses.failed, error: msg, finishedAt: new Date().toISOString() })

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -16,6 +16,7 @@ import {
   formatIsoDateInTimeZone,
   linearTrend,
   calendarDateRange,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from './gbp-summary.js'
@@ -428,7 +429,7 @@ function gscErrorToAppError(err: unknown, context: string): AppError {
     )
   }
 
-  return providerError(`${context}: ${err instanceof Error ? err.message : String(err)}`)
+  return providerError(`${context}: ${describeError(err)}`)
 }
 
 export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptions) {
@@ -636,7 +637,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     try {
       tokens = await exchangeCode(googleClientId, googleClientSecret, code, redirectUri)
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       return reply.type('text/html').send(
         `<html><body style="font-family:system-ui;padding:40px;max-width:600px;margin:0 auto">
           <h2 style="color:#ef4444">Token exchange failed</h2>
@@ -1585,7 +1586,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
         })
         results.push({ sitemapUrl, status: 'accepted', submittedAt })
       } catch (err) {
-        results.push({ sitemapUrl, status: 'error', error: err instanceof Error ? err.message : String(err) })
+        results.push({ sitemapUrl, status: 'error', error: describeError(err) })
       }
     }
     const accepted = results.filter((result) => result.status === 'accepted').length
@@ -1842,7 +1843,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
           status: 'success',
         })
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = describeError(err)
         results.push({
           url,
           type: 'URL_UPDATED',

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyError } from 'fastify'
 import rateLimit from '@fastify/rate-limit'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import fs from 'node:fs'
-import { AppError, runtimeStateMissing } from '@ainyc/canonry-contracts'
+import { AppError, runtimeStateMissing, describeError } from '@ainyc/canonry-contracts'
 import { authPlugin } from './auth.js'
 import { projectRoutes } from './projects.js'
 import type { ProjectRoutesOptions } from './projects.js'
@@ -755,7 +755,7 @@ function buildTrafficSourceValidators(opts: ApiRoutesOptions): Record<string, Tr
             summary: `Cloud Run access token resolves for "${source.displayName}" (project ${record.gcpProjectId}).`,
           }
         } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e)
+          const msg = describeError(e)
           return {
             status: CheckStatuses.fail,
             code: 'traffic.credentials.resolve-failed',
@@ -801,7 +801,7 @@ function buildTrafficSourceValidators(opts: ApiRoutesOptions): Record<string, Tr
           }
         } catch (e) {
           const httpStatus = e instanceof WordpressTrafficApiError ? e.status : null
-          const msg = e instanceof Error ? e.message : String(e)
+          const msg = describeError(e)
           return {
             status: CheckStatuses.fail,
             code: httpStatus === 401 || httpStatus === 403
@@ -854,7 +854,7 @@ function buildTrafficSourceValidators(opts: ApiRoutesOptions): Record<string, Tr
           }
         } catch (e) {
           const httpStatus = e instanceof VercelLogsApiError ? e.status : null
-          const msg = e instanceof Error ? e.message : String(e)
+          const msg = describeError(e)
           return {
             status: CheckStatuses.fail,
             code: httpStatus === 401 || httpStatus === 403

--- a/packages/api-routes/src/measurement-discovery-v2.ts
+++ b/packages/api-routes/src/measurement-discovery-v2.ts
@@ -23,6 +23,7 @@ import {
   type MeasurementDraftCounts,
   type MeasurementDraftTarget,
   type MeasurementDraftWarning,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import {
   measurementDiscoveryConfigs,
@@ -504,7 +505,7 @@ function availableStableKey(preferred: string, taken: ReadonlySet<string>): stri
 }
 
 function messageOf(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+  return describeError(error)
 }
 
 /**

--- a/packages/api-routes/src/measurement-service.ts
+++ b/packages/api-routes/src/measurement-service.ts
@@ -7,6 +7,7 @@ import {
   measurementReportResponseSchema,
   notFound,
   validationError,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { requireScope } from './auth.js'
 import {
@@ -28,7 +29,7 @@ export interface MeasurementServiceRoutesOptions {
 }
 
 function messageOf(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+  return describeError(error)
 }
 
 /** Network and persistence adapters around the pure Target discovery/report kernels. */

--- a/packages/api-routes/src/schedules.ts
+++ b/packages/api-routes/src/schedules.ts
@@ -11,6 +11,7 @@ import {
   scheduleUpsertRequestSchema,
   validationError,
   notFound,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import { resolvePreset, validateCron, isValidTimezone } from './schedule-utils.js'
@@ -114,7 +115,7 @@ export async function scheduleRoutes(app: FastifyInstance, opts: ScheduleRoutesO
       try {
         cronExpr = resolvePreset(preset)
       } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = describeError(err)
         throw validationError(msg)
       }
     } else {

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -45,6 +45,7 @@ import {
   classifyTrafficPath,
   segmentCrawlerHits,
   sumInfraHits,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import type {
   NormalizedTrafficRequest,
@@ -1052,7 +1053,7 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
   try {
     allEvents = await pullForBackfill()
   } catch (e) {
-    markFailed(`${pullErrorPrefix}: ${e instanceof Error ? e.message : String(e)}`)
+    markFailed(`${pullErrorPrefix}: ${describeError(e)}`)
     return
   }
 
@@ -1421,7 +1422,7 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
     })
     if (commitOutcome === 'source-inactive') return
   } catch (e) {
-    markFailed(`Backfill rollup write failed: ${e instanceof Error ? e.message : String(e)}`)
+    markFailed(`Backfill rollup write failed: ${describeError(e)}`)
   }
 }
 
@@ -1745,7 +1746,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
             `WordPress traffic probe failed (HTTP ${e.status}): ${e.message}${e.body ? ` — ${e.body}` : ''}`,
           )
         }
-        const msg = e instanceof Error ? e.message : String(e)
+        const msg = describeError(e)
         throw providerError(`WordPress traffic probe failed: ${msg}`)
       }
     })
@@ -1868,7 +1869,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           `Vercel traffic probe failed (HTTP ${e.status}): ${e.message}${e.body ? ` — ${e.body}` : ''}`,
         )
       }
-      const msg = e instanceof Error ? e.message : String(e)
+      const msg = describeError(e)
       throw providerError(`Vercel traffic probe failed: ${msg}`)
     }
 
@@ -2924,7 +2925,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       try {
         accessToken = await resolveAccessToken(credential)
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e)
+        const msg = describeError(e)
         markFailed(msg, 'PROVIDER_AUTH')
         throw providerError(`Failed to resolve Cloud Run access token: ${msg}`)
       }
@@ -2948,7 +2949,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         })
         allEvents = page.events
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e)
+        const msg = describeError(e)
         markFailed(msg, 'PROVIDER_PULL')
         throw providerError(`Cloud Run pull failed: ${msg}`)
       }
@@ -2998,7 +2999,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       try {
         pinnedDispatcher = await assertWordpressTargetAllowed(credential.baseUrl)
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e)
+        const msg = describeError(e)
         markFailed(msg, 'PROVIDER_PULL')
         throw e
       }
@@ -3030,7 +3031,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         allEvents = collected
         nextCursor = cursor
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e)
+        const msg = describeError(e)
         markFailed(msg, 'PROVIDER_PULL')
         throw providerError(`WordPress pull failed: ${msg}`)
       } finally {
@@ -3187,7 +3188,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         }
         allEvents = drained.events
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e)
+        const msg = describeError(e)
         markFailed(msg, 'PROVIDER_PULL')
         throw providerError(`Vercel pull failed: ${msg}`)
       }

--- a/packages/api-routes/src/wordpress.ts
+++ b/packages/api-routes/src/wordpress.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify'
-import { AppError, notFound, providerError, validationError } from '@ainyc/canonry-contracts'
+import { AppError, notFound, providerError, validationError, describeError } from '@ainyc/canonry-contracts'
 import type { WordpressEnv } from '@ainyc/canonry-contracts'
 import {
   buildManualLlmsTxtUpdate,
@@ -605,7 +605,7 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
       })
       steps.push({ name: 'connect', status: 'completed', summary: `Connected to ${url}` })
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       steps.push({ name: 'connect', status: 'failed', error: msg })
       return { projectName: project.name, steps }
     }
@@ -628,7 +628,7 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
 
       steps.push({ name: 'audit', status: 'completed', summary: `${pageCount} pages audited, ${issueCount} issues` })
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       steps.push({ name: 'audit', status: 'failed', error: msg })
       return { projectName: project.name, steps }
     }
@@ -671,7 +671,7 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
         })
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       steps.push({ name: 'set-meta', status: 'failed', error: msg })
       return { projectName: project.name, steps }
     }
@@ -699,7 +699,7 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
           })
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = describeError(err)
         steps.push({ name: 'schema-deploy', status: 'failed', error: msg })
         return { projectName: project.name, steps }
       }
@@ -735,7 +735,7 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
           }
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = describeError(err)
         steps.push({ name: 'google-submit', status: 'skipped', summary: `Google not available: ${msg}` })
       }
 
@@ -762,7 +762,7 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
           }
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = describeError(err)
         steps.push({ name: 'bing-submit', status: 'skipped', summary: `Bing not available: ${msg}` })
       }
     }

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.165.2",
+  "version": "4.166.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/ads-sync.ts
+++ b/packages/canonry/src/ads-sync.ts
@@ -8,6 +8,7 @@ import {
   dollarsToMicros,
   formatIsoDateInTimeZone,
   startOfDayHourInTimeZone,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import {
   getAdAccount,
@@ -345,8 +346,8 @@ export async function executeAdsSync(
           insightUpserts.push(...toDailyUpserts('ad_group', group.id, insights))
         }
       } catch (err) {
-        errors.set(campaign.name, err instanceof Error ? err.message : String(err))
-        log.error('campaign.failed', { runId, campaignId: campaign.id, error: err instanceof Error ? err.message : String(err) })
+        errors.set(campaign.name, describeError(err))
+        log.error('campaign.failed', { runId, campaignId: campaign.id, error: describeError(err) })
       }
     }
 
@@ -490,7 +491,7 @@ export async function executeAdsSync(
 
     log.info('sync.done', { runId, projectId, campaigns: syncedCampaigns.length, insightRows: insightUpserts.length, failed: errors.size })
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
+    const errorMsg = describeError(err)
     db.update(runs)
       .set({ status: 'failed', error: serializeRunError({ message: errorMsg }), finishedAt: new Date().toISOString() })
       .where(eq(runs.id, runId))

--- a/packages/canonry/src/agent/agent-routes.ts
+++ b/packages/canonry/src/agent/agent-routes.ts
@@ -14,6 +14,7 @@ import {
   notFound,
   validationError,
   type AgentMemoryListResponse,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import type { AgentEvent, AgentMessage } from '@mariozechner/pi-agent-core'
 import type { SessionRegistry } from './session-registry.js'
@@ -193,7 +194,7 @@ export function registerAgentRoutes(app: FastifyInstance, opts: AgentRoutesOptio
       await agent.waitForIdle()
       opts.sessionRegistry.save(project.name)
     } catch (err) {
-      write({ type: 'error', message: err instanceof Error ? err.message : String(err) })
+      write({ type: 'error', message: describeError(err) })
     } finally {
       unsubscribe()
       write({ type: 'stream_close' })

--- a/packages/canonry/src/agent/remote-mcp.ts
+++ b/packages/canonry/src/agent/remote-mcp.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import type { AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core'
 import { createLogger } from '../logger.js'
 import type { ExternalMcpServerConfig } from '../config.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 const log = createLogger('RemoteMcp')
 
@@ -166,7 +167,7 @@ export async function loadExternalMcpTools(
     } catch (err) {
       log.error('external-mcp.connect-failed', {
         label,
-        error: err instanceof Error ? err.message : String(err),
+        error: describeError(err),
       })
       continue
     }
@@ -177,7 +178,7 @@ export async function loadExternalMcpTools(
     } catch (err) {
       log.error('external-mcp.list-failed', {
         label,
-        error: err instanceof Error ? err.message : String(err),
+        error: describeError(err),
       })
       continue
     }

--- a/packages/canonry/src/agent/session-registry.ts
+++ b/packages/canonry/src/agent/session-registry.ts
@@ -8,7 +8,7 @@ import {
 } from '@ainyc/canonry-db'
 import type { Agent, AgentMessage, AgentTool } from '@mariozechner/pi-agent-core'
 import type { Api, Model } from '@mariozechner/pi-ai'
-import { agentBusy, AgentProviderIds } from '@ainyc/canonry-contracts'
+import { agentBusy, AgentProviderIds, describeError } from '@ainyc/canonry-contracts'
 import { createLogger } from '../logger.js'
 import type { ApiClient } from '../client.js'
 import type { CanonryConfig } from '../config.js'
@@ -144,7 +144,7 @@ export class SessionRegistry {
       this.externalToolsPromise = loadExternalMcpTools(this.opts.config.externalMcpServers).catch(
         (err) => {
           log.error('external-mcp.load-failed', {
-            error: err instanceof Error ? err.message : String(err),
+            error: describeError(err),
           })
           return []
         },
@@ -427,7 +427,7 @@ export class SessionRegistry {
     } catch (err) {
       log.error('compaction.failed', {
         projectName,
-        error: err instanceof Error ? err.message : String(err),
+        error: describeError(err),
       })
     }
   }
@@ -560,7 +560,7 @@ export class SessionRegistry {
     } catch (err) {
       log.error('drain.failed', {
         projectName,
-        error: err instanceof Error ? err.message : String(err),
+        error: describeError(err),
       })
     }
   }

--- a/packages/canonry/src/agent/tools.ts
+++ b/packages/canonry/src/agent/tools.ts
@@ -12,6 +12,7 @@ import {
   type CanonryMcpToolName,
 } from '../mcp/tool-registry.js'
 import { buildMcpAgentTools, truncateToolResult } from './mcp-to-agent-tool.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 /**
  * Context Aero tools close over so the LLM can never target a different
@@ -137,7 +138,7 @@ async function readSection<T>(fn: () => Promise<T>): Promise<ContextSection<T>> 
   } catch (err) {
     return {
       status: 'error',
-      error: err instanceof Error ? err.message : String(err),
+      error: describeError(err),
     }
   }
 }

--- a/packages/canonry/src/backlink-extract.ts
+++ b/packages/canonry/src/backlink-extract.ts
@@ -14,7 +14,7 @@ import {
   loadDuckdb as defaultLoadDuckdb,
   type BacklinkRow,
 } from '@ainyc/canonry-integration-commoncrawl'
-import { BacklinkSources, CcReleaseSyncStatuses, RunStatuses, computeBacklinkSummaryMetrics } from '@ainyc/canonry-contracts'
+import { BacklinkSources, CcReleaseSyncStatuses, RunStatuses, computeBacklinkSummaryMetrics, describeError } from '@ainyc/canonry-contracts'
 import { createLogger } from './logger.js'
 
 const log = createLogger('BacklinkExtract')
@@ -148,7 +148,7 @@ export async function executeBacklinkExtract(
 
     log.info('extract.completed', { runId, projectId, release, rows: rows.length })
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
+    const errorMsg = describeError(err)
     const finishedAt = deps.now().toISOString()
     db.update(runs).set({
       status: RunStatuses.failed, error: errorMsg, finishedAt,

--- a/packages/canonry/src/bing-inspect-sitemap.ts
+++ b/packages/canonry/src/bing-inspect-sitemap.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { eq, desc } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { runs, projects, bingUrlInspections, bingCoverageSnapshots } from '@ainyc/canonry-db'
-import { RunStatuses } from '@ainyc/canonry-contracts'
+import { RunStatuses, describeError } from '@ainyc/canonry-contracts'
 import { getUrlInfo, getCrawlIssues } from '@ainyc/canonry-integration-bing'
 import type { CanonryConfig } from './config.js'
 import { fetchAndParseSitemap } from './sitemap-parser.js'
@@ -25,18 +25,6 @@ const log = createLogger('BingInspectSitemap')
  * so 2s spacing finishes everything in about three minutes.
  */
 export const BING_INSPECT_SPACING_MS = 2_000
-
-/** Render an `unknown` thrown value as text a human can act on. */
-function describeError(err: unknown): string {
-  if (err instanceof Error) return err.message
-  if (typeof err === 'string') return err
-  if (err == null) return 'unknown error'
-  try {
-    return JSON.stringify(err)
-  } catch {
-    return 'unserializable error'
-  }
-}
 
 interface BingInspectSitemapOptions {
   sitemapUrl?: string
@@ -132,7 +120,7 @@ export async function executeBingInspectSitemap(
       log.warn('crawl-issues.lookup-failed', {
         runId,
         projectId,
-        error: err instanceof Error ? err.message : String(err),
+        error: describeError(err),
       })
       blockedUrls = new Set()
     }
@@ -222,7 +210,7 @@ export async function executeBingInspectSitemap(
             runId,
             projectId,
             url: pageUrl,
-            error: err instanceof Error ? err.message : String(err),
+            error: describeError(err),
           })
         },
       },
@@ -367,7 +355,7 @@ export async function executeBingInspectSitemap(
       unknown: snapUnknown,
     })
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
+    const errorMsg = describeError(err)
     db.update(runs)
       .set({ status: RunStatuses.failed, error: errorMsg, finishedAt: new Date().toISOString() })
       .where(eq(runs.id, runId))

--- a/packages/canonry/src/cli-commands/wordpress.ts
+++ b/packages/canonry/src/cli-commands/wordpress.ts
@@ -25,6 +25,7 @@ import {
   wordpressStatus,
   wordpressUpdatePage,
 } from '../commands/wordpress.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 function resolveEnv(input: CliCommandInput, command: string, usage: string): WordpressEnv | undefined {
   const live = getBoolean(input.values, 'live')
@@ -74,7 +75,7 @@ function resolveContent(
     try {
       return fs.readFileSync(contentFile, 'utf-8')
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
+      const message = describeError(error)
       throw usageError(`Error: could not read --content-file "${contentFile}": ${message}`, {
         message: `could not read --content-file "${contentFile}": ${message}`,
         details: { command, usage },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -558,6 +558,7 @@ import {
   type PostApiV1ProjectsByNameMeasurementPlanDraftActionsDiscardResponse,
   type PostApiV1ProjectsByNameMeasurementPlanActionsDeactivateResponse,
 } from '@ainyc/canonry-api-client'
+import { describeError } from '@ainyc/canonry-contracts'
 
 export type { BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto, AuditLogEntry, CompetitorDto, KeywordDto, QueryDto }
 
@@ -791,7 +792,7 @@ export class ApiClient {
       result = await call()
     } catch (err) {
       if (err instanceof CliError) throw err
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       if (traceEnabled) {
         process.stderr.write(`[trace] (sdk-call) → ERROR (${Date.now() - traceStart}ms): ${msg}\n`)
       }
@@ -948,7 +949,7 @@ export class ApiClient {
       res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body ?? {}), signal })
     } catch (err) {
       if (err instanceof CliError) throw err
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       if (msg.includes('fetch failed') || msg.includes('ECONNREFUSED') || msg.includes('connect ECONNREFUSED')) {
         throw new CliError({
           code: 'CONNECTION_ERROR',
@@ -1087,7 +1088,7 @@ export class ApiClient {
         headers: { Authorization: `Bearer ${this.apiKey}` },
       })
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = describeError(err)
       if (message.includes('fetch failed') || message.includes('ECONNREFUSED') || message.includes('connect ECONNREFUSED')) {
         throw new CliError({
           code: 'CONNECTION_ERROR',

--- a/packages/canonry/src/commands/ads.ts
+++ b/packages/canonry/src/commands/ads.ts
@@ -49,6 +49,7 @@ import {
   AdsDeliverySnapshotStatuses,
   AdsLiveEntityTypes,
   formatMicros,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import type { z } from 'zod'
 import { createApiClient } from '../client.js'
@@ -74,8 +75,8 @@ function readRequest<TSchema extends z.ZodTypeAny>(inputPath: string | undefined
     if (err instanceof CliError) throw err
     throw new CliError({
       code: 'ADS_INPUT_INVALID',
-      message: err instanceof Error ? err.message : String(err),
-      displayMessage: `Error: invalid ads JSON input (${err instanceof Error ? err.message : String(err)})`,
+      message: describeError(err),
+      displayMessage: `Error: invalid ads JSON input (${describeError(err)})`,
       details: { inputPath },
     })
   }

--- a/packages/canonry/src/commands/apply.ts
+++ b/packages/canonry/src/commands/apply.ts
@@ -3,6 +3,7 @@ import { parseAllDocuments } from 'yaml'
 import type { ProjectConfig } from '@ainyc/canonry-contracts'
 import { createApiClient, type ApplyResultDto } from '../client.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 
 
@@ -45,7 +46,7 @@ export async function applyConfigFile(filePath: string): Promise<ApplyFileResult
       const result = await client.apply(config)
       applied.push(result)
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       errors.push(`Document ${i + 1}: ${msg}`)
     }
   }
@@ -61,7 +62,7 @@ export async function applyConfigs(filePaths: string[], format?: string): Promis
     try {
       result = await applyConfigFile(filePath)
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = describeError(err)
       result = {
         filePath,
         applied: [],

--- a/packages/canonry/src/commands/bing.ts
+++ b/packages/canonry/src/commands/bing.ts
@@ -1,4 +1,5 @@
 import type { RunDetailDto } from '@ainyc/canonry-contracts'
+import { describeError } from '@ainyc/canonry-contracts'
 import { type ApiClient, createApiClient } from '../client.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
 import { emitJsonl } from '../cli-output.js'
@@ -368,7 +369,7 @@ export async function bingRefresh(project: string, format?: string): Promise<voi
     )
     for (const r of results) {
       if (r.status === 'rejected') {
-        errors.push(r.reason instanceof Error ? r.reason.message : String(r.reason))
+        errors.push(describeError(r.reason))
       }
     }
     if (!isMachineFormat(format)) {

--- a/packages/canonry/src/commands/cdp.ts
+++ b/packages/canonry/src/commands/cdp.ts
@@ -1,6 +1,7 @@
 import { loadConfig, saveConfigPatch } from '../config.js'
 import { createApiClient } from '../client.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 function getClient() {
   return createApiClient()
@@ -66,7 +67,7 @@ export async function cdpStatus(format?: string): Promise<void> {
       console.log('Launch Chrome with: chrome --remote-debugging-port=9222')
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     if (msg.includes('501') || msg.includes('not configured')) {
       if (isMachineFormat(format)) {
         console.log(JSON.stringify({
@@ -144,7 +145,7 @@ export async function cdpScreenshot(query: string, opts?: { targets?: string; fo
       }
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     throw new CliError({
       code: 'CDP_SCREENSHOT_FAILED',
       message: `CDP screenshot failed: ${msg}`,

--- a/packages/canonry/src/commands/daemon.ts
+++ b/packages/canonry/src/commands/daemon.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { getConfigDir } from '../config.js'
 import type { CliFormat } from '../cli-error.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 function getPidPath(): string {
   return path.join(getConfigDir(), 'canonry.pid')
@@ -214,7 +215,7 @@ export function stopDaemon(format: CliFormat = 'text'): void {
     }
     console.log(`Canonry stopped (PID: ${pid})`)
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     throw new CliError({
       code: 'DAEMON_STOP_FAILED',
       message: `Failed to stop Canonry (PID: ${pid}): ${msg}`,

--- a/packages/canonry/src/commands/discover.ts
+++ b/packages/canonry/src/commands/discover.ts
@@ -1,6 +1,6 @@
 import { createApiClient } from '../client.js'
 import type { ApiClient, DiscoveryRunStartResponse } from '../client.js'
-import { CitationStates } from '@ainyc/canonry-contracts'
+import { CitationStates, describeError } from '@ainyc/canonry-contracts'
 import type {
   DiscoveryBucket,
   DiscoveryCompetitorType,
@@ -89,7 +89,7 @@ export function summarizeAngles(sessions: readonly DiscoverySessionCounts[]): An
 }
 
 function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
+  return describeError(err)
 }
 
 export async function discoverRun(project: string, opts: DiscoverRunOptions): Promise<void> {

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -2,6 +2,7 @@ import type { GaConnectResponse, GA4PropertiesDto, GaStatusResponse, GaSyncRespo
 import { createApiClient } from '../client.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
 import { emitJsonl } from '../cli-output.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 function getClient() {
   return createApiClient()
@@ -63,7 +64,7 @@ export async function gaConnect(project: string, opts: {
       JSON.parse(content)
       body.keyJson = content
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
+      const msg = describeError(e)
       throw new CliError({
         code: 'GA_KEY_FILE_READ_ERROR',
         message: `Failed to read key file: ${msg}`,

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -7,6 +7,7 @@ import type {
 import { type ApiClient, createApiClient } from '../client.js'
 import { CliError, EXIT_SYSTEM_ERROR, isMachineFormat } from '../cli-error.js'
 import { emitJsonl } from '../cli-output.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 const INDEXING_API_SCOPE_NOTICE =
   "Note: Google's Indexing API officially supports only pages with JobPosting or BroadcastEvent (livestream VideoObject) structured data. " +
@@ -772,7 +773,7 @@ export async function submitGscSitemaps(
       const remaining = sitemapUrls.length - attempted
       const causeDetails = cause instanceof CliError
         ? { code: cause.code, message: cause.message, details: cause.details }
-        : { message: cause instanceof Error ? cause.message : String(cause) }
+        : { message: describeError(cause) }
       throw new CliError({
         code: 'GOOGLE_SITEMAP_SUBMISSION_PARTIAL',
         message: `Sitemap submission stopped at batch ${index + 1}/${batches.length}; ${aggregate.summary.accepted} accepted, ${aggregate.summary.failed} failed, ${batchSitemapUrls.length} unconfirmed, ${remaining} not attempted.`,

--- a/packages/canonry/src/commands/history.ts
+++ b/packages/canonry/src/commands/history.ts
@@ -2,6 +2,7 @@ import { createApiClient } from '../client.js'
 import { CliError } from '../cli-error.js'
 import { emitJsonl } from '../cli-output.js'
 import type { AuditLogEntry } from '@ainyc/canonry-contracts'
+import { describeError } from '@ainyc/canonry-contracts'
 
 function getClient() {
   return createApiClient()
@@ -61,7 +62,7 @@ export async function showHistory(project: string | undefined, format?: string, 
       if (entry.diff != null) console.log(`    diff: ${JSON.stringify(entry.diff)}`)
     }
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = describeError(err)
     throw new CliError({
       code: 'HISTORY_FETCH_FAILED',
       message: project ? `Failed to fetch history for project "${project}"` : 'Failed to fetch instance history',

--- a/packages/canonry/src/commands/init.ts
+++ b/packages/canonry/src/commands/init.ts
@@ -12,6 +12,7 @@ import { apiKeys } from '@ainyc/canonry-db'
 import { CliError, type CliFormat, isMachineFormat } from '../cli-error.js'
 import { installSkills, type SkillsInstallSummary } from './skills.js'
 import { installMcp, type McpInstallResult } from './mcp.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 /**
  * Hand control to `canonry serve` after init finishes.
@@ -325,7 +326,7 @@ export async function initCommand(opts?: InitOptions): Promise<ResolvedAgentLLM 
       try {
         skillsSummary = await installSkills({ dir: skillsTarget })
       } catch (err) {
-        skillsTip = `Skills auto-install failed: ${err instanceof Error ? err.message : String(err)}. Run "canonry skills install" manually.`
+        skillsTip = `Skills auto-install failed: ${describeError(err)}. Run "canonry skills install" manually.`
       }
     } else {
       skillsTip = 'Run "canonry skills install" in a project directory to add the canonry + Aero playbook to .claude/skills/ and .codex/skills/.'
@@ -352,7 +353,7 @@ export async function initCommand(opts?: InitOptions): Promise<ResolvedAgentLLM 
           process.chdir(previousCwd)
         }
       } catch (err) {
-        mcpTip = `MCP auto-install failed: ${err instanceof Error ? err.message : String(err)}. Run "canonry mcp install --client claude-code" manually.`
+        mcpTip = `MCP auto-install failed: ${describeError(err)}. Run "canonry mcp install --client claude-code" manually.`
       }
     } else {
       mcpTip = 'Run "canonry mcp install --client claude-code" in a project directory to register the canonry MCP server in `.mcp.json` for Claude Code sessions.'

--- a/packages/canonry/src/commands/mcp.ts
+++ b/packages/canonry/src/commands/mcp.ts
@@ -8,6 +8,7 @@ import {
   type McpClientFormat,
 } from '../mcp-clients.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 export interface McpInstallOptions {
   client: string
@@ -120,7 +121,7 @@ function readJsonConfig(configPath: string): Record<string, unknown> {
   } catch (err) {
     throw new CliError({
       code: 'VALIDATION_ERROR',
-      message: `Failed to parse ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+      message: `Failed to parse ${configPath}: ${describeError(err)}`,
       exitCode: 1,
       details: { configPath },
     })

--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { type ApiClient, createApiClient } from '../client.js'
-import { CitationStates, resolveProviderInput, type RunDetailDto } from '@ainyc/canonry-contracts'
+import { CitationStates, resolveProviderInput, type RunDetailDto, describeError } from '@ainyc/canonry-contracts'
 import { CliError, isMachineFormat } from '../cli-error.js'
 import { emitJsonl } from '../cli-output.js'
 
@@ -201,7 +201,7 @@ export async function triggerRunAll(opts?: { provider?: string; wait?: boolean; 
         })
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       results.push({ project: p.name, runId: '', status: 'error', location: null, error: msg })
     }
   }

--- a/packages/canonry/src/commands/serve.ts
+++ b/packages/canonry/src/commands/serve.ts
@@ -6,6 +6,7 @@ import { CliError, type CliFormat, isMachineFormat } from '../cli-error.js'
 import { backfillAiReferralPaths, backfillNormalizedPaths } from './backfill.js'
 import { getMissingUserSkillsNudge } from './skills.js'
 import { detectCanonryAgentPlugin } from '../agent-plugin.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 /**
  * Precedence: `CANONRY_PORT` env var (also set by `--port`) > config.yaml `port:` > 4100.
@@ -44,7 +45,7 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
     // Don't block startup on backfill failure — the manual CLI command
     // remains available, and the dashboards remain partially correct
     // via COALESCE for non-fragmented legacy rows.
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     process.stderr.write(`warning: normalized-path backfill skipped: ${msg}\n`)
   }
 
@@ -60,7 +61,7 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
       )
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     process.stderr.write(`warning: ai-referral-paths backfill skipped: ${msg}\n`)
   }
 
@@ -132,7 +133,7 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
       providers: providerNames,
     })
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = describeError(err)
     throw new CliError({
       code: 'SERVE_START_FAILED',
       message: `Failed to start server: ${message}`,

--- a/packages/canonry/src/commands/traffic.ts
+++ b/packages/canonry/src/commands/traffic.ts
@@ -10,7 +10,7 @@ import type {
   TrafficStatusResponse,
   TrafficSyncResponse,
 } from '@ainyc/canonry-contracts'
-import { RunStatuses, TrafficEventKinds, TrafficSeriesGranularities } from '@ainyc/canonry-contracts'
+import { RunStatuses, TrafficEventKinds, TrafficSeriesGranularities, describeError } from '@ainyc/canonry-contracts'
 import fs from 'node:fs'
 import { getCloudflareTrafficConnectionBySourceId } from '../cloudflare-traffic-config.js'
 import {
@@ -40,7 +40,7 @@ function configString(value: unknown, fallback = '(unset)'): string {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+  return describeError(error)
 }
 
 function requireCloudflareQueueOption(
@@ -440,7 +440,7 @@ export async function trafficConnectWordpress(project: string, opts: {
     try {
       applicationPassword = fs.readFileSync(opts.appPasswordFile, 'utf-8').trim()
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
+      const msg = describeError(e)
       throw new CliError({
         code: 'TRAFFIC_WP_APP_PASSWORD_FILE_READ_ERROR',
         message: `Failed to read --app-password-file: ${msg}`,
@@ -512,7 +512,7 @@ export async function trafficConnectCloudRun(project: string, opts: {
     keyJson = fs.readFileSync(opts.serviceAccountKey, 'utf-8')
     JSON.parse(keyJson)
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
+    const msg = describeError(e)
     throw new CliError({
       code: 'TRAFFIC_KEY_FILE_READ_ERROR',
       message: `Failed to read service-account key: ${msg}`,
@@ -587,7 +587,7 @@ export async function trafficConnectVercel(project: string, opts: {
     try {
       token = fs.readFileSync(opts.tokenFile, 'utf-8').trim()
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
+      const msg = describeError(e)
       throw new CliError({
         code: 'TRAFFIC_VERCEL_TOKEN_FILE_READ_ERROR',
         message: `Failed to read --token-file: ${msg}`,

--- a/packages/canonry/src/commoncrawl-sync.ts
+++ b/packages/canonry/src/commoncrawl-sync.ts
@@ -17,7 +17,7 @@ import {
   queryBacklinks,
   type BacklinkRow,
 } from '@ainyc/canonry-integration-commoncrawl'
-import { BacklinkSources, CcReleaseSyncStatuses } from '@ainyc/canonry-contracts'
+import { BacklinkSources, CcReleaseSyncStatuses, describeError } from '@ainyc/canonry-contracts'
 import { createLogger } from './logger.js'
 
 const log = createLogger('CommonCrawlSync')
@@ -207,13 +207,13 @@ export async function executeReleaseSync(
         } catch (err) {
           log.error('auto-extract.enqueue-failed', {
             syncId, release, projectId: p.id,
-            error: err instanceof Error ? err.message : String(err),
+            error: describeError(err),
           })
         }
       }
     }
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
+    const errorMsg = describeError(err)
     const finishedAt = deps.now().toISOString()
     db.update(ccReleaseSyncs).set({
       status: CcReleaseSyncStatuses.failed,

--- a/packages/canonry/src/coverage-refresh.ts
+++ b/packages/canonry/src/coverage-refresh.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { and, desc, eq, inArray } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { projects, runs } from '@ainyc/canonry-db'
-import { RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
+import { RunKinds, RunStatuses, RunTriggers, describeError } from '@ainyc/canonry-contracts'
 import type { CanonryConfig } from './config.js'
 import { getGoogleAuthConfig, getGoogleConnection } from './google-config.js'
 import { executeInspectSitemap } from './gsc-inspect-sitemap.js'
@@ -197,7 +197,7 @@ export async function maybeRefreshGscCoverage(
     log.error('refresh.failed', {
       projectId,
       runId,
-      error: err instanceof Error ? err.message : String(err),
+      error: describeError(err),
     })
   }
   return runId

--- a/packages/canonry/src/data-refresh.ts
+++ b/packages/canonry/src/data-refresh.ts
@@ -1,4 +1,5 @@
 import { createLogger } from './logger.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 const log = createLogger('DataRefresh')
 
@@ -43,7 +44,7 @@ export async function refreshAllIntegrations(client: DataRefreshClient, projectN
       log.info('integration.refreshed', { projectName, integration })
     } else {
       const reason: unknown = result.reason
-      const message = reason instanceof Error ? reason.message : String(reason)
+      const message = describeError(reason)
       log.warn('integration.refresh-failed', { projectName, integration, error: message })
     }
   })

--- a/packages/canonry/src/discovery-run.ts
+++ b/packages/canonry/src/discovery-run.ts
@@ -17,6 +17,7 @@ import {
   withRetry,
   type DiscoveryCompetitorType,
   type LocationContext,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { embedQueries } from '@ainyc/canonry-provider-gemini'
 import {
@@ -224,7 +225,7 @@ export async function executeDiscoveryRun(opts: ExecuteDiscoveryRunOptions): Pro
       competitorCount: result.competitorMap.length,
     })
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
+    const errorMsg = describeError(err)
     log.error('discovery.failed', { runId: opts.runId, sessionId: opts.sessionId, error: errorMsg })
 
     markSessionFailed(opts.db, opts.sessionId, errorMsg)

--- a/packages/canonry/src/execute-site-audit.ts
+++ b/packages/canonry/src/execute-site-audit.ts
@@ -35,6 +35,7 @@ import {
   type SiteAuditPageFactorDto,
   type SiteCrawlAuditFactorDto,
   type SiteCrawlCriticalDefectDto,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { resolvePublicHttpTarget, resolveWebhookTarget } from '@ainyc/canonry-api-routes'
 import { createLogger } from './logger.js'
@@ -692,7 +693,7 @@ export async function executeSiteAudit(
       log.warn('graph-layout.persist-failed', {
         runId,
         projectId,
-        error: error instanceof Error ? error.message : String(error),
+        error: describeError(error),
       })
       // A failed node/edge batch rolls its transaction back. Persist the
       // minimal unavailable marker separately so this new snapshot cannot be
@@ -713,7 +714,7 @@ export async function executeSiteAudit(
         log.warn('graph-layout.marker-persist-failed', {
           runId,
           projectId,
-          error: markerError instanceof Error ? markerError.message : String(markerError),
+          error: describeError(markerError),
         })
       }
     }
@@ -832,7 +833,7 @@ export async function executeSiteAudit(
         log.warn('graph-layout.cleanup-failed', {
           runId,
           projectId,
-          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          error: describeError(cleanupError),
         })
       }
       const current = db.select({ status: runs.status }).from(runs).where(eq(runs.id, runId)).get()
@@ -844,7 +845,7 @@ export async function executeSiteAudit(
   } catch (error) {
     const finishedAt = new Date().toISOString()
     const cancelled = isCancelled(error, opts.signal)
-    const message = error instanceof Error ? error.message : String(error)
+    const message = describeError(error)
     db.transaction((tx) => {
       tx.update(siteCrawlAttempts).set({
         state: cancelled ? 'cancelled' : 'failed',

--- a/packages/canonry/src/gbp-sync.ts
+++ b/packages/canonry/src/gbp-sync.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { eq, and, desc, inArray, lt } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { runs, projects, gbpLocations, gbpDailyMetrics, gbpKeywordImpressions, gbpKeywordMonthly, gbpPlaceActions, gbpLodgingSnapshots, gbpPlaceDetails, gbpAttributesSnapshots } from '@ainyc/canonry-db'
-import { buildRunErrorFromMessages, serializeRunError } from '@ainyc/canonry-contracts'
+import { buildRunErrorFromMessages, serializeRunError, describeError } from '@ainyc/canonry-contracts'
 import { refreshAccessToken } from '@ainyc/canonry-integration-google'
 import {
   listLocations,
@@ -237,7 +237,7 @@ export async function executeGbpSync(
                   placeToTouch = latestPlace.id
                 }
               } catch (placesErr) {
-                log.warn('places.failed', { runId, location: loc.locationName, error: placesErr instanceof Error ? placesErr.message : String(placesErr) })
+                log.warn('places.failed', { runId, location: loc.locationName, error: describeError(placesErr) })
               }
             }
           }
@@ -408,8 +408,8 @@ export async function executeGbpSync(
           })
           okCount++
         } catch (err) {
-          errors.set(loc.locationName, err instanceof Error ? err.message : String(err))
-          log.error('location.failed', { runId, location: loc.locationName, error: err instanceof Error ? err.message : String(err) })
+          errors.set(loc.locationName, describeError(err))
+          log.error('location.failed', { runId, location: loc.locationName, error: describeError(err) })
         }
       }))
     }
@@ -433,7 +433,7 @@ export async function executeGbpSync(
 
     log.info('sync.done', { runId, projectId, ok: okCount, failed: errors.size })
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
+    const errorMsg = describeError(err)
     db.update(runs)
       .set({ status: 'failed', error: serializeRunError({ message: errorMsg }), finishedAt: new Date().toISOString() })
       .where(eq(runs.id, runId))

--- a/packages/canonry/src/gsc-inspect-paced.ts
+++ b/packages/canonry/src/gsc-inspect-paced.ts
@@ -1,4 +1,4 @@
-import { withRetry, isRetryableHttpError } from '@ainyc/canonry-contracts'
+import { withRetry, isRetryableHttpError, describeError } from '@ainyc/canonry-contracts'
 import { sharedRateGate } from './inspect-rate-gate.js'
 
 /**
@@ -266,7 +266,7 @@ export async function inspectUrlsPaced<TResult>(
             url,
             attempt,
             delayMs: Math.round(delayMs),
-            error: err instanceof Error ? err.message : String(err),
+            error: describeError(err),
           }),
       })
         cb.onResult(url, result, index)

--- a/packages/canonry/src/gsc-inspect-sitemap.ts
+++ b/packages/canonry/src/gsc-inspect-sitemap.ts
@@ -13,6 +13,7 @@ import { fetchAndParseSitemap } from './sitemap-parser.js'
 import { writeCoverageSnapshot } from './gsc-coverage-snapshot.js'
 import { createLogger } from './logger.js'
 import { inspectUrlsPaced, INSPECT_FAILFAST_THRESHOLD, INSPECT_SWEEP_MAX_URLS, INSPECT_DAILY_QUOTA } from './gsc-inspect-paced.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 const log = createLogger('InspectSitemap')
 
@@ -130,7 +131,7 @@ export async function executeInspectSitemap(
           log.info('inspect.url-done', { runId, projectId, url: pageUrl, progress: `${index + 1}/${urls.length}` })
         },
         onError: (pageUrl, err) => {
-          log.error('inspect.url-failed', { runId, projectId, url: pageUrl, error: err instanceof Error ? err.message : String(err) })
+          log.error('inspect.url-failed', { runId, projectId, url: pageUrl, error: describeError(err) })
         },
       },
       {
@@ -148,7 +149,7 @@ export async function executeInspectSitemap(
     )
 
     if (aborted) {
-      const detail = abortError instanceof Error ? abortError.message : String(abortError)
+      const detail = describeError(abortError)
       throw new Error(
         `URL inspection aborted after ${INSPECT_FAILFAST_THRESHOLD} consecutive rate/access failures (likely GSC URL Inspection quota exhaustion or property access loss). Last error: ${detail}`,
       )
@@ -175,7 +176,7 @@ export async function executeInspectSitemap(
 
     log.info('inspect.completed', { runId, projectId, inspected, errors, total: urls.length, indexed: snapIndexed, notIndexed: snapNotIndexed })
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
+    const errorMsg = describeError(err)
     db.update(runs)
       .set({ status: 'failed', error: errorMsg, finishedAt: new Date().toISOString() })
       .where(eq(runs.id, runId))

--- a/packages/canonry/src/gsc-sitemap-submission.ts
+++ b/packages/canonry/src/gsc-sitemap-submission.ts
@@ -1,6 +1,7 @@
 import type { GscSubmitSitemapsResponseDto } from '@ainyc/canonry-contracts'
 import type { ApiClient } from './client.js'
 import { CliError, EXIT_SYSTEM_ERROR } from './cli-error.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 export type DiscoveredGscSitemapMode = 'indexes' | 'all-files'
 
@@ -97,7 +98,7 @@ export async function submitGscSitemapBatches(
           partialResult: aggregate,
           cause: cause instanceof CliError
             ? { code: cause.code, message: cause.message, details: cause.details }
-            : { message: cause instanceof Error ? cause.message : String(cause) },
+            : { message: describeError(cause) },
         },
       })
     }

--- a/packages/canonry/src/gsc-sync.ts
+++ b/packages/canonry/src/gsc-sync.ts
@@ -8,7 +8,7 @@ import {
   GSC_DATA_LAG_DAYS,
   GSC_REPORTING_TIME_ZONE,
 } from '@ainyc/canonry-integration-google'
-import { formatIsoDateInTimeZone, shiftIsoCalendarDate } from '@ainyc/canonry-contracts'
+import { formatIsoDateInTimeZone, shiftIsoCalendarDate, describeError } from '@ainyc/canonry-contracts'
 import type { CanonryConfig } from './config.js'
 import { saveConfigPatch } from './config.js'
 import { writeCoverageSnapshot } from './gsc-coverage-snapshot.js'
@@ -291,7 +291,7 @@ export async function executeGscSync(
 
     log.info('sync.completed', { runId, projectId, searchDataRows: rows.length, indexed: coverage.indexed, notIndexed: coverage.notIndexed, unknown: coverage.unknown, verifiedByInspection: coverage.verifiedByInspection })
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
+    const errorMsg = describeError(err)
     db.update(runs)
       .set({ status: 'failed', error: errorMsg, finishedAt: new Date().toISOString() })
       .where(eq(runs.id, runId))

--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -6,7 +6,7 @@ import { and, eq, inArray, ne, sql } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { runs, queries, competitors, projects, querySnapshots, siteCrawlAttempts, usageCounters } from '@ainyc/canonry-db'
 import type { ProviderName, LocationContext, MeasurementRunManifestV1 } from '@ainyc/canonry-contracts'
-import { CITED_URL_CAPTURE_VERSION, ONBOARDING_FLOW_VERSION, RunKinds, bucketOnboardingCount, buildRunErrorFromMessages, determineAnswerMentioned, effectiveBrandNames, effectiveDomains, isBrowserProvider, normalizeMeasurementExecutionQueryText, parseMeasurementRunManifestV1, providerSupportsLocationContext, serializeRunError } from '@ainyc/canonry-contracts'
+import { CITED_URL_CAPTURE_VERSION, ONBOARDING_FLOW_VERSION, RunKinds, bucketOnboardingCount, buildRunErrorFromMessages, determineAnswerMentioned, effectiveBrandNames, effectiveDomains, isBrowserProvider, normalizeMeasurementExecutionQueryText, parseMeasurementRunManifestV1, providerSupportsLocationContext, serializeRunError, describeError } from '@ainyc/canonry-contracts'
 import type { ProviderRegistry, RegisteredProvider } from './provider-registry.js'
 import { trackEvent } from './telemetry.js'
 import { buildRunCompletedProps, hashDomain, type RunPhaseTimings } from './run-telemetry.js'
@@ -530,7 +530,7 @@ export class JobRunner {
                 runId,
                 provider: providerName,
                 query: q.query,
-                error: err instanceof Error ? err.message : String(err),
+                error: describeError(err),
               })
             }
             this.throwIfRunCancelled(runId)
@@ -641,7 +641,7 @@ export class JobRunner {
             throw err
           }
 
-          const msg = err instanceof Error ? err.message : String(err)
+          const msg = describeError(err)
           const stack = err instanceof Error ? err.stack : undefined
           log.error('query.failed', { runId, provider: providerName, query: q.query, error: msg, stack })
           if (!providerErrors.has(providerName)) {
@@ -720,7 +720,7 @@ export class JobRunner {
                 runId,
                 provider: providerName,
                 query: unit.queryText,
-                error: err instanceof Error ? err.message : String(err),
+                error: describeError(err),
               })
             }
             this.throwIfRunCancelled(runId)
@@ -812,7 +812,7 @@ export class JobRunner {
             throw err
           }
 
-          const msg = err instanceof Error ? err.message : String(err)
+          const msg = describeError(err)
           const stack = err instanceof Error ? err.stack : undefined
           log.error('query.failed', { runId, provider: providerName, query: unit.queryText, executionId: unit.executionId, error: msg, stack })
           if (!providerErrors.has(providerName)) {
@@ -964,7 +964,7 @@ export class JobRunner {
       // Notify after run completion
       if (this.onRunCompleted) {
         this.onRunCompleted(runId, projectId).catch((err: unknown) => {
-          log.error('notification.callback-failed', { runId, error: err instanceof Error ? err.message : String(err) })
+          log.error('notification.callback-failed', { runId, error: describeError(err) })
         })
       }
     } catch (err: unknown) {
@@ -984,7 +984,7 @@ export class JobRunner {
       }
 
       // Mark run as failed
-      const errorMessage = err instanceof Error ? err.message : String(err)
+      const errorMessage = describeError(err)
       this.db
         .update(runs)
         .set({
@@ -1040,7 +1040,7 @@ export class JobRunner {
       // Notify on failure too
       if (this.onRunCompleted) {
         this.onRunCompleted(runId, projectId).catch((notifErr: unknown) => {
-          log.error('notification.callback-failed', { runId, error: notifErr instanceof Error ? notifErr.message : String(notifErr) })
+          log.error('notification.callback-failed', { runId, error: describeError(notifErr) })
         })
       }
     }
@@ -1160,7 +1160,7 @@ export class JobRunner {
 
     if (this.onRunCompleted) {
       this.onRunCompleted(runId, projectId).catch((err: unknown) => {
-        log.error('notification.callback-failed', { runId, error: err instanceof Error ? err.message : String(err) })
+        log.error('notification.callback-failed', { runId, error: describeError(err) })
       })
     }
   }

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -60,6 +60,7 @@ import {
   measurementQueryTemplateApplyRequestSchema,
   measurementQueryTemplateUpsertRequestSchema,
   type NotificationEvent,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { z } from 'zod'
 import type { ApiClient } from '../client.js'
@@ -442,7 +443,7 @@ async function submitGscSitemapsFromMcp(
           partialResult: aggregate,
           cause: cause instanceof CliError
             ? { code: cause.code, message: cause.message, details: cause.details }
-            : { message: cause instanceof Error ? cause.message : String(cause) },
+            : { message: describeError(cause) },
         },
       })
     }

--- a/packages/canonry/src/notifier.ts
+++ b/packages/canonry/src/notifier.ts
@@ -6,6 +6,7 @@ import type { NotificationEvent, WebhookPayload, InsightWebhookPayload, HealthWe
 import type { AnalysisResult } from '@ainyc/canonry-intelligence'
 import crypto from 'node:crypto'
 import { createLogger } from './logger.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 const log = createLogger('Notifier')
 
@@ -519,7 +520,7 @@ export class Notifier {
           this.logDelivery(projectId, notificationId, payload.event, 'failed', errorDetail)
         }
       } catch (err: unknown) {
-        const errorDetail = err instanceof Error ? err.message : String(err)
+        const errorDetail = describeError(err)
         if (attempt === maxRetries - 1) {
           this.logDelivery(projectId, notificationId, payload.event, 'failed', errorDetail)
           log.error('webhook.exhausted', { event: payload.event, url: targetLabel, maxRetries, error: errorDetail })

--- a/packages/canonry/src/research-runner.ts
+++ b/packages/canonry/src/research-runner.ts
@@ -8,6 +8,7 @@ import {
   mapWithConcurrency,
   ResearchQueryStatuses,
   ResearchRunStatuses,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { computeCitedCompetitorDomains, determineCitationState, extractRecommendedCompetitors } from './citation-utils.js'
 import type { ProviderRegistry } from './provider-registry.js'
@@ -103,7 +104,7 @@ export async function executeResearchRun(db: DatabaseClient, registry: ProviderR
         try {
           markResearchQueryFailed(db, runId, row.id, error)
         } catch (persistenceError) {
-          workerPersistenceErrors.push(persistenceError instanceof Error ? persistenceError.message : String(persistenceError))
+          workerPersistenceErrors.push(describeError(persistenceError))
         }
       }
     })
@@ -111,7 +112,7 @@ export async function executeResearchRun(db: DatabaseClient, registry: ProviderR
       fatalError = `Failed to persist one or more research query results: ${workerPersistenceErrors[0]}`
     }
   } catch (error) {
-    fatalError = error instanceof Error ? error.message : String(error)
+    fatalError = describeError(error)
   } finally {
     // A failure before or between worker writes must still leave this batch in a
     // terminal state. Mark only unfinished children so completed evidence stays intact.
@@ -129,7 +130,7 @@ function incrementResearchProgress(db: DatabaseClient, runId: string, column: 'c
 }
 
 function markResearchQueryFailed(db: DatabaseClient, runId: string, queryId: string, error: unknown): void {
-  const message = error instanceof Error ? error.message : String(error)
+  const message = describeError(error)
   const failed = db.update(researchRunQueries).set({ status: ResearchQueryStatuses.failed, error: message, finishedAt: new Date().toISOString() })
     .where(and(eq(researchRunQueries.id, queryId), inArray(researchRunQueries.status, unfinishedResearchQueryStatuses))).run()
   if (failed.changes === 1) incrementResearchProgress(db, runId, 'failedQueries')

--- a/packages/canonry/src/run-coordinator.ts
+++ b/packages/canonry/src/run-coordinator.ts
@@ -6,6 +6,7 @@ import {
   RunTriggers,
   type DiscoveryCompetitorMapEntry,
   type RunKind,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { measurementRunCompleteness } from '@ainyc/canonry-api-routes'
 import type { Notifier } from './notifier.js'
@@ -96,7 +97,7 @@ export class RunCoordinator {
       try {
         await this.notifier.onRunCompleted(runId, projectId)
       } catch (err) {
-        log.error('notifier.failed', { runId, error: err instanceof Error ? err.message : String(err) })
+        log.error('notifier.failed', { runId, error: describeError(err) })
       }
       return
     }
@@ -121,12 +122,12 @@ export class RunCoordinator {
             try {
               await this.onInsightsGenerated(runId, projectId, result)
             } catch (err) {
-              log.error('insight-webhook.failed', { runId, error: err instanceof Error ? err.message : String(err) })
+              log.error('insight-webhook.failed', { runId, error: describeError(err) })
             }
           }
         }
       } catch (err) {
-        log.error('intelligence.failed', { runId, error: err instanceof Error ? err.message : String(err) })
+        log.error('intelligence.failed', { runId, error: describeError(err) })
       }
     } else if (kind === RunKinds['gbp-sync']) {
       // GBP sync runs produce location-scoped local-AEO insights (lodging gaps,
@@ -144,11 +145,11 @@ export class RunCoordinator {
           try {
             await this.onInsightsGenerated(runId, projectId, analysisResultFromInsights(gbpInsights))
           } catch (err) {
-            log.error('gbp-insight-webhook.failed', { runId, error: err instanceof Error ? err.message : String(err) })
+            log.error('gbp-insight-webhook.failed', { runId, error: describeError(err) })
           }
         }
       } catch (err) {
-        log.error('gbp-intelligence.failed', { runId, error: err instanceof Error ? err.message : String(err) })
+        log.error('gbp-intelligence.failed', { runId, error: describeError(err) })
       }
     }
 
@@ -156,7 +157,7 @@ export class RunCoordinator {
     try {
       await this.notifier.onRunCompleted(runId, projectId)
     } catch (err) {
-      log.error('notifier.failed', { runId, error: err instanceof Error ? err.message : String(err) })
+      log.error('notifier.failed', { runId, error: describeError(err) })
     }
 
     // 3. Aero — enqueue + drain so the built-in agent wakes up unprompted.
@@ -173,7 +174,7 @@ export class RunCoordinator {
             }
         await this.onAeroEvent(ctx)
       } catch (err) {
-        log.error('aero.failed', { runId, error: err instanceof Error ? err.message : String(err) })
+        log.error('aero.failed', { runId, error: describeError(err) })
       }
     }
   }

--- a/packages/canonry/src/scheduler.ts
+++ b/packages/canonry/src/scheduler.ts
@@ -12,6 +12,7 @@ import {
   RunTriggers,
   normalizeSiteAuditRunRequest,
   siteAuditRequestIdentity,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { createLogger } from './logger.js'
 
@@ -566,7 +567,7 @@ export class Scheduler {
       log.info('run.triggered', { runId, projectName: project.name, providers: providers ?? 'all' })
       this.callbacks.onRunCreated(runId, projectId, providers, resolvedLocation)
     } catch (err: unknown) {
-      log.error('trigger.error', { scheduleId, projectId, kind, error: err instanceof Error ? err.message : String(err) })
+      log.error('trigger.error', { scheduleId, projectId, kind, error: describeError(err) })
     }
   }
 }

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -57,6 +57,7 @@ import {
   type AdsAdGroupBillingEventType,
   type ProviderAdapter,
   type AgentPluginState,
+  describeError,
 } from "@ainyc/canonry-contracts";
 import type {
   CanonryConfig,
@@ -629,7 +630,7 @@ export async function createServer(opts: {
     dropLegacyCredentialColumns(opts.db);
   } catch (err) {
     log.warn("credentials.migration.failed", {
-      error: err instanceof Error ? err.message : String(err),
+      error: describeError(err),
     });
   }
 
@@ -1265,7 +1266,7 @@ export async function createServer(opts: {
           {
             projectName,
             sourceId,
-            err: err instanceof Error ? err.message : String(err),
+            err: describeError(err),
           },
           "Scheduled traffic sync failed",
         );
@@ -1359,7 +1360,7 @@ export async function createServer(opts: {
               {
                 projectName,
                 release: probed.release,
-                err: err instanceof Error ? err.message : String(err),
+                err: describeError(err),
               },
               "Scheduled backlinks sync failed",
             );

--- a/packages/canonry/src/sitemap-parser.ts
+++ b/packages/canonry/src/sitemap-parser.ts
@@ -1,5 +1,6 @@
 import { resolveWebhookTarget } from '@ainyc/canonry-api-routes'
 import { createLogger } from './logger.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 const log = createLogger('SitemapParser')
 
@@ -74,7 +75,7 @@ async function parseSitemapRecursive(
     if (!isChild) throw err
     log.warn('child-sitemap.fetch-failed', {
       url,
-      error: err instanceof Error ? err.message : String(err),
+      error: describeError(err),
     })
     return
   }
@@ -94,7 +95,7 @@ async function parseSitemapRecursive(
     if (!isChild) throw err
     log.warn('child-sitemap.parse-failed', {
       url,
-      error: err instanceof Error ? err.message : String(err),
+      error: describeError(err),
     })
     return
   }

--- a/packages/canonry/src/snapshot-service.ts
+++ b/packages/canonry/src/snapshot-service.ts
@@ -7,6 +7,7 @@ import {
   resolveSnapshotRequestQueries,
   textContainsBrandAlias,
   textContainsDomain,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import type {
   GroundingSource,
@@ -139,7 +140,7 @@ export class SnapshotService {
       const report = await runAeoAudit(homepageUrl)
       return mapAuditReport(report)
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = describeError(err)
       log.warn('audit.failed', { homepageUrl, error: message })
       return {
         url: homepageUrl,
@@ -190,7 +191,7 @@ export class SnapshotService {
         log.warn('profile.generation-failed', {
           domain: ctx.domain,
           provider: ctx.analysisProvider.adapter.name,
-          error: err instanceof Error ? err.message : String(err),
+          error: describeError(err),
         })
       }
     }
@@ -294,7 +295,7 @@ export class SnapshotService {
               groundingSources: [],
               searchQueries: [],
               answerText: '',
-              error: err instanceof Error ? err.message : String(err),
+              error: describeError(err),
             } satisfies SnapshotProviderResultDto
           }
         })
@@ -384,7 +385,7 @@ export class SnapshotService {
     } catch (err) {
       log.warn('response.analysis-failed', {
         provider: ctx.analysisProvider.adapter.name,
-        error: err instanceof Error ? err.message : String(err),
+        error: describeError(err),
       })
       return buildFallbackBatchAssessment(ctx.companyName, ctx.audit)
     }

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -8,7 +8,7 @@ Shared DTOs, enums, Zod schemas, error codes, config validation, and **generic u
 
 | File | Role |
 |------|------|
-| `src/errors.ts` | `AppError` class, `ErrorCode` union (15 codes), factory functions |
+| `src/errors.ts` | `AppError` class, `ErrorCode` union (27 codes), factory functions, and `describeError` — the shared way to render a caught `unknown` as text. Prefer it over `err instanceof Error ? err.message : String(err)` everywhere: that `String()` branch renders a thrown plain object as `[object Object]`, and `@typescript-eslint/no-base-to-string` only catches it where the value is typed `unknown`. `describeError` keeps the Error and string paths identical, reports null/undefined as `'unknown error'`, JSON-serializes anything else, and never throws. Note the one place it must NOT be used: `integration-cloudflare-worker`'s generated Worker source is a template literal, so a call there would compile to a reference the edge bundle cannot resolve. |
 | `src/provider.ts` | `ProviderName`, `ProviderConfig`, `ProviderAdapter` interface |
 | `src/project.ts` | Project DTOs and Zod schemas |
 | `src/run.ts` | Run and grounding source types |

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -245,3 +245,43 @@ export function internalError(message: string, details?: Record<string, unknown>
 export function runtimeStateMissing(message: string, details?: Record<string, unknown>): AppError {
   return new AppError('RUNTIME_STATE_MISSING', message, 503, details)
 }
+
+/**
+ * Render an unknown caught value as human-readable text for a log line, an
+ * error field, or a message to the operator.
+ *
+ * `catch (err)` binds `unknown`, and the reflex is
+ * `err instanceof Error ? err.message : String(err)`. That `String(err)` is
+ * the problem: a thrown plain object renders `[object Object]`, so the one
+ * line written to explain a failure explains nothing, and the detail is gone
+ * by the time anyone reads it. Rejected promises from HTTP and SDK layers
+ * throw non-`Error` objects often enough for this to be the common case, not
+ * the exotic one.
+ *
+ * Never throws — a helper on the failure path that can itself fail would
+ * replace a logged error with a crash.
+ */
+export function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  if (err === null || err === undefined) return 'unknown error'
+  try {
+    // lib.es5.d.ts types this `string`, but it genuinely returns `undefined`
+    // for a function or symbol input. The assertion corrects the lib, so the
+    // guard below is real rather than "unnecessary".
+    const json = JSON.stringify(err) as string | undefined
+    if (json !== undefined) return json
+  } catch {
+    // Circular references and BigInt both make JSON.stringify throw.
+  }
+  try {
+    // The one intentional base-to-string in the monorepo. Reaching it means
+    // JSON.stringify already declined the value, so '[object Object]' here is
+    // the floor rather than the careless default the rule exists to catch.
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    return String(err)
+  } catch {
+    // A null-prototype or throwing-`toString` object cannot be stringified.
+    return 'unknown error'
+  }
+}

--- a/packages/contracts/test/errors.test.ts
+++ b/packages/contracts/test/errors.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { AppError, describeError, notFound, validationError } from '../src/errors.js'
+
+describe('describeError', () => {
+  it('returns the message of an Error', () => {
+    expect(describeError(new Error('boom'))).toBe('boom')
+    expect(describeError(new TypeError('bad type'))).toBe('bad type')
+  })
+
+  it('returns the message of an AppError subclass', () => {
+    expect(describeError(notFound('Project', 'acme'))).toBe("Project 'acme' not found")
+    expect(describeError(validationError('"queries" must be non-empty'))).toBe(
+      '"queries" must be non-empty',
+    )
+    expect(describeError(new AppError('INTERNAL_ERROR', 'oops', 500))).toBe('oops')
+  })
+
+  it('preserves an empty Error message rather than substituting a placeholder', () => {
+    // The caller threw an Error with nothing in it; inventing text here would
+    // claim detail the throw site never provided.
+    expect(describeError(new Error(''))).toBe('')
+  })
+
+  it('returns a thrown string unchanged', () => {
+    expect(describeError('plain failure')).toBe('plain failure')
+    expect(describeError('')).toBe('')
+  })
+
+  it('reports null and undefined as "unknown error"', () => {
+    expect(describeError(null)).toBe('unknown error')
+    expect(describeError(undefined)).toBe('unknown error')
+  })
+
+  it('serializes a plain object instead of rendering "[object Object]"', () => {
+    // The whole point of the helper: String({code:'E'}) is '[object Object]',
+    // which is the useless log line this replaces.
+    expect(describeError({ code: 'E_LIMIT', message: 'rate limited' })).toBe(
+      '{"code":"E_LIMIT","message":"rate limited"}',
+    )
+    expect(describeError({})).toBe('{}')
+  })
+
+  it('serializes an array', () => {
+    expect(describeError([1, 'two'])).toBe('[1,"two"]')
+    expect(describeError([])).toBe('[]')
+  })
+
+  it('renders primitives the way String() did, so migrated call sites do not change', () => {
+    expect(describeError(42)).toBe('42')
+    expect(describeError(0)).toBe('0')
+    expect(describeError(true)).toBe('true')
+    expect(describeError(false)).toBe('false')
+  })
+
+  it('falls back to String() when JSON.stringify throws on a circular reference', () => {
+    const circular: Record<string, unknown> = { name: 'loop' }
+    circular.self = circular
+    expect(describeError(circular)).toBe('[object Object]')
+  })
+
+  it('falls back to String() when JSON.stringify throws on a BigInt', () => {
+    expect(describeError(BigInt(7))).toBe('7')
+  })
+
+  it('falls back to String() when JSON.stringify returns undefined', () => {
+    // Functions and symbols are not JSON-representable.
+    expect(describeError(Symbol('token'))).toBe('Symbol(token)')
+    expect(describeError(function named() {})).toContain('named')
+  })
+
+  it('reports "unknown error" when the value cannot be stringified at all', () => {
+    // Circular AND null-prototype: JSON.stringify throws, then String() throws
+    // too. The helper must still return, not propagate a second failure out of
+    // the catch block that was handling the first one.
+    const hostile = Object.create(null) as Record<string, unknown>
+    hostile.self = hostile
+    expect(describeError(hostile)).toBe('unknown error')
+  })
+
+  it('never throws, whatever it is handed', () => {
+    const throwingToString = {
+      toString() {
+        throw new Error('nope')
+      },
+      toJSON() {
+        throw new Error('also nope')
+      },
+    }
+    expect(() => describeError(throwingToString)).not.toThrow()
+    expect(describeError(throwingToString)).toBe('unknown error')
+  })
+
+  it('uses a custom toJSON when the value defines one', () => {
+    expect(describeError({ toJSON: () => ({ reason: 'quota' }) })).toBe('{"reason":"quota"}')
+  })
+
+  it('serializes an AppError-shaped plain object thrown by a non-Error path', () => {
+    expect(describeError({ error: { code: 'NOT_FOUND', message: 'gone' } })).toBe(
+      '{"error":{"code":"NOT_FOUND","message":"gone"}}',
+    )
+  })
+})

--- a/packages/integration-traffic/scripts/refresh-ip-ranges.ts
+++ b/packages/integration-traffic/scripts/refresh-ip-ranges.ts
@@ -25,6 +25,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { validateIpRangeManifestPayload } from '../src/ip-range-manifest.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const rangesDir = path.resolve(dirname, '..', 'src', 'ip-ranges')
@@ -121,7 +122,7 @@ async function refreshOne(source: Source): Promise<FetchResult> {
     return {
       source,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: describeError(err),
     }
   }
 }

--- a/packages/integration-wordpress/src/wordpress-client.ts
+++ b/packages/integration-wordpress/src/wordpress-client.ts
@@ -18,7 +18,7 @@ import type {
   WordpressSeoStateDto,
   WordpressSiteStatusDto,
 } from '@ainyc/canonry-contracts'
-import { wordpressEnvSchema } from '@ainyc/canonry-contracts'
+import { wordpressEnvSchema, describeError } from '@ainyc/canonry-contracts'
 import type { WordpressConnectionRecord, WordpressRestPage, WordpressSiteContext } from './types.js'
 import { WordpressApiError } from './types.js'
 import type { SchemaPageEntry, SchemaProfileFile } from './schema-templates.js'
@@ -439,7 +439,7 @@ export async function getSiteStatus(
       authenticatedUser: userInfo,
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
+    const message = describeError(error)
     return {
       url: site.siteUrl,
       reachable: false,
@@ -811,7 +811,7 @@ export async function bulkSetSeoMeta(
         return {
           slug: entry.slug,
           status: 'skipped',
-          error: error instanceof Error ? error.message : String(error),
+          error: describeError(error),
         }
       }
     },
@@ -909,7 +909,7 @@ export async function deploySchema(
     return {
       slug,
       status: 'failed',
-      error: error instanceof Error ? error.message : String(error),
+      error: describeError(error),
     }
   }
 }

--- a/packages/provider-cdp/src/adapter.ts
+++ b/packages/provider-cdp/src/adapter.ts
@@ -13,6 +13,7 @@ import { chatgptTarget } from './targets/chatgpt.js'
 import { captureElementScreenshot } from './screenshot.js'
 import { normalizeResult as cdpNormalizeResult } from './normalize.js'
 import { CDPProviderError } from './targets/types.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 // Connection pool keyed by "host:port" — one manager per distinct CDP endpoint.
 // Using a map (instead of a single shared singleton) prevents concurrent calls
@@ -98,7 +99,7 @@ export const cdpChatgptAdapter: ProviderAdapter = {
       return {
         ok: false,
         provider: 'cdp:chatgpt',
-        message: err instanceof Error ? err.message : String(err),
+        message: describeError(err),
       }
     }
   },
@@ -157,7 +158,7 @@ export const cdpChatgptAdapter: ProviderAdapter = {
         screenshotPath: capturedScreenshotPath,
       }
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = describeError(err)
       throw new Error(`[provider-cdp] ${msg}`)
     }
   },

--- a/packages/provider-cdp/src/connection.ts
+++ b/packages/provider-cdp/src/connection.ts
@@ -1,6 +1,7 @@
 import CDP from 'chrome-remote-interface'
 import type { CDPTarget } from './targets/types.js'
 import { CDPProviderError } from './targets/types.js'
+import { describeError } from '@ainyc/canonry-contracts'
 
 interface TabEntry {
   client: CDP.Client
@@ -110,7 +111,7 @@ export class CDPConnectionManager {
     } catch (err) {
       throw new CDPProviderError(
         'CDP_CONNECTION_REFUSED',
-        `Failed to connect to Chrome at ${this.host}:${this.port}: ${err instanceof Error ? err.message : String(err)}`,
+        `Failed to connect to Chrome at ${this.host}:${this.port}: ${describeError(err)}`,
       )
     }
   }
@@ -131,7 +132,7 @@ export class CDPConnectionManager {
     } catch (err) {
       throw new CDPProviderError(
         'CDP_TARGET_SELECTOR_FAILED',
-        `Failed to navigate to ${target.newConversationUrl}: ${err instanceof Error ? err.message : String(err)}`,
+        `Failed to navigate to ${target.newConversationUrl}: ${describeError(err)}`,
       )
     }
 

--- a/packages/provider-claude/src/normalize.ts
+++ b/packages/provider-claude/src/normalize.ts
@@ -6,6 +6,7 @@ import {
   hostOf,
   normalizeServedModel,
   registrableDomain,
+  describeError,
 } from "@ainyc/canonry-contracts";
 import { withRetry } from "./utils.js";
 import type {
@@ -122,7 +123,7 @@ export async function healthcheck(
     return {
       ok: false,
       provider: "claude",
-      message: err instanceof Error ? err.message : String(err),
+      message: describeError(err),
       model: resolveModel(config),
     };
   }
@@ -179,7 +180,7 @@ export async function executeTrackedQuery(
       retrievalContract: CLAUDE_RETRIEVAL_CONTRACT,
     };
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = describeError(err);
     throw new Error(`[provider-claude] ${msg}`);
   }
 }

--- a/packages/provider-claude/src/utils.ts
+++ b/packages/provider-claude/src/utils.ts
@@ -1,4 +1,4 @@
-import { withRetry as sharedWithRetry, isRetryableHttpError } from '@ainyc/canonry-contracts'
+import { withRetry as sharedWithRetry, isRetryableHttpError, describeError } from '@ainyc/canonry-contracts'
 
 /**
  * Provider-flavored `withRetry` — pre-binds the shared retry helper (in
@@ -25,7 +25,7 @@ export async function withRetry<T>(
     onRetry: ({ attempt, err, delayMs }) => {
       console.warn(
         `[provider] Attempt ${attempt + 1} failed, retrying in ${delayMs}ms...`,
-        err instanceof Error ? err.message : String(err),
+        describeError(err),
       )
     },
   })

--- a/packages/provider-gemini/src/normalize.ts
+++ b/packages/provider-gemini/src/normalize.ts
@@ -6,6 +6,7 @@ import {
   hostOf,
   normalizeServedModel,
   registrableDomain,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { withRetry } from './utils.js'
 import type {
@@ -113,7 +114,7 @@ export async function healthcheck(config: GeminiConfig): Promise<GeminiHealthche
     return {
       ok: false,
       provider: 'gemini',
-      message: err instanceof Error ? err.message : String(err),
+      message: describeError(err),
       model: config.model ?? DEFAULT_MODEL,
     }
   }
@@ -147,7 +148,7 @@ export async function executeTrackedQuery(input: GeminiTrackedQueryInput): Promi
       searchQueries: parsed.searchQueries,
     }
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     throw new Error(`[provider-gemini] ${msg}`)
   }
 }

--- a/packages/provider-gemini/src/utils.ts
+++ b/packages/provider-gemini/src/utils.ts
@@ -1,4 +1,4 @@
-import { withRetry as sharedWithRetry, isRetryableHttpError } from '@ainyc/canonry-contracts'
+import { withRetry as sharedWithRetry, isRetryableHttpError, describeError } from '@ainyc/canonry-contracts'
 
 /**
  * Provider-flavored `withRetry` — pre-binds the shared retry helper (in
@@ -25,7 +25,7 @@ export async function withRetry<T>(
     onRetry: ({ attempt, err, delayMs }) => {
       console.warn(
         `[provider] Attempt ${attempt + 1} failed, retrying in ${delayMs}ms...`,
-        err instanceof Error ? err.message : String(err),
+        describeError(err),
       )
     },
   })

--- a/packages/provider-local/src/normalize.ts
+++ b/packages/provider-local/src/normalize.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai'
-import { hostOf, normalizeServedModel, registrableDomain } from '@ainyc/canonry-contracts'
+import { hostOf, normalizeServedModel, registrableDomain, describeError } from '@ainyc/canonry-contracts'
 import { withRetry } from './utils.js'
 import type {
   GroundingSource,
@@ -52,7 +52,7 @@ export async function healthcheck(config: LocalConfig): Promise<LocalHealthcheck
     return {
       ok: false,
       provider: 'local',
-      message: err instanceof Error ? err.message : String(err),
+      message: describeError(err),
       model: config.model ?? DEFAULT_MODEL,
     }
   }
@@ -93,7 +93,7 @@ export async function executeTrackedQuery(input: LocalTrackedQueryInput): Promis
       searchQueries: [],
     }
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     throw new Error(`[provider-local] ${msg}`)
   }
 }

--- a/packages/provider-local/src/utils.ts
+++ b/packages/provider-local/src/utils.ts
@@ -1,4 +1,4 @@
-import { withRetry as sharedWithRetry, isRetryableHttpError } from '@ainyc/canonry-contracts'
+import { withRetry as sharedWithRetry, isRetryableHttpError, describeError } from '@ainyc/canonry-contracts'
 
 /**
  * Provider-flavored `withRetry` — pre-binds the shared retry helper (in
@@ -25,7 +25,7 @@ export async function withRetry<T>(
     onRetry: ({ attempt, err, delayMs }) => {
       console.warn(
         `[provider] Attempt ${attempt + 1} failed, retrying in ${delayMs}ms...`,
-        err instanceof Error ? err.message : String(err),
+        describeError(err),
       )
     },
   })

--- a/packages/provider-openai/src/normalize.ts
+++ b/packages/provider-openai/src/normalize.ts
@@ -5,6 +5,7 @@ import {
   hostOf,
   normalizeServedModel,
   registrableDomain,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { withRetry } from './utils.js'
 import type {
@@ -65,7 +66,7 @@ export async function healthcheck(config: OpenAIConfig): Promise<OpenAIHealthche
     return {
       ok: false,
       provider: 'openai',
-      message: err instanceof Error ? err.message : String(err),
+      message: describeError(err),
       model: config.model ?? DEFAULT_MODEL,
     }
   }
@@ -108,7 +109,7 @@ export async function executeTrackedQuery(input: OpenAITrackedQueryInput): Promi
       searchQueries: parsed.searchQueries,
     }
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     throw new Error(`[provider-openai] ${msg}`)
   }
 }

--- a/packages/provider-openai/src/utils.ts
+++ b/packages/provider-openai/src/utils.ts
@@ -1,4 +1,4 @@
-import { withRetry as sharedWithRetry, isRetryableHttpError } from '@ainyc/canonry-contracts'
+import { withRetry as sharedWithRetry, isRetryableHttpError, describeError } from '@ainyc/canonry-contracts'
 
 /**
  * Provider-flavored `withRetry` — pre-binds the shared retry helper (in
@@ -25,7 +25,7 @@ export async function withRetry<T>(
     onRetry: ({ attempt, err, delayMs }) => {
       console.warn(
         `[provider] Attempt ${attempt + 1} failed, retrying in ${delayMs}ms...`,
-        err instanceof Error ? err.message : String(err),
+        describeError(err),
       )
     },
   })

--- a/packages/provider-perplexity/src/normalize.ts
+++ b/packages/provider-perplexity/src/normalize.ts
@@ -5,6 +5,7 @@ import {
   hostOf,
   normalizeServedModel,
   registrableDomain,
+  describeError,
 } from '@ainyc/canonry-contracts'
 import { withRetry } from './utils.js'
 import type {
@@ -54,7 +55,7 @@ export async function healthcheck(config: PerplexityConfig): Promise<PerplexityH
     return {
       ok: false,
       provider: 'perplexity',
-      message: err instanceof Error ? err.message : String(err),
+      message: describeError(err),
       model: config.model ?? DEFAULT_MODEL,
     }
   }
@@ -86,7 +87,7 @@ export async function executeTrackedQuery(input: PerplexityTrackedQueryInput): P
       searchQueries: parsed.searchQueries,
     }
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     throw new Error(`[provider-perplexity] ${msg}`)
   }
 }

--- a/packages/provider-perplexity/src/utils.ts
+++ b/packages/provider-perplexity/src/utils.ts
@@ -1,4 +1,4 @@
-import { withRetry as sharedWithRetry, isRetryableHttpError } from '@ainyc/canonry-contracts'
+import { withRetry as sharedWithRetry, isRetryableHttpError, describeError } from '@ainyc/canonry-contracts'
 
 /**
  * Provider-flavored `withRetry` — pre-binds the shared retry helper (in
@@ -25,7 +25,7 @@ export async function withRetry<T>(
     onRetry: ({ attempt, err, delayMs }) => {
       console.warn(
         `[provider] Attempt ${attempt + 1} failed, retrying in ${delayMs}ms...`,
-        err instanceof Error ? err.message : String(err),
+        describeError(err),
       )
     },
   })

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.165.2",
+  "version": "4.166.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.165.2",
+  "version": "4.166.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.165.2",
+  "version": "4.166.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## What

Adds `describeError(err: unknown): string` to `packages/contracts/src/errors.ts` and replaces the 168 hand-written copies of `err instanceof Error ? err.message : String(err)` across 11 packages with a call to it.

## Why

`catch (err)` binds `unknown`, and the reflex is that ternary. The `String(err)` branch renders a thrown plain object as `[object Object]`, so the one line written to explain a failure explains nothing. HTTP and SDK layers reject with non-`Error` objects often enough that this is the common case, not the exotic one. `@typescript-eslint/no-base-to-string` only catches it where the value is typed `unknown`, which is why 168 copies accumulated.

Most sites are not transient logs. They write into `runs.error`, notification bodies, discovery-session failure reasons, doctor-check summaries, and per-slug WordPress deploy errors — columns where `[object Object]` is unrecoverable after the fact, because the thrown value is long gone by the time anyone reads the row.

## Behavior

Identical for the two paths that matter: `Error` yields `.message`, a string yields itself. Numbers and booleans render as before. What changes:

| input | before | after |
|---|---|---|
| `{code:'E'}` | `[object Object]` | `{"code":"E"}` |
| `null` / `undefined` | `'null'` / `'undefined'` | `'unknown error'` |
| `[1,2]` | `'1,2'` | `'[1,2]'` |

The helper never throws: circular references and BigInt fall back to `String()`, and a value that cannot be stringified at all returns `'unknown error'` rather than propagating a second failure out of the handler for the first.

## Reviewing

One commit per package, in dependency order. The five migration commits are pure codemod output apart from one hand edit noted below, so they can be skimmed; the helper and its tests are the part worth reading.

## Things worth a reviewer's attention

- **`integration-cloudflare-worker` is deliberately excluded.** Its three matches sit inside the template literal that generates the deployed Worker source. Substituting the helper would emit a call the edge bundle cannot resolve — a `ReferenceError` inside the catch block that exists to never mask the customer response.
- **Four sites string-match the result** (`client.ts` on `'fetch failed'`/`'ECONNREFUSED'`, `commands/cdp.ts` and `CdpConfigCard.tsx` on `'501'`). All are fed by `fetch()` and `CliError`, both `Error` instances, so the matched text is byte-identical. A non-`Error` there previously produced a constant that could never match either pattern.
- **The local `describeError` in `bing-inspect-sitemap.ts` is deleted.** The shared helper is a superset: the local one answered `'unserializable error'` when `JSON.stringify` threw, and could return `undefined` from a `string` signature because `JSON.stringify(fn)` is `undefined`.
- **`JSON.stringify` can serialize secrets** into logs and DB columns where `[object Object]` could not. A thrown config or request object now lands in full in `runs.error`. Flagging rather than pre-solving — a size cap or redaction pass is a reasonable follow-up if that is a concern.
- **Left alone on purpose:** ~8 sites using a bespoke human-readable fallback (`: 'Could not load run history.'`) — converting those would replace deliberate copy with a serialized blob. Also `apps/web/src/lib/extract-error-message.ts`, which has the same defect in its `String()` fallback but is an SDK-envelope unwrapper whose tests explicitly assert the current `'[object Object]'` behavior.

## Verification

`pnpm typecheck` and `pnpm lint` both clean. `pnpm test`: 8615 of 8617 pass. The 2 failures are 5000ms timeouts in `apps/web` files this branch does not touch and that do not reference the helper; both pass in isolation (22/22), consistent with the suite-level CPU contention #1012 addressed.

The helper's 15 tests were mutation-checked: reverting `describeError` to the old idiom fails 7 of them.

Version bumped to 4.166.0 (minor rather than 4.165.2, which an unmerged branch already claims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)