### PR TITLE
fix(google-marketing): accept the form POST the OAuth confirm page itself sends

### DIFF
--- a/packages/api-routes/src/google-marketing.ts
+++ b/packages/api-routes/src/google-marketing.ts
@@ -930,6 +930,29 @@ function oauthConfirmationHtml(input: {
  * and sanitized, append-only evidence rows.
  */
 export async function googleMarketingRoutes(app: FastifyInstance, opts: GoogleMarketingRoutesOptions) {
+  // The OAuth confirmation page this module serves is plain server-rendered HTML
+  // whose only control is a `<form method="post">`. Browsers submit that as
+  // `application/x-www-form-urlencoded`, and Fastify parses bodies before the
+  // handler runs, so without a parser for that type the submit answered
+  // `415 Unsupported Media Type` and the request never reached the route. That
+  // made the final step of every Google Ads and GTM connection impossible to
+  // complete: the server's own button posted to an endpoint the server refused.
+  //
+  // Registered HERE rather than on the root instance on purpose. Fastify scopes
+  // content-type parsers to the encapsulation context, and this module is added
+  // with `api.register(googleMarketingRoutes, ...)`, so the rest of the API keeps
+  // rejecting form bodies and stays JSON-only.
+  //
+  // The body is deliberately discarded. The confirmation id travels in the path
+  // and the browser binding is the HttpOnly cookie, so the form carries no
+  // fields worth reading, and accepting an empty object keeps a submitted field
+  // from ever reaching the handler as input.
+  app.addContentTypeParser(
+    'application/x-www-form-urlencoded',
+    { parseAs: 'string' },
+    (_request, _body, done) => { done(null, {}) },
+  )
+
   const pendingOAuthFlows = new PendingGoogleMarketingOAuthFlows()
   let stateSecret: string | null = null
   if (opts.googleStateSecret !== undefined) {

--- a/packages/api-routes/test/google-marketing-routes.test.ts
+++ b/packages/api-routes/test/google-marketing-routes.test.ts
@@ -79,7 +79,14 @@ async function confirmGoogleMarketingOAuth(ctx: TestContext, callback: { body: s
       host: 'canonry.example',
       origin: 'https://canonry.example',
       cookie: 'canonry_test_browser_session=present',
+      // What the confirmation page's own `<form method="post">` sends. Omitting
+      // it made every confirm assertion below pass against a request no browser
+      // produces: with no content-type Fastify skips body parsing entirely, so
+      // the suite was green while the real button answered 415 and no Google
+      // Ads or GTM connection could be completed on any install.
+      'content-type': 'application/x-www-form-urlencoded',
     },
+    payload: '',
   })
 }
 


### PR DESCRIPTION
## What

The OAuth confirmation page this module serves is plain server-rendered HTML whose only control is a `<form method="post">`. Browsers submit that as `application/x-www-form-urlencoded`. Fastify parses bodies before the handler runs, and no parser was registered for that type, so the submit answered `415 Unsupported Media Type` and never reached the route.

The server's own Confirm button posted to an endpoint the server refused.

## Impact

Confirmation is the final step of the OAuth flow, so **no Google Ads or GTM connection could be completed on any install**. The callback succeeded, minted a confirmation id, and rendered a button that could not work. This is the headline feature of 4.172.0.

Found while connecting a real Google Ads account. Every attempt ended at `{"code":"VALIDATION_ERROR","message":"Unsupported Media Type"}`.

Reproduced by content type against a live server:

| Content-Type | Result |
|---|---|
| *(none)* | reaches the handler |
| `text/plain` | reaches the handler |
| `application/json` | reaches the handler |
| **`application/x-www-form-urlencoded`** | **415, before the handler** |

## Why this shape of fix

The form-POST is deliberate: the page is server-rendered and works without JavaScript. The defect is the missing parser, not the page, so the page is unchanged.

The parser is registered **inside this module**, not on the root instance. Fastify scopes content-type parsers to the encapsulation context and this module is added with `api.register(googleMarketingRoutes, ...)`, so every other route keeps rejecting form bodies and the API stays JSON-only.

The body is discarded. The confirmation id travels in the path and the browser binding is the HttpOnly cookie, so the form carries no fields worth reading, and accepting an empty object also prevents a submitted field ever reaching the handler as input.

## Why the suite missed it

The test helper posted with **no** `content-type`, which makes Fastify skip body parsing entirely. That is a request no browser sends, so the suite was green while the real button was broken.

The helper now sends the header the confirmation page's own form sends, which makes the existing assertions exercise the real path. Verified by mutation: reverting the parser now fails **5 tests** that were previously green.

## Verification

`packages/api-routes`: 155 files / 2832 tests pass. Typecheck clean.

30 changed lines, under the 100-line threshold, so no version bump.