### PR TITLE
fix(google-ads): log per-customer detail failures instead of hiding them in a boolean

### DIFF
--- a/packages/canonry/src/google-marketing-runtime.ts
+++ b/packages/canonry/src/google-marketing-runtime.ts
@@ -93,6 +93,9 @@ import {
   getGtmConnection,
   upsertGtmConnection,
 } from './gtm-config.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('GoogleMarketing')
 
 const TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1_000
 const DEFAULT_LIST_LIMIT = 100
@@ -763,6 +766,22 @@ class DefaultGoogleMarketingRuntime implements GoogleMarketingRuntime {
     }
     const customers = [...customersById.values()]
       .sort((left, right) => left.level - right.level || left.customerId.localeCompare(right.customerId))
+    // Per-customer detail failures are rich (status, providerStatus, requestId,
+    // sanitized message) and were collapsed into the `truncated` boolean and
+    // otherwise discarded. That hid the only useful signal in the common case:
+    // `listAccessibleCustomers` succeeds, every `getCustomerDetails` is denied
+    // because the developer token's manager cannot reach the customer, and the
+    // dashboard reports "0 of 0 accessible customers" as though the account
+    // simply had none. Log them; the response shape is unchanged.
+    if (result.data.failures.length > 0) {
+      log.error('google-ads.customer-details-failed', {
+        project: normalizedProject.name,
+        totalAccessible: result.data.totalAccessible,
+        attempted: result.data.attempted,
+        returned: customers.length,
+        failures: result.data.failures,
+      })
+    }
     return googleAdsAccessibleCustomersResponseSchema.parse({
       customers,
       totalAccessible: customers.length,


### PR DESCRIPTION
Follow-up to #1025, which merged before this commit was pushed.

## What

`listGoogleAdsCustomers` collapsed `result.data.failures` into the `truncated` flag and discarded everything else. The client already captures `status`, `providerStatus`, `requestId` and a secret-sanitized `message` per customer. All of it was thrown away.

## Why it matters

This hides the entire signal in the most common setup failure. `listAccessibleCustomers` succeeds, because it only needs the OAuth user. Then every `getCustomerDetails` is denied, because the developer token's manager account cannot reach that customer. `customers` comes back empty and the dashboard says:

```
Incomplete result: showing 0 of 0 accessible customers.
```

which reads as "this account has no Ads accounts". The truth is the opposite: the accounts were listed and every lookup was refused.

Hit live while connecting a real Google Ads account. Diagnosing it required deducing from the response shape, because `truncated` is

```js
result.data.truncated || failures.length > 0 || hierarchyTruncated
```

and with zero customers the first and third terms are structurally false. So `truncated: true` alongside `totalAccessible: 0` can only mean failures. Nobody should have to derive that to debug a connection.

## The change

Failures are logged at error level with the counts around them (`totalAccessible`, `attempted`, `returned`), so the gap between listed and returned is visible in one line.

The response shape is unchanged, so no contract change and no codegen.

## Verification

222 files / 2336 tests pass across `packages/api-routes` and `packages/canonry`. Typecheck clean.