### PR TITLE
A throttled link is not a broken link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.167.0",
+  "version": "4.167.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.167.0",
+  "version": "4.167.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/execute-site-audit.ts
+++ b/packages/canonry/src/execute-site-audit.ts
@@ -270,6 +270,19 @@ function deadLinkCheckedCount(edges: Iterable<CrawlEdgeObservation>, pages: Iter
     .map((edge) => edge.to)).size
 }
 
+/**
+ * "Too Many Requests" is the server describing OUR request rate, not the
+ * resource. It is the one error status that is never evidence about the link,
+ * so reporting it as broken blames a site for how hard we crawled it — the
+ * same mistake as reporting a timeout, arriving with a status code attached.
+ *
+ * The engine classifies this correctly from 6.0.0 (`reason: 'throttled'`), but
+ * this repo pins 4.7.0 and the published 5.0.0 carries the bug too, so the
+ * platform has to make the call itself. Redundant once the dependency moves,
+ * exactly like the null-status branch beside it.
+ */
+const RATE_LIMITED_STATUS = 429
+
 /** One dead-link row as the engine reports it, across engine versions. */
 interface EngineLinkFinding {
   key: string
@@ -299,9 +312,11 @@ function partitionDeadLinks(deadLinks: SiteCrawlReport['deadLinks']): {
   const engineUnverified = (deadLinks as { unverified?: EngineLinkFinding[] }).unverified ?? []
   // `typeof` rather than `!== null` so this keeps compiling once the engine
   // narrows `statusCode` to a plain number.
-  const dead = reported.filter((finding) => typeof finding.statusCode === 'number' && finding.statusCode >= 400)
+  const answeredWithError = (finding: EngineLinkFinding): boolean =>
+    typeof finding.statusCode === 'number' && finding.statusCode >= 400
+  const dead = reported.filter((finding) => answeredWithError(finding) && finding.statusCode !== RATE_LIMITED_STATUS)
   const unverified = [
-    ...reported.filter((finding) => typeof finding.statusCode !== 'number'),
+    ...reported.filter((finding) => !answeredWithError(finding) || finding.statusCode === RATE_LIMITED_STATUS),
     ...engineUnverified,
   ]
   return { dead, unverified }

--- a/packages/canonry/test/site-audit-dead-link-partition.test.ts
+++ b/packages/canonry/test/site-audit-dead-link-partition.test.ts
@@ -263,6 +263,45 @@ describe('site audit persists broken links and unfetchable links as different th
     expect(snapshot.deadLinksUnverified).toBe(1)
   })
 
+  it('a throttled target is unchecked, not broken', async () => {
+    // 429 is the server describing OUR request rate. It is the one error status
+    // that says nothing about the resource, so filing it as a broken link
+    // blames the site for how hard we crawled it — the same mistake as filing a
+    // timeout, arriving with a status code attached.
+    const { snapshot, findings } = await run({
+      state: 'complete',
+      findings: [
+        { key: 'dead-link:gone', from: ROOT, to: GONE, statusCode: 404, reason: 'http-error' },
+        { key: 'dead-link:busy', from: ROOT, to: FLAKY, statusCode: 429, reason: 'http-error' },
+      ],
+    })
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({ targetUrl: GONE })
+    expect(findings.some((row) => (row.evidence as { statusCode?: unknown }).statusCode === 429)).toBe(false)
+    expect(snapshot.deadLinksFound).toBe(1)
+    expect(snapshot.deadLinksUnverified).toBe(1)
+  })
+
+  it('keeps every other 4xx and 5xx a dead link, so 429 is a carve-out and not a hole', async () => {
+    // The risk of special-casing a status is over-reaching into ones that ARE
+    // evidence. 404/410/500/503 all stay findings.
+    const { snapshot, findings } = await run({
+      state: 'complete',
+      findings: [404, 410, 500, 503].map((statusCode, index) => ({
+        key: `dead-link:${statusCode}`,
+        from: ROOT,
+        to: `https://example.com/broken-${index}`,
+        statusCode,
+        reason: 'http-error',
+      })),
+    })
+
+    expect(findings).toHaveLength(4)
+    expect(snapshot.deadLinksFound).toBe(4)
+    expect(snapshot.deadLinksUnverified).toBe(0)
+  })
+
   it('a clean crawl reports zero of both, so the counts are not merely never-zero', async () => {
     const { snapshot, findings } = await run({ state: 'complete', findings: [], unverified: [] })
     expect(findings).toHaveLength(0)

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.167.0",
+  "version": "4.167.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.167.0",
+  "version": "4.167.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.167.0",
+  "version": "4.167.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## What

`partitionDeadLinks` asked only whether the status was `>= 400`, so an HTTP `429` was filed as a broken link. It now goes to `unverified` alongside targets that never answered.

```
dead       = answered 4xx/5xx  AND NOT 429
unverified = never answered    OR  429      (+ what the engine already split out)
```

## Why

429 is the server describing **our** request rate, not the resource. It is the one error status that is never evidence about the link, so reporting it as broken blames a site for how hard we crawled it. That is the same defect #1013 just fixed for timeouts and reset sockets — this is the variant that arrives with a status code attached, which is exactly why the earlier filter missed it.

## Why not just take the engine fix

`@canonry/aeo-audit` 6.0.0 classifies this correctly (`reason: 'throttled'`, and it retries first, honouring `Retry-After`). But this repo pins `4.7.0`, and the published `5.0.0` carries the same bug — so the upgrade is not a fix on its own. It also pulls 5.0.0's scoring change, which moves every page score and deserves its own release with a re-baselined score.

Waiting on that would leave a known instance of the defect live in front of clients. So the platform makes the call itself. This becomes redundant once the dependency moves, exactly like the null-status branch beside it.

## Implementation note

`answeredWithError` is extracted rather than inlining the negation. The `unverified` filter has to be the exact complement of `dead`; two mirrored boolean expressions drift into either dropping a finding from both buckets or counting it in both. One shared predicate makes that structurally impossible.

## Tests

Both directions, and both verified falsifiable (reverting the predicate fails the throttled case):

- a 429 target is unchecked, not broken, and no persisted row carries `statusCode: 429`
- `404` / `410` / `500` / `503` all stay dead links — the guard that this is a carve-out and not a hole, and the one that matters if someone later reasons "5xx is transient too" and widens the exclusion

## Data

No backfill. There are currently zero stored dead-link findings of any kind (migration 140 cleared the fabricated ones and nothing has re-scanned since), so no historical 429 rows exist to reclassify.

`pnpm verify` clean: gen:check, plugin:check, typecheck, lint, 663 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)