### PR TITLE
feat(web): simplify conversion setup and connection management

### DIFF
--- a/apps/web/src/components/project/ConversionIntegritySection.tsx
+++ b/apps/web/src/components/project/ConversionIntegritySection.tsx
@@ -451,6 +451,145 @@ function providerRow({
   )
 }
 
+function ConversionIntegritySetup({
+  workspace,
+  action,
+  onPrimaryAction,
+  onChangeGoogleAdsSelection,
+  onChangeGtmSelection,
+  actionPending,
+  actionError,
+}: {
+  workspace: ConversionIntegrityWorkspaceVm
+  action: PrimaryActionPresentation
+  onPrimaryAction?: (action: ConversionIntegrityPrimaryAction) => void
+  onChangeGoogleAdsSelection?: () => void
+  onChangeGtmSelection?: () => void
+  actionPending: boolean
+  actionError: string | null
+}) {
+  const googleAdsReady = workspace.googleAds.state === 'connected'
+  const gtmReady = workspace.gtm.state === 'connected'
+  const steps = [
+    {
+      title: 'Google Ads account',
+      ready: googleAdsReady,
+      summary: workspace.googleAds.selection,
+      detail: 'Connect read-only access and choose the customer account.',
+      changeLabel: 'Change Google Ads account',
+      onChange: onChangeGoogleAdsSelection,
+    },
+    {
+      title: 'Tag Manager container',
+      ready: gtmReady,
+      summary: workspace.gtm.selection,
+      detail: 'Connect read-only access and choose the container.',
+      changeLabel: 'Change Tag Manager container',
+      onChange: onChangeGtmSelection,
+    },
+    {
+      title: 'Conversion to check',
+      ready: false,
+      summary: null,
+      detail: 'Choose the website event, conversion action, and tag to check.',
+      changeLabel: null,
+      onChange: undefined,
+    },
+  ]
+  const activeStep = steps.findIndex((step) => !step.ready)
+
+  return (
+    <section className="page-section" aria-labelledby="conversion-integrity-title">
+      <div className="section-head mb-5">
+        <div>
+          <p className="eyebrow">Google marketing</p>
+          <h2 id="conversion-integrity-title" className="mt-1 text-xl font-semibold tracking-[-0.02em] text-heading">
+            Conversion Integrity
+          </h2>
+          <p className="lede mt-2">Check one website conversion across Tag Manager and Google Ads.</p>
+        </div>
+      </div>
+
+      <div className="max-w-3xl pt-3">
+        <h3 className="text-base font-semibold text-heading">Complete setup</h3>
+        <p className="supporting-copy mt-2 max-w-2xl">
+          Connect your existing Google accounts, then choose the conversion Canonry should check.
+        </p>
+
+        <ol className="mt-5 divide-y divide-default border-y border-default">
+          {steps.map((step, index) => {
+            const isActive = index === activeStep
+            const detail = step.ready ? step.summary ?? 'Connected' : isActive ? action.detail : step.detail
+
+            return (
+              <li
+                key={step.title}
+                aria-current={isActive ? 'step' : undefined}
+                className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 py-4"
+              >
+                <span
+                  aria-hidden="true"
+                  className={`flex size-7 items-center justify-center rounded-full border text-xs font-semibold ${step.ready ? 'border-positive bg-positive-soft text-positive' : isActive ? 'border-strong bg-surface-active text-heading' : 'border-base text-muted'}`}
+                >
+                  {step.ready ? '✓' : index + 1}
+                </span>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                    <h4 className="text-sm font-semibold text-heading">{step.title}</h4>
+                    {step.ready ? <ToneBadge tone="positive">Ready</ToneBadge> : null}
+                    {step.summary && step.changeLabel && step.onChange ? (
+                      <WriteButton
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        aria-label={step.changeLabel}
+                        disabled={actionPending}
+                        onClick={step.onChange}
+                      >
+                        Change
+                      </WriteButton>
+                    ) : null}
+                  </div>
+                  {isActive && !step.ready && step.summary ? (
+                    <p className="mt-1 max-w-xl text-sm font-medium text-heading">{step.summary}</p>
+                  ) : null}
+                  <p className="mt-1 max-w-xl text-sm leading-6 text-secondary">{detail}</p>
+                  {isActive && onPrimaryAction ? (
+                    <div className="mt-3">
+                      {action.id === 'retry-connection-status' ? (
+                        <Button
+                          type="button"
+                          disabled={actionPending}
+                          onClick={() => onPrimaryAction(action.id)}
+                        >
+                          {actionPending ? 'Working…' : action.label}
+                        </Button>
+                      ) : (
+                        <WriteButton
+                          type="button"
+                          disabled={actionPending}
+                          onClick={() => onPrimaryAction(action.id)}
+                        >
+                          {actionPending ? 'Working…' : action.label}
+                        </WriteButton>
+                      )}
+                    </div>
+                  ) : null}
+                  {isActive && actionError ? <p role="alert" className="mt-2 text-sm text-negative">{actionError}</p> : null}
+                </div>
+              </li>
+            )
+          })}
+        </ol>
+
+        <p className="mt-4 text-sm leading-6 text-secondary">
+          Canonry reads your Google configuration. It does not change or publish it.
+        </p>
+      </div>
+    </section>
+  )
+}
+
 export function ConversionIntegritySection({
   workspace = EMPTY_CONVERSION_INTEGRITY_WORKSPACE,
   onPrimaryAction,
@@ -491,6 +630,24 @@ export function ConversionIntegritySection({
   const nonPassingFindings = findings.filter((finding) => finding.outcome !== 'pass')
   const passingFindings = findings.filter((finding) => finding.outcome === 'pass')
   const findingsTone: MetricTone = nonPassingFindings.some((finding) => finding.outcome === 'fail') ? 'negative' : 'caution'
+  const setupIncomplete = contracts.length === 0
+    && workspace.contract === null
+    && !workspace.contractSelectionRequired
+    && contractError === null
+
+  if (setupIncomplete) {
+    return (
+      <ConversionIntegritySetup
+        workspace={workspace}
+        action={action}
+        onPrimaryAction={onPrimaryAction}
+        onChangeGoogleAdsSelection={onChangeGoogleAdsSelection}
+        onChangeGtmSelection={onChangeGtmSelection}
+        actionPending={actionPending}
+        actionError={actionError}
+      />
+    )
+  }
 
   return (
     <section className="page-section" aria-labelledby="conversion-integrity-title">

--- a/apps/web/src/components/project/ConversionIntegrityWorkspace.tsx
+++ b/apps/web/src/components/project/ConversionIntegrityWorkspace.tsx
@@ -7,6 +7,8 @@ import type {
   GtmConnectionStatusDto,
 } from '@ainyc/canonry-api-client'
 import {
+  deleteApiV1ProjectsByNameGoogleAdsConnectionMutation,
+  deleteApiV1ProjectsByNameGtmConnectionMutation,
   getApiV1ProjectsByNameConversionTrackingContractsByContractIdIntegrityOptions,
   getApiV1ProjectsByNameConversionTrackingContractsOptions,
   getApiV1ProjectsByNameGoogleAdsCustomersOptions,
@@ -328,6 +330,84 @@ function CheckField({
   )
 }
 
+function DisconnectConnection({
+  providerLabel,
+  disabled,
+  onDisconnect,
+}: {
+  providerLabel: string
+  disabled: boolean
+  onDisconnect: () => Promise<void>
+}) {
+  const [armed, setArmed] = useState(false)
+  const [disconnecting, setDisconnecting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const controlRef = useRef<HTMLDivElement>(null)
+  const keepConnectedRef = useRef<HTMLButtonElement>(null)
+  const wasArmedRef = useRef(false)
+
+  useEffect(() => {
+    const wasArmed = wasArmedRef.current
+    wasArmedRef.current = armed
+    if (armed) keepConnectedRef.current?.focus()
+    else if (wasArmed) controlRef.current?.querySelector<HTMLButtonElement>('button')?.focus()
+  }, [armed])
+
+  function arm() {
+    setError(null)
+    setArmed(true)
+  }
+
+  function cancel() {
+    setError(null)
+    setArmed(false)
+  }
+
+  async function disconnect() {
+    setDisconnecting(true)
+    setError(null)
+    try {
+      await onDisconnect()
+    } catch (disconnectError) {
+      setError(extractErrorMessage(disconnectError))
+      setDisconnecting(false)
+    }
+  }
+
+  return (
+    <div ref={controlRef} className="mt-5 border-t border-subtle pt-4">
+      {armed ? (
+        <div role="group" aria-label={`Confirm disconnect ${providerLabel}`} className="max-w-2xl">
+          <p className="text-sm font-medium text-heading">Remove Canonry's stored access and selection?</p>
+          <p className="mt-1 text-sm leading-6 text-secondary">
+            Saved evidence and conversion contracts remain. New checks stop until you reconnect.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button ref={keepConnectedRef} type="button" variant="outline" size="sm" className="min-h-11" disabled={disconnecting} onClick={cancel}>
+              Keep connected
+            </Button>
+            <WriteButton type="button" variant="destructive" size="sm" className="min-h-11" disabled={disabled || disconnecting} onClick={() => void disconnect()}>
+              {disconnecting ? 'Disconnecting…' : `Disconnect ${providerLabel}`}
+            </WriteButton>
+          </div>
+          {error ? <p role="alert" className="mt-2 text-sm text-negative">{error}</p> : null}
+        </div>
+      ) : (
+        <WriteButton
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="min-h-11 text-negative hover:text-negative"
+          disabled={disabled}
+          onClick={arm}
+        >
+          Disconnect {providerLabel}
+        </WriteButton>
+      )}
+    </div>
+  )
+}
+
 export function ConversionIntegrityWorkspace({ projectId, projectName }: { projectId: string; projectName: string }) {
   const account = useAccount()
   const [actionError, setActionError] = useState<string | null>(null)
@@ -416,6 +496,8 @@ export function ConversionIntegrityWorkspace({ projectId, projectName }: { proje
   const gtmSelectionMutation = useMutation(putApiV1ProjectsByNameGtmSelectionMutation({ client: heyClient }))
   const googleAdsSyncMutation = useMutation(postApiV1ProjectsByNameGoogleAdsSyncMutation({ client: heyClient }))
   const gtmSyncMutation = useMutation(postApiV1ProjectsByNameGtmSyncMutation({ client: heyClient }))
+  const googleAdsDisconnectMutation = useMutation(deleteApiV1ProjectsByNameGoogleAdsConnectionMutation({ client: heyClient }))
+  const gtmDisconnectMutation = useMutation(deleteApiV1ProjectsByNameGtmConnectionMutation({ client: heyClient }))
   const createContractMutation = useMutation(postApiV1ProjectsByNameConversionTrackingContractsMutation({ client: heyClient }))
 
   useEffect(() => {
@@ -545,6 +627,8 @@ export function ConversionIntegrityWorkspace({ projectId, projectName }: { proje
     || gtmSelectionMutation.isPending
     || googleAdsSyncMutation.isPending
     || gtmSyncMutation.isPending
+    || googleAdsDisconnectMutation.isPending
+    || gtmDisconnectMutation.isPending
     || createContractMutation.isPending
     || googleMarketingSyncInFlight
 
@@ -768,6 +852,50 @@ export function ConversionIntegrityWorkspace({ projectId, projectName }: { proje
     } catch (error) {
       setActionError(extractErrorMessage(error))
     }
+  }
+
+  async function disconnectGoogleAds() {
+    assertCanWrite(account)
+    setActionError(null)
+    await googleAdsDisconnectMutation.mutateAsync({ path: { name: projectName } })
+    setSelectionPanel(null)
+    setShowGoogleAdsConnect(false)
+    setGoogleAdsCustomerId('')
+    setLoginCustomerId('')
+    setGoogleAdsSelectionSeeded(false)
+    setOauthNotice(null)
+    await refreshStoredEvidence()
+    addToast({
+      title: 'Google Ads disconnected',
+      detail: 'Stored evidence and conversion contracts were retained.',
+      tone: 'neutral',
+      dedupeKey: `google-ads-disconnected:${projectId}`,
+      dedupeMode: 'replace',
+    })
+    openerRef.current = null
+    scheduleAfterRender(() => focusElement(document.getElementById('conversion-integrity-title')))
+  }
+
+  async function disconnectGtm() {
+    assertCanWrite(account)
+    setActionError(null)
+    await gtmDisconnectMutation.mutateAsync({ path: { name: projectName } })
+    setSelectionPanel(null)
+    setGtmAccountId('')
+    setGtmContainerId('')
+    setGtmWorkspaceId('')
+    setGtmSelectionSeeded(false)
+    setOauthNotice(null)
+    await refreshStoredEvidence()
+    addToast({
+      title: 'Tag Manager disconnected',
+      detail: 'Stored evidence and conversion contracts were retained.',
+      tone: 'neutral',
+      dedupeKey: `gtm-disconnected:${projectId}`,
+      dedupeMode: 'replace',
+    })
+    openerRef.current = null
+    scheduleAfterRender(() => focusElement(document.getElementById('conversion-integrity-title')))
   }
 
   async function queueGoogleAdsSync() {
@@ -1116,6 +1244,13 @@ export function ConversionIntegrityWorkspace({ projectId, projectName }: { proje
             </WriteButton>
             <Button type="button" variant="outline" onClick={cancelSelection}>Cancel</Button>
           </div>
+          {googleAdsStatusQuery.data?.connected ? (
+            <DisconnectConnection
+              providerLabel="Google Ads"
+              disabled={actionPending}
+              onDisconnect={disconnectGoogleAds}
+            />
+          ) : null}
         </section>
       ) : null}
 
@@ -1190,6 +1325,13 @@ export function ConversionIntegrityWorkspace({ projectId, projectName }: { proje
             </WriteButton>
             <Button type="button" variant="outline" onClick={cancelSelection}>Cancel</Button>
           </div>
+          {gtmStatusQuery.data?.connected ? (
+            <DisconnectConnection
+              providerLabel="Tag Manager"
+              disabled={actionPending}
+              onDisconnect={disconnectGtm}
+            />
+          ) : null}
         </section>
       ) : null}
 

--- a/apps/web/test/conversion-integrity-section.test.tsx
+++ b/apps/web/test/conversion-integrity-section.test.tsx
@@ -239,14 +239,65 @@ describe('ConversionIntegritySection', () => {
     expect(conversionIntegrityPrimaryAction(unconnected)).toMatchObject({ id: 'connect-google-ads' })
   })
 
-  test('renders the no-contract state without pretending that static checks ran', () => {
-    render(<ConversionIntegritySection />)
+  test('replaces the no-contract workspace with one focused setup path', () => {
+    const action = vi.fn()
+    render(<ConversionIntegritySection onPrimaryAction={action} />)
 
-    expect(screen.getByText('Setup needed')).toBeTruthy()
-    expect(screen.getByText('No conversion declared')).toBeTruthy()
-    expect(screen.getByText('Not declared')).toBeTruthy()
-    expect(screen.getAllByText('Not checked')).toHaveLength(2)
+    expect(screen.getByRole('heading', { name: 'Complete setup' })).toBeTruthy()
+    expect(screen.getByText('Google Ads account')).toBeTruthy()
+    expect(screen.getByText('Tag Manager container')).toBeTruthy()
+    expect(screen.getByText('Conversion to check')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Connect Google Ads' })).toBeTruthy()
+    expect(screen.queryByText('Setup needed')).toBeNull()
+    expect(screen.queryByText('No conversion declared')).toBeNull()
+    expect(screen.queryByText('Evidence progression')).toBeNull()
+    expect(screen.queryByText('Connection evidence')).toBeNull()
     expect(screen.queryByText('Latest sanitized snapshots')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Google Ads' }))
+    expect(action).toHaveBeenCalledWith('connect-google-ads')
+  })
+
+  test('advances the focused setup path through Tag Manager and conversion declaration', () => {
+    const action = vi.fn()
+    const changeGoogleAdsSelection = vi.fn()
+    const changeGtmSelection = vi.fn()
+    const gtmNotConnected = {
+      state: 'not-connected' as const,
+      selection: null,
+      snapshotCount: 0,
+      evidence: 'No stored evidence yet.',
+      lastSnapshotAt: null,
+    }
+    const setup = workspace({ contract: null, assessment: null, gtm: gtmNotConnected })
+    const { rerender } = render(
+      <ConversionIntegritySection
+        workspace={setup}
+        onPrimaryAction={action}
+        onChangeGoogleAdsSelection={changeGoogleAdsSelection}
+        onChangeGtmSelection={changeGtmSelection}
+      />,
+    )
+
+    expect(screen.getByText('Example Hotel').closest('li')?.textContent).toContain('Ready')
+    expect(screen.getByRole('button', { name: 'Connect Google Tag Manager' }).closest('li')?.getAttribute('aria-current')).toBe('step')
+    fireEvent.click(screen.getByRole('button', { name: 'Change Google Ads account' }))
+    expect(changeGoogleAdsSelection).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('button', { name: 'Declare conversion' })).toBeNull()
+
+    rerender(
+      <ConversionIntegritySection
+        workspace={workspace({ contract: null, assessment: null })}
+        onPrimaryAction={action}
+        onChangeGoogleAdsSelection={changeGoogleAdsSelection}
+        onChangeGtmSelection={changeGtmSelection}
+      />,
+    )
+
+    expect(screen.getAllByText('Ready')).toHaveLength(2)
+    expect(screen.getByRole('button', { name: 'Declare conversion' }).closest('li')?.getAttribute('aria-current')).toBe('step')
+    fireEvent.click(screen.getByRole('button', { name: 'Change Tag Manager container' }))
+    expect(changeGtmSelection).toHaveBeenCalledTimes(1)
   })
 
   test('keeps a declared conversion configured while its integrity assessment loads', () => {

--- a/apps/web/test/conversion-integrity-workspace.test.tsx
+++ b/apps/web/test/conversion-integrity-workspace.test.tsx
@@ -137,6 +137,8 @@ type MarketingFixture = {
   gtmRun?: unknown
   gtmSelectionResponse?: unknown
   createdContract?: unknown
+  googleAdsDisconnect?: { body: unknown; status?: number }
+  gtmDisconnect?: { body: unknown; status?: number }
   onRequest?: (path: string, init?: RequestInit) => void
 }
 
@@ -150,6 +152,12 @@ function installMarketingFetch(fixture: MarketingFixture, requested: string[]) {
     const path = pathOf(url)
     requested.push(path)
     fixture.onRequest?.(path, init)
+    if (path === `${prefix}/google-ads/connection` && init?.method === 'DELETE') {
+      return jsonResponse(fixture.googleAdsDisconnect?.body ?? { provider: 'google-ads', disconnected: true }, fixture.googleAdsDisconnect?.status ?? 200)
+    }
+    if (path === `${prefix}/gtm/connection` && init?.method === 'DELETE') {
+      return jsonResponse(fixture.gtmDisconnect?.body ?? { provider: 'gtm', disconnected: true }, fixture.gtmDisconnect?.status ?? 200)
+    }
     if (path.startsWith(`${prefix}/google-ads/status`)) return jsonResponse(googleAds)
     if (path.startsWith(`${prefix}/gtm/status`)) return jsonResponse(gtm)
     if (path.startsWith(`${prefix}/google-ads/snapshots`)) {
@@ -301,6 +309,135 @@ describe('ConversionIntegrityWorkspace', () => {
       expect.stringMatching(/^\/api\/v1\/projects\/example\/conversion-tracking\/contracts$/),
       expect.stringMatching(/^\/api\/v1\/projects\/example\/conversion-tracking\/contracts\/contract_purchase\/integrity/),
     ]))
+
+    queryClient.clear()
+  })
+
+  test.each([
+    {
+      provider: 'Google Ads',
+      changeAction: 'Change Google Ads account',
+      connectionPath: '/api/v1/projects/example/google-ads/connection',
+      connectAction: 'Connect Google Ads',
+    },
+    {
+      provider: 'Tag Manager',
+      changeAction: 'Change Tag Manager container',
+      connectionPath: '/api/v1/projects/example/gtm/connection',
+      connectAction: 'Connect Google Tag Manager',
+    },
+  ])('disconnects $provider only after inline confirmation and retains saved evidence', async ({
+    provider,
+    changeAction,
+    connectionPath,
+    connectAction,
+  }) => {
+    const requests: Array<{ path: string; method: string }> = []
+    let disconnectedProvider: string | null = null
+    const restore = mockFetch((url, init) => {
+      const path = pathOf(url)
+      const method = init?.method ?? 'GET'
+      requests.push({ path, method })
+
+      if (path === connectionPath && method === 'DELETE') {
+        disconnectedProvider = provider
+        return jsonResponse({ provider: provider === 'Google Ads' ? 'google-ads' : 'gtm', disconnected: true })
+      }
+      if (path.startsWith('/api/v1/projects/example/google-ads/status')) {
+        return jsonResponse(disconnectedProvider === 'Google Ads'
+          ? { connected: false, status: 'not-connected', connection: null, selectedCustomer: null }
+          : googleAdsStatus())
+      }
+      if (path.startsWith('/api/v1/projects/example/gtm/status')) {
+        return jsonResponse(disconnectedProvider === 'Tag Manager'
+          ? { connected: false, status: 'not-connected', connection: null, selection: null }
+          : gtmStatus())
+      }
+      if (path.startsWith('/api/v1/projects/example/conversion-tracking/contracts/contract_purchase/integrity')) {
+        return jsonResponse({
+          assessment: {
+            contract,
+            status: 'runtime-unverified',
+            evaluatedAt: capturedAt,
+            findings: [],
+          },
+          googleAdsSnapshot: null,
+          gtmSnapshot: null,
+        })
+      }
+      if (path.startsWith('/api/v1/projects/example/conversion-tracking/contracts')) return jsonResponse([contract])
+      if (path.startsWith('/api/v1/projects/example/google-ads/snapshots')) {
+        return jsonResponse({ snapshots: [{ id: 'ads_retained', kind: 'inventory', capturedAt }], nextCursor: null, total: 1 })
+      }
+      if (path.startsWith('/api/v1/projects/example/gtm/snapshots')) {
+        return jsonResponse({ snapshots: [{ id: 'gtm_retained', kind: 'live', capturedAt }], nextCursor: null, total: 1 })
+      }
+      if (path.startsWith('/api/v1/projects/example/google-ads/customers')) {
+        return jsonResponse({ customers: [googleAdsStatus().selectedCustomer], totalAccessible: 1, truncated: false, selection: adsConnection.selection, fetchedAt: capturedAt })
+      }
+      if (path.includes('/gtm/accounts/account_example/containers/GTM-TEST123/workspaces')) {
+        return jsonResponse({ accountId: 'account_example', containerId: 'GTM-TEST123', workspaces: [], totalAccessible: 0, truncated: false, fetchedAt: capturedAt })
+      }
+      if (path.includes('/gtm/accounts/account_example/containers')) {
+        return jsonResponse({ accountId: 'account_example', containers: [{ id: 'GTM-TEST123', name: 'Production container' }], totalAccessible: 1, truncated: false, fetchedAt: capturedAt })
+      }
+      if (path.startsWith('/api/v1/projects/example/gtm/accounts')) {
+        return jsonResponse({ accounts: [{ id: 'account_example', name: 'Example account' }], totalAccessible: 1, truncated: false, fetchedAt: capturedAt })
+      }
+      return jsonResponse({ error: { message: `Unexpected request: ${path}` } }, 500)
+    })
+    onTestFinished(restore)
+
+    const { queryClient } = renderWorkspace()
+    const changeButton = await screen.findByRole('button', { name: changeAction })
+    fireEvent.click(changeButton)
+
+    const disconnectTrigger = await screen.findByRole('button', { name: `Disconnect ${provider}` })
+    disconnectTrigger.focus()
+    fireEvent.click(disconnectTrigger)
+    expect(requests.some((request) => request.path === connectionPath && request.method === 'DELETE')).toBe(false)
+    expect(screen.getByRole('group', { name: `Confirm disconnect ${provider}` })).toBeTruthy()
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Keep connected' })))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep connected' }))
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: `Disconnect ${provider}` })))
+
+    fireEvent.click(screen.getByRole('button', { name: `Disconnect ${provider}` }))
+    fireEvent.click(screen.getByRole('button', { name: `Disconnect ${provider}` }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: connectAction })).toBeTruthy())
+    expect(requests.filter((request) => request.path === connectionPath && request.method === 'DELETE')).toHaveLength(1)
+    expect(screen.getByRole('heading', { name: 'Payment confirmed' })).toBeTruthy()
+    expect(screen.getByText('ads_retained')).toBeTruthy()
+    expect(screen.getByText('gtm_retained')).toBeTruthy()
+
+    queryClient.clear()
+  })
+
+  test('keeps disconnect confirmation open and surfaces a provider error when the request fails', async () => {
+    const requested: string[] = []
+    installMarketingFetch({
+      contracts: [contract],
+      integrity: () => ({
+        assessment: { contract, status: 'runtime-unverified', evaluatedAt: capturedAt, findings: [] },
+        googleAdsSnapshot: null,
+        gtmSnapshot: null,
+      }),
+      googleAdsDisconnect: {
+        body: { error: { message: 'Google Ads disconnect unavailable' } },
+        status: 503,
+      },
+    }, requested)
+
+    const { queryClient } = renderWorkspace()
+    fireEvent.click(await screen.findByRole('button', { name: 'Change Google Ads account' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Disconnect Google Ads' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect Google Ads' }))
+
+    await waitFor(() => expect(screen.getByText('Google Ads disconnect unavailable')).toBeTruthy())
+    expect(screen.getByRole('group', { name: 'Confirm disconnect Google Ads' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Disconnect Google Ads' }).hasAttribute('disabled')).toBe(false)
+    expect(requested).toContain('/api/v1/projects/example/google-ads/connection')
 
     queryClient.clear()
   })


### PR DESCRIPTION
## Summary

- Replace the no-contract dashboard with a focused three-step setup flow.
- Show only the next relevant setup action while preserving connected resource context.
- Add inline Google Ads and Tag Manager disconnect controls inside their existing selection panels.
- Retain stored evidence and conversion contracts after disconnecting.

## Validation

- Web tests: 103 files, 1,078 tests passed.
- Typecheck passed.
- Lint passed with 0 errors.
- Production build passed.
- Browser-verified the setup, disconnect, confirmation, focus, and error-free render states.