### PR TITLE
feat(web): cut the conversion setup copy down to the rows

### DIFF
--- a/apps/web/src/components/project/ConversionIntegritySection.tsx
+++ b/apps/web/src/components/project/ConversionIntegritySection.tsx
@@ -587,24 +587,23 @@ function ConversionIntegritySetup({
       <div className="section-head mb-5">
         <div>
           <p className="eyebrow">Google marketing</p>
-          <h2 id="conversion-integrity-title" className="mt-1 text-xl font-semibold tracking-[-0.02em] text-heading">
-            Conversion Integrity
-          </h2>
-          <p className="lede mt-2">Check one website conversion across Tag Manager and Google Ads.</p>
+          <div className="mt-1 flex items-center gap-1.5">
+            <h2 id="conversion-integrity-title" className="text-xl font-semibold tracking-[-0.02em] text-heading">
+              Conversion Integrity
+            </h2>
+            <InfoTooltip text="Canonry reads your Google configuration and never changes or publishes it. Connect Google Ads and Tag Manager, then choose one website conversion to check across both." />
+          </div>
         </div>
       </div>
 
       <div className="max-w-3xl pt-3">
-        <h3 className="text-base font-semibold text-heading">Complete setup</h3>
-        <p className="supporting-copy mt-2 max-w-2xl">
-          Connect your existing Google accounts, then choose the conversion Canonry should check.
-        </p>
-
-        <ol className="mt-5 divide-y divide-default border-y border-default">
+        <ol className="divide-y divide-default border-y border-default">
           {steps.map((step, index) => {
             const isActive = index === activeStep
-            // Each row explains ITS own next step, not the list's single active one.
-            const detail = step.ready ? step.summary ?? 'Connected' : step.action?.detail ?? step.detail
+            // A connected row states what it is connected TO. An unconnected row
+            // says nothing: its title and its button already carry the meaning,
+            // and a sentence restating the button is the copy an operator skips.
+            const detail = step.ready ? step.summary ?? 'Connected' : null
 
             return (
               <li
@@ -638,7 +637,7 @@ function ConversionIntegritySetup({
                   {isActive && !step.ready && step.summary ? (
                     <p className="mt-1 max-w-xl text-sm font-medium text-heading">{step.summary}</p>
                   ) : null}
-                  <p className="mt-1 max-w-xl text-sm leading-6 text-secondary">{detail}</p>
+                  {detail ? <p className="mt-1 max-w-xl text-sm leading-6 text-secondary">{detail}</p> : null}
                   {step.action && onPrimaryAction ? (
                     <div className="mt-3">
                       {step.action.id === 'retry-connection-status' ? (
@@ -667,9 +666,6 @@ function ConversionIntegritySetup({
           })}
         </ol>
 
-        <p className="mt-4 text-sm leading-6 text-secondary">
-          Canonry reads your Google configuration. It does not change or publish it.
-        </p>
       </div>
     </section>
   )

--- a/apps/web/test/conversion-integrity-section.test.tsx
+++ b/apps/web/test/conversion-integrity-section.test.tsx
@@ -236,6 +236,12 @@ describe('ConversionIntegritySection', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Connect Google Ads' }))
     expect(action).toHaveBeenCalledWith('connect-google-ads')
+
+    // Setup prose is gone from the page and lives on the heading's tooltip, so
+    // nothing is lost for assistive tech or for a reader who wants the detail.
+    expect(screen.queryByText(/Connect your existing Google accounts/)).toBeNull()
+    expect(screen.queryByText(/It does not change or publish it/)).toBeNull()
+    expect(screen.getByRole('button', { name: /never changes or publishes it/ })).toBeTruthy()
     expect(conversionIntegrityPrimaryAction(unconnected)).toMatchObject({ id: 'connect-google-ads' })
   })
 
@@ -243,7 +249,9 @@ describe('ConversionIntegritySection', () => {
     const action = vi.fn()
     render(<ConversionIntegritySection onPrimaryAction={action} />)
 
-    expect(screen.getByRole('heading', { name: 'Complete setup' })).toBeTruthy()
+    // The rows ARE the instructions. A "Complete setup" heading over three
+    // labelled rows with buttons on them restated what the rows already said.
+    expect(screen.queryByRole('heading', { name: 'Complete setup' })).toBeNull()
     expect(screen.getByText('Google Ads account')).toBeTruthy()
     expect(screen.getByText('Tag Manager container')).toBeTruthy()
     expect(screen.getByText('Conversion to check')).toBeTruthy()


### PR DESCRIPTION
**Stacked on #1028** (which is stacked on #1026). Base is `feat/conversion-setup-independent-providers`, so this diff is 1 commit / 2 files.

## What

Setup asked an operator to read four headings and five sentences before clicking two buttons:

```
Conversion Integrity
Check one website conversion across Tag Manager and Google Ads.
Complete setup
Connect your existing Google accounts, then choose the conversion Canonry should check.
1  Google Ads account      Canonry only queries data; connect a Google Ads user with...
2  Tag Manager container   Authorize read-only Tag Manager access for this project.
3  Conversion to check     Choose the website event, conversion action, and tag to check.
Canonry reads your Google configuration. It does not change or publish it.
```

Every per-row sentence restated the button beneath it. "Complete setup" over three labelled rows with buttons on them said nothing the rows did not.

After:

```
Google Ads account      Not connected   [Connect Google Ads]
Tag Manager container   Not connected   [Connect Google Tag Manager]
Conversion to check
```

## Removed

- the "Complete setup" heading and its subheading
- the per-row sentences on unconnected rows
- the trailing assurance paragraph

A connected row still states what it is connected **to**, which is the one detail not already on a button.

## Not lost

The read-only assurance moves onto the section heading as an `InfoTooltip`. That matches the repo rule that explanatory prose belongs in a tooltip rather than inline in a data view, and the same pattern is already used further down this file for the integrity-status explainer. It stays keyboard reachable and addressable by name, which is why the test asserts it as a button.

## No behavior change

Rows, buttons, ordering and the disconnect controls from #1026 are untouched. Copy and density only.

103 files / 1,080 web tests pass. Typecheck and lint clean.