### PR TITLE
fix(google-marketing): report why a provider discovery call failed

### DIFF
--- a/packages/api-routes/src/google-marketing.ts
+++ b/packages/api-routes/src/google-marketing.ts
@@ -62,6 +62,8 @@ import {
   type GtmContainerListResponse,
   type GtmRawSnapshotDto,
   type GtmWorkspaceListResponse,
+  describeError,
+  AppError,
 } from '@ainyc/canonry-contracts'
 import { assertNotProjectScoped, requireAdminSession, requireBroadInstanceKey, requireScope } from './auth.js'
 import { auditFromRequest, resolveProject, writeAuditLog } from './helpers.js'
@@ -929,6 +931,27 @@ function oauthConfirmationHtml(input: {
  * secrets are host-injected; this plugin stores only typed selection metadata
  * and sanitized, append-only evidence rows.
  */
+/**
+ * Turn a failed provider call into an error an operator can act on.
+ *
+ * These calls fail for a small set of SETUP reasons that look identical from the
+ * dashboard: the API is not enabled on the Cloud project that owns the OAuth
+ * client, the developer token is not approved, or the OAuth user cannot see the
+ * account. Google says which of those it is, precisely. A bare `catch` used to
+ * discard that and answer "discovery failed", which left the operator with no
+ * next step: diagnosing one real case needed a `gcloud services list` against
+ * the Cloud project, because nothing in the product said the API was disabled.
+ *
+ * The provider error is logged in full, and a short summary reaches the caller.
+ * These routes already require an admin session, and Google's messages carry no
+ * credentials, so the summary discloses nothing the operator cannot already see.
+ */
+function discoveryFailure(app: FastifyInstance, what: string, err: unknown): AppError {
+  app.log.error({ err, discovery: what }, `${what} failed`)
+  const detail = describeError(err).trim()
+  return providerError(detail ? `${what} failed: ${detail}` : `${what} failed.`)
+}
+
 export async function googleMarketingRoutes(app: FastifyInstance, opts: GoogleMarketingRoutesOptions) {
   // The OAuth confirmation page this module serves is plain server-rendered HTML
   // whose only control is a `<form method="post">`. Browsers submit that as
@@ -1044,8 +1067,8 @@ export async function googleMarketingRoutes(app: FastifyInstance, opts: GoogleMa
         try {
           authorizationUrl = await adapter.authorizationUrl({ provider, redirectUri, state, scopes })
           new URL(authorizationUrl)
-        } catch {
-          throw providerError('Could not start the Google Marketing OAuth flow.')
+        } catch (err) {
+          throw discoveryFailure(app, 'Google Marketing OAuth start', err)
         }
 
         // Do not persist a supplied developer token until the signed-in browser
@@ -1326,8 +1349,8 @@ export async function googleMarketingRoutes(app: FastifyInstance, opts: GoogleMa
     let result: GoogleAdsAccessibleCustomersResponse
     try {
       result = googleAdsAccessibleCustomersResponseSchema.parse(await reader.listGoogleAdsCustomers(projectRef))
-    } catch {
-      throw providerError('Google Ads customer discovery failed.')
+    } catch (err) {
+      throw discoveryFailure(app, 'Google Ads customer discovery', err)
     }
     return result
   })
@@ -1341,8 +1364,8 @@ export async function googleMarketingRoutes(app: FastifyInstance, opts: GoogleMa
     const reader = requireLiveReader(opts)
     try {
       return gtmAccountsResponseSchema.parse(await reader.listGtmAccounts(projectRef))
-    } catch {
-      throw providerError('Google Tag Manager account discovery failed.')
+    } catch (err) {
+      throw discoveryFailure(app, 'Google Tag Manager account discovery', err)
     }
   })
 
@@ -1357,8 +1380,8 @@ export async function googleMarketingRoutes(app: FastifyInstance, opts: GoogleMa
     const reader = requireLiveReader(opts)
     try {
       return gtmContainerListResponseSchema.parse(await reader.listGtmContainers(projectRef, accountId))
-    } catch {
-      throw providerError('Google Tag Manager container discovery failed.')
+    } catch (err) {
+      throw discoveryFailure(app, 'Google Tag Manager container discovery', err)
     }
   })
 
@@ -1380,8 +1403,8 @@ export async function googleMarketingRoutes(app: FastifyInstance, opts: GoogleMa
         selection.accountId,
         selection.containerId,
       ))
