### PR TITLE
feat(web): let each conversion provider offer its own next step

### DIFF
--- a/apps/web/src/components/project/ConversionIntegritySection.tsx
+++ b/apps/web/src/components/project/ConversionIntegritySection.tsx
@@ -172,6 +172,75 @@ export function conversionIntegrityPresentation(
   }
 }
 
+/**
+ * Google Ads and Tag Manager are INDEPENDENT providers: separate OAuth, separate
+ * APIs, separate selections. Nothing about choosing an Ads customer is a
+ * prerequisite for authorizing Tag Manager.
+ *
+ * The setup list used to advance strictly, showing a button only on the first
+ * incomplete row, which implied a dependency that does not exist. The cost is
+ * not theoretical: a Google Ads developer token still awaiting Basic approval
+ * pins Ads at `selection-required` indefinitely, and that left Tag Manager
+ * unreachable in the UI even though it needs no developer token and would have
+ * connected in seconds.
+ *
+ * Each provider now owns its own next step. The conversion step is deliberately
+ * still gated on both, because a contract genuinely names resources from each.
+ */
+function googleAdsSetupAction(
+  workspace: ConversionIntegrityWorkspaceVm,
+): PrimaryActionPresentation | null {
+  switch (workspace.googleAds.state) {
+    case 'not-connected':
+      return {
+        id: 'connect-google-ads',
+        label: 'Connect Google Ads',
+        detail: 'Canonry only queries data; connect a Google Ads user with the Read-only role.',
+      }
+    case 'selection-required':
+      return {
+        id: 'select-google-ads',
+        label: 'Select Google Ads account',
+        detail: 'Choose the customer account Canonry should inspect.',
+      }
+    case 'stale':
+      return {
+        id: 'sync-google-ads',
+        label: 'Refresh Google Ads evidence',
+        detail: 'Read the selected account again and save a new sanitized observation.',
+      }
+    default:
+      return null
+  }
+}
+
+function gtmSetupAction(
+  workspace: ConversionIntegrityWorkspaceVm,
+): PrimaryActionPresentation | null {
+  switch (workspace.gtm.state) {
+    case 'not-connected':
+      return {
+        id: 'connect-gtm',
+        label: 'Connect Google Tag Manager',
+        detail: 'Authorize read-only Tag Manager access for this project.',
+      }
+    case 'selection-required':
+      return {
+        id: 'select-gtm',
+        label: 'Select Tag Manager container',
+        detail: 'Choose the account and container Canonry should inspect.',
+      }
+    case 'stale':
+      return {
+        id: 'sync-gtm',
+        label: 'Refresh Tag Manager evidence',
+        detail: 'Read the selected container again and save a new sanitized observation.',
+      }
+    default:
+      return null
+  }
+}
+
 export function conversionIntegrityPrimaryAction(
   workspace: ConversionIntegrityWorkspaceVm,
 ): PrimaryActionPresentation {
@@ -453,7 +522,6 @@ function providerRow({
 
 function ConversionIntegritySetup({
   workspace,
-  action,
   onPrimaryAction,
   onChangeGoogleAdsSelection,
   onChangeGtmSelection,
@@ -461,7 +529,6 @@ function ConversionIntegritySetup({
   actionError,
 }: {
   workspace: ConversionIntegrityWorkspaceVm
-  action: PrimaryActionPresentation
   onPrimaryAction?: (action: ConversionIntegrityPrimaryAction) => void
   onChangeGoogleAdsSelection?: () => void
   onChangeGtmSelection?: () => void
@@ -470,6 +537,16 @@ function ConversionIntegritySetup({
 }) {
   const googleAdsReady = workspace.googleAds.state === 'connected'
   const gtmReady = workspace.gtm.state === 'connected'
+  // A provider read that failed is the one case that outranks everything: the
+  // states below are not trustworthy until it is retried, so it takes over the
+  // whole list rather than showing two buttons over stale data.
+  const connectionUnavailable = workspace.googleAds.state === 'unavailable'
+    || workspace.gtm.state === 'unavailable'
+  const retryAction: PrimaryActionPresentation = {
+    id: 'retry-connection-status',
+    label: 'Retry connection status',
+    detail: 'Retry the stored connection reads before starting another provider action.',
+  }
   const steps = [
     {
       title: 'Google Ads account',
@@ -478,6 +555,7 @@ function ConversionIntegritySetup({
       detail: 'Connect read-only access and choose the customer account.',
       changeLabel: 'Change Google Ads account',
       onChange: onChangeGoogleAdsSelection,
+      action: connectionUnavailable ? retryAction : googleAdsSetupAction(workspace),
     },
     {
       title: 'Tag Manager container',
@@ -486,6 +564,7 @@ function ConversionIntegritySetup({
       detail: 'Connect read-only access and choose the container.',
       changeLabel: 'Change Tag Manager container',
       onChange: onChangeGtmSelection,
+      action: connectionUnavailable ? null : gtmSetupAction(workspace),
     },
     {
       title: 'Conversion to check',
@@ -494,6 +573,11 @@ function ConversionIntegritySetup({
       detail: 'Choose the website event, conversion action, and tag to check.',
       changeLabel: null,
       onChange: undefined,
+      // Genuinely dependent: a contract names resources from BOTH providers, so
+      // this stays gated where the provider rows no longer are.
+      action: googleAdsReady && gtmReady && !connectionUnavailable
+        ? conversionIntegrityPrimaryAction(workspace)
+        : null,
     },
   ]
   const activeStep = steps.findIndex((step) => !step.ready)
@@ -519,7 +603,8 @@ function ConversionIntegritySetup({
         <ol className="mt-5 divide-y divide-default border-y border-default">
           {steps.map((step, index) => {
             const isActive = index === activeStep
-            const detail = step.ready ? step.summary ?? 'Connected' : isActive ? action.detail : step.detail
+            // Each row explains ITS own next step, not the list's single active one.
+            const detail = step.ready ? step.summary ?? 'Connected' : step.action?.detail ?? step.detail
 
             return (
               <li
@@ -554,23 +639,23 @@ function ConversionIntegritySetup({
                     <p className="mt-1 max-w-xl text-sm font-medium text-heading">{step.summary}</p>
                   ) : null}
                   <p className="mt-1 max-w-xl text-sm leading-6 text-secondary">{detail}</p>
-                  {isActive && onPrimaryAction ? (
+                  {step.action && onPrimaryAction ? (
                     <div className="mt-3">
-                      {action.id === 'retry-connection-status' ? (
+                      {step.action.id === 'retry-connection-status' ? (
                         <Button
                           type="button"
                           disabled={actionPending}
-                          onClick={() => onPrimaryAction(action.id)}
+                          onClick={() => onPrimaryAction(step.action!.id)}
                         >
-                          {actionPending ? 'Working…' : action.label}
+                          {actionPending ? 'Working…' : step.action.label}
                         </Button>
                       ) : (
                         <WriteButton
                           type="button"
                           disabled={actionPending}
-                          onClick={() => onPrimaryAction(action.id)}
+                          onClick={() => onPrimaryAction(step.action!.id)}
                         >
-                          {actionPending ? 'Working…' : action.label}
+                          {actionPending ? 'Working…' : step.action.label}
                         </WriteButton>
                       )}
                     </div>
@@ -639,7 +724,6 @@ export function ConversionIntegritySection({
     return (
       <ConversionIntegritySetup
         workspace={workspace}
-        action={action}
         onPrimaryAction={onPrimaryAction}
         onChangeGoogleAdsSelection={onChangeGoogleAdsSelection}
         onChangeGtmSelection={onChangeGtmSelection}

--- a/apps/web/test/conversion-integrity-section.test.tsx
+++ b/apps/web/test/conversion-integrity-section.test.tsx
@@ -219,7 +219,7 @@ describe('ConversionIntegritySection', () => {
     expect(screen.getByRole('button', { name: 'Add conversion' }).hasAttribute('disabled')).toBe(true)
   })
 
-  test('uses a single primary action, selected by the first unresolved provider step', () => {
+  test('offers the Google Ads step its own action', () => {
     const action = vi.fn()
     const unconnected = workspace({
       contract: null,
@@ -363,4 +363,63 @@ describe('ConversionIntegritySection', () => {
     expect(screen.getAllByText('Use the next step above')).toHaveLength(2)
     expect(screen.queryByText('—')).toBeNull()
   })
+
+  test('a blocked Google Ads step does not hide the Tag Manager step', () => {
+    // The providers are independent: separate OAuth, separate APIs, separate
+    // selections. A Google Ads developer token awaiting Basic approval pins Ads
+    // at `selection-required` indefinitely, and the strictly-advancing list used
+    // to show a button only on the first incomplete row, so Tag Manager became
+    // unreachable in the UI despite needing no developer token at all.
+    const action = vi.fn()
+    const adsBlocked = workspace({
+      contract: null,
+      assessment: null,
+      googleAds: {
+        state: 'selection-required',
+        selection: null,
+        snapshotCount: 0,
+        evidence: 'No stored evidence yet.',
+        lastSnapshotAt: null,
+      },
+      gtm: {
+        state: 'not-connected',
+        selection: null,
+        snapshotCount: 0,
+        evidence: 'No stored evidence yet.',
+        lastSnapshotAt: null,
+      },
+    })
+    render(<ConversionIntegritySection workspace={adsBlocked} onPrimaryAction={action} />)
+
+    // Both providers are actionable at once.
+    expect(screen.getByRole('button', { name: 'Select Google Ads account' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Connect Google Tag Manager' })).toBeTruthy()
+
+    // And the blocked one does not intercept the other's click.
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Google Tag Manager' }))
+    expect(action).toHaveBeenCalledWith('connect-gtm')
+  })
+
+  test('the conversion step stays gated until BOTH providers are ready', () => {
+    // Unlike the provider rows, a contract names resources from each side, so
+    // this dependency is real and must survive the change above.
+    const action = vi.fn()
+    const gtmMissing = workspace({
+      contract: null,
+      assessment: null,
+      gtm: {
+        state: 'not-connected',
+        selection: null,
+        snapshotCount: 0,
+        evidence: 'No stored evidence yet.',
+        lastSnapshotAt: null,
+      },
+    })
+    render(<ConversionIntegritySection workspace={gtmMissing} onPrimaryAction={action} />)
+
+    expect(screen.getByText('Conversion to check')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Declare conversion' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Select conversion' })).toBeNull()
+  })
+
 })


### PR DESCRIPTION
**Stacked on #1026.** Base is `ax/simplify-conversion-setup`, so review this diff alone (1 commit, 2 files).

## What

Google Ads and Tag Manager are independent providers: separate OAuth, separate APIs, separate selections. Nothing about choosing an Ads customer is a prerequisite for authorizing Tag Manager.

The setup list advances strictly, rendering a button only on the first incomplete row. That encodes a dependency that does not exist.

## Why it matters

Found live. A Google Ads developer token still awaiting Basic approval pins Ads at `selection-required` indefinitely:

```
DEVELOPER_TOKEN_NOT_APPROVED
"The developer token is only approved for use with test accounts."
```

That is resolved by Google, on Google's timetable. Meanwhile Tag Manager needs **no** developer token and would connect in seconds, but it was unreachable in the UI because the Ads row would never complete. One provider's external blocker made the entire tab unusable.

## The change

Each provider row owns its next step and renders its own button.

Two dependencies stay gated, because they are real:

| Row | Gated on |
|---|---|
| Google Ads | nothing |
| Tag Manager | nothing |
| Conversion to check | **both** providers ready, since a contract names resources from each |
| any row | a failed provider read still takes over the list, because the other states are untrustworthy until retried |

Visual design, step framing, and #1026's disconnect controls are unchanged. Only which rows can act is different.

## Tests

- a blocked Ads step must not hide the Tag Manager step, and clicking Tag Manager must not be intercepted by the blocked row
- the conversion row must still offer nothing while Tag Manager is unconnected

Verified by mutation: reverting the render to `isActive` fails the first on the exact missing button (`Unable to find an accessible element with the role "button" and name "Connect Google Tag Manager"`).

The pre-existing test named *"uses a single primary action, selected by the first unresolved provider step"* is renamed, since it described the model this replaces.

103 files / 1,080 web tests pass. Typecheck and lint clean.

Note: when #1026 squash-merges, this needs `git rebase --onto origin/main <old-base-tip> <branch>` per the repo's stacked-PR guidance.