### PR TITLE
test(guards): pay ESLint's cold start in setup, not in the first assertion

### DIFF
--- a/test/eslint-guards.test.ts
+++ b/test/eslint-guards.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { ESLint, RuleTester } from 'eslint'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import { createRestrictedSyntaxRule } from '../eslint-rules/restricted-syntax.js'
 
 /**
@@ -97,6 +97,31 @@ describe('workspace lint guards', () => {
   const eslint = new ESLint({ cwd: workspaceRoot })
   const resolveConfig = async (file: string) =>
     await eslint.calculateConfigForFile(file) as { rules?: Record<string, unknown> }
+
+  // Warm the config resolver once, as SETUP rather than inside a test.
+  //
+  // The first `calculateConfigForFile` loads `eslint.config.js` and every
+  // plugin it imports (typescript-eslint, the local rule files, the whole
+  // flat-config graph). Measured: that first call is ~675ms and every later
+  // one is 0-8ms, because the result is cached. Without this hook that cost
+  // lands on whichever test runs first, under the 5s default timeout.
+  //
+  // This was observed three times as `enables every guard that names
+  // apps/web/src/pages/ProjectPage.tsx` timing out at 5s while a full
+  // `pnpm verify` ran concurrently — always that test, never the four
+  // identically-shaped ones after it, which is the signature of shared setup
+  // rather than of anything about that file (`calculateConfigForFile` never
+  // opens it, so its size is irrelevant). It does NOT reproduce on an idle
+  // machine or under pure CPU saturation, so the exact contention is not
+  // pinned down; what is certain is that a multi-second one-time cost had no
+  // business inside a 5s per-test budget.
+  //
+  // Paying it here leaves each assertion below measuring only its own
+  // marginal work, so the tight default timeout still catches a real
+  // regression in config resolution.
+  beforeAll(async () => {
+    await resolveConfig(GUARD_COVERAGE[0]!.file)
+  }, 120_000)
 
   // `calculateConfigForFile` answers for any path, real or not, so a renamed
   // file would leave the matrix asserting about nothing. Fail on that instead.


### PR DESCRIPTION
## What

`test/eslint-guards.test.ts` billed ESLint's one-time cold start to whichever
test ran first, inside the 5s per-test default. That test now warms the resolver
in `beforeAll` with its own timeout.

## Evidence

`enables every guard that names apps/web/src/pages/ProjectPage.tsx` timed out at
5s three times while a full `pnpm verify` ran concurrently. Always that test,
never the four identically-shaped ones after it.

That is the signature of shared setup, not of the file it names:
`calculateConfigForFile` never opens the file, so `ProjectPage.tsx` being 2,728
lines is irrelevant. Measured cost of resolving config for the five covered
files, in order:

```
   675 ms  apps/web/src/pages/ProjectPage.tsx
     6 ms  packages/api-routes/src/report-renderer.ts
     8 ms  packages/canonry/src/commands/run.ts
     1 ms  packages/canonry/src/cli-commands/query.ts
     7 ms  packages/integration-google-analytics/src/ga4-client.ts
     0 ms  apps/web/src/pages/ProjectPage.tsx (repeat)
```

The first call loads `eslint.config.js` and every plugin it imports; the result
is cached, so every later call is free.

## Honest limits

This is a mitigation, not a proven repair. The failure does NOT reproduce on an
idle machine (passes in 1.01s) or under 2x-core CPU saturation (passes in 2.14s)
— with or without this change. The exact contention that pushed one call past 5s
is not pinned down.

What is certain: a multi-second one-time cost sat inside a 5s per-test budget,
and the failures landed exactly where that cost lands. After this change each
assertion measures only its own marginal work (0-8ms), so the tight default
timeout still catches a real regression in config resolution rather than being
loosened to paper over setup.

## Verification

`pnpm verify` green on this branch: 697 test files, 9,069 tests, zero failures —
including the guards test under the full suite's own load, which is the condition
the original failures appeared under.

No version bump: 26 lines, under the 100-line threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