-    } catch {
-      throw providerError('Google Tag Manager workspace discovery failed.')
+    } catch (err) {
+      throw discoveryFailure(app, 'Google Tag Manager workspace discovery', err)
     }
   })
 

--- a/packages/api-routes/test/google-marketing-routes.test.ts
+++ b/packages/api-routes/test/google-marketing-routes.test.ts
@@ -92,12 +92,15 @@ async function confirmGoogleMarketingOAuth(ctx: TestContext, callback: { body: s
 
 interface BuildAppOptions {
   includeLiveReader?: boolean
+  /** Make discovery throw, mirroring a real Google setup failure. */
+  liveReaderError?: Error
   publicUrl?: string | null
   routePrefix?: string
 }
 
 function buildApp({
   includeLiveReader = true,
+  liveReaderError,
   publicUrl = 'https://canonry.example',
   routePrefix,
 }: BuildAppOptions = {}): TestContext {
@@ -205,6 +208,7 @@ function buildApp({
       googleMarketingLiveReader: {
         listGoogleAdsCustomers: async () => {
           liveCalls.push('google-ads-customers')
+          if (liveReaderError) throw liveReaderError
           return {
             customers: [], totalAccessible: 0, truncated: false,
             selection: { loginCustomerId: null, customerId: null, selectedAt: null }, fetchedAt: NOW,
@@ -1225,4 +1229,31 @@ describe('Google Marketing routes', () => {
     expect(staleIntegrity.statusCode).toBe(200)
     expect(staleIntegrity.json()).toMatchObject({ googleAdsSnapshot: null, gtmSnapshot: null })
   })
+
+  it('surfaces the provider cause when discovery fails, instead of a dead end', async () => {
+    // The real failure this came from: the Google Ads API was not enabled on the
+    // Cloud project that owns the OAuth client. Google says exactly that, but a
+    // bare `catch` discarded it and answered "discovery failed", so diagnosing it
+    // needed `gcloud services list` against the project. Nothing in the product
+    // pointed there. Assert the cause reaches the operator.
+    const cause = new Error(
+      'Google Ads API has not been used in project 701814655766 before or it is disabled (SERVICE_DISABLED)',
+    )
+    const ctx = buildApp({ liveReaderError: cause })
+    contexts.push(ctx)
+    await connectGoogleAds(ctx)
+
+    const res = await ctx.app.inject({
+      method: 'GET',
+      url: '/projects/acme/google-ads/customers',
+    })
+    expect(res.statusCode).toBe(502)
+    const body = JSON.parse(res.payload) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe('PROVIDER_ERROR')
+    // Names the operation AND why it failed. The bare-catch version returned
+    // only the first half, which is what made it undiagnosable.
+    expect(body.error.message).toContain('Google Ads customer discovery failed')
+    expect(body.error.message).toContain('SERVICE_DISABLED')
+  })
+
 })


### PR DESCRIPTION
## What

Five discovery paths caught the provider error with a bare `catch` and threw a fixed string, discarding the cause and logging nothing:

```js
} catch {
  throw providerError('Google Ads customer discovery failed.')
}
```

## Why it matters

These calls fail for a small set of **setup** reasons that are indistinguishable from the dashboard:

- the API is not enabled on the Cloud project that owns the OAuth client
- the developer token is not approved
- the OAuth user cannot see the account

Google names which one, precisely. All of it was thrown away, and nothing was written to the log, so there was nowhere to look either.

Diagnosing one real occurrence took a `gcloud services list` against the Cloud project to find that `googleads.googleapis.com` had simply never been enabled. Google had said exactly that. The product replaced it with "discovery failed" and left the operator with no next step.

## The change

The provider error is logged in full, and a short summary reaches the caller. These routes already require an admin session and Google's messages carry no credentials, so the summary discloses nothing the operator cannot already see in the Cloud console.

Applied to all five sites, so OAuth start and the Ads / GTM account / container / workspace discoveries behave consistently.

Before and after, for the real case:

```
before:  Google Ads customer discovery failed.
after:   Google Ads customer discovery failed: Google Ads API has not been used
         in project 701814655766 before or it is disabled (SERVICE_DISABLED)
```

## Verification

`packages/api-routes`: 156 files / 2857 tests pass.

The harness gains a live reader that throws, and the new case asserts a `SERVICE_DISABLED` cause reaches the response. Verified by mutation: reverting one site fails on the assertion that matters, `expected 'Google Ads customer discovery failed.' to contain 'SERVICE_DISABLED'`.

64 changed lines, under the 100-line threshold, so no version bump.