### PR TITLE
feat(web): make mention share one object with a branded/non-brand control

### DIFF
--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -623,6 +623,10 @@ function emptyCommandCenter(
       ...placeholder,
       label: 'Mention Share',
       scope: 'non-brand',
+      // This shell is reached only when the /overview fetch failed, and its
+      // zero counters look exactly like a project that has never swept. Say
+      // which one it is instead of letting the reader infer the wrong one.
+      unavailable: true,
       breakdown: emptyMentionShareBreakdown(),
       branded: emptyMentionShareBreakdown(),
     },

--- a/apps/web/src/components/project/MentionShare.tsx
+++ b/apps/web/src/components/project/MentionShare.tsx
@@ -1,0 +1,267 @@
+import React, { useId, useState } from 'react'
+import type { ProjectCommandCenterVm } from '../../view-models.js'
+import { METRIC_TONE_TEXT_CLASS } from '../../lib/tone-helpers.js'
+import { InfoTooltip } from '../shared/InfoTooltip.js'
+
+export type MentionShareBreakdownVm = ProjectCommandCenterVm['mentionShareSummary']['breakdown']
+
+const MENTION_CLASS_OPTIONS = [
+  { value: 'non-brand', label: 'Non-brand' },
+  { value: 'branded', label: 'Branded' },
+] as const
+
+type MentionClassKey = (typeof MENTION_CLASS_OPTIONS)[number]['value']
+type MentionScopeKey = MentionClassKey | 'pooled'
+
+/** The denominator's name, rendered as visible text in the caption. Never
+ *  demoted to a tooltip: a cropped screenshot of the figure must still carry
+ *  which class it belongs to. */
+const MENTION_SCOPE_WORD: Record<MentionScopeKey, string> = {
+  'non-brand': 'Non-brand',
+  branded: 'Branded',
+  pooled: 'All queries',
+}
+
+/** One tooltip per scope, selected by what is actually rendered, so the
+ *  explanation can never describe a denominator other than the one on screen. */
+const MENTION_SCOPE_TOOLTIP: Record<MentionScopeKey, string> = {
+  'non-brand': 'On queries that do not contain your name: of the brand names written into the answer text, the share that were yours. Branded queries are scored separately because you are named on nearly all of them and a competitor cannot be.',
+  branded: 'On queries that contain your name: of the brand names written into the answer text, the share that were yours. This is recognition, not competitive placement, and it is never pooled with the non-brand figure.',
+  pooled: 'This project has no brand name or domain to match on, so branded and non-brand queries could not be separated. This figure pools both and is not a competitive read. Set a display name or aliases to split them.',
+}
+
+const MENTION_COUNT_TOOLTIP = 'Mentioned = brand in the answer. Cited = domain in the sources. Neither implies the other.'
+
+/**
+ * Headline and caption detail for ONE class, derived only from that class's own
+ * counters. Nothing here can read the other class, so no figure can be captioned
+ * with the other class's denominator.
+ */
+export function mentionClassFigures(
+  breakdown: MentionShareBreakdownVm,
+  opts: { hasCompetitors: boolean; noRun: boolean; unavailable: boolean },
+): { headline: string; numeric: boolean; detail: string; showRows: boolean } {
+  // Checked BEFORE `noRun`, because the two produce an identical all-zero
+  // payload. `/overview` failing is swallowed by the dashboard fan-out, so
+  // without this a project with a year of sweeps would be told, with no error
+  // banner to contradict it, that it has never swept.
+  if (opts.unavailable) {
+    return { headline: 'No data', numeric: false, detail: 'could not load, refresh to retry', showRows: false }
+  }
+  if (opts.noRun) {
+    return { headline: 'No data', numeric: false, detail: 'no sweep has run yet', showRows: false }
+  }
+  if (breakdown.snapshotsTotal === 0) {
+    return { headline: 'No queries', numeric: false, detail: 'none tracked', showRows: false }
+  }
+  if (breakdown.snapshotsWithAnswerText === 0) {
+    return { headline: 'No answers', numeric: false, detail: 'no answer text in this run', showRows: false }
+  }
+  // A project-only denominator is never rendered as a 100% share chart.
+  if (!opts.hasCompetitors) {
+    return {
+      headline: 'Add competitors',
+      numeric: false,
+      detail: `you were named in ${breakdown.projectMentionSnapshots} of ${breakdown.snapshotsWithAnswerText} answers`,
+      showRows: false,
+    }
+  }
+  const named = breakdown.projectMentionSnapshots + breakdown.competitorMentionSnapshots
+  if (named === 0 || breakdown.score === null) {
+    return {
+      headline: 'No mentions',
+      numeric: false,
+      detail: `no brand named in ${breakdown.snapshotsWithAnswerText} answers`,
+      showRows: false,
+    }
+  }
+  return {
+    headline: `${breakdown.score}`,
+    numeric: true,
+    detail: `${breakdown.projectMentionSnapshots} of ${named} brand mentions`,
+    showRows: true,
+  }
+}
+
+/**
+ * One class's ranked list. Every tracked competitor gets a row, including the
+ * ones at zero, so "no competitor was named in this class" is visible instead of
+ * being an absent row. Bar width is the share itself, so the bar and the printed
+ * number can never disagree.
+ */
+function MentionShareRows({
+  breakdown,
+  projectLabel,
+  competitorDomains,
+}: {
+  breakdown: MentionShareBreakdownVm
+  projectLabel: string
+  competitorDomains: string[]
+}) {
+  const total = breakdown.projectMentionSnapshots + breakdown.competitorMentionSnapshots
+  if (total === 0) return null
+
+  const byDomain = new Map(breakdown.perCompetitor.map(c => [c.domain, c.mentionSnapshots]))
+  const rows = [
+    { label: `${projectLabel} (you)`, mentions: breakdown.projectMentionSnapshots, isYou: true },
+    ...competitorDomains.map(domain => ({
+      label: domain,
+      mentions: byDomain.get(domain) ?? 0,
+      isYou: false,
+    })),
+  ].sort((a, b) => b.mentions - a.mentions || (a.label < b.label ? -1 : 1))
+
+  return (
+    <div className="mention-share-table">
+      <div className="mention-share-row mention-share-row-head">
+        <span />
+        <span />
+        <span className="mention-share-count">
+          Mentions
+          <InfoTooltip text={MENTION_COUNT_TOOLTIP} />
+        </span>
+        <span className="mention-share-share">Share</span>
+      </div>
+      <ul className="mention-share-rows">
+        {rows.map(row => {
+          const share = (row.mentions / total) * 100
+          return (
+            <li key={row.label} className="mention-share-row">
+              <span className={`mention-share-row-label ${row.isYou ? 'text-heading font-medium' : 'text-secondary'}`}>
+                {row.label}
+              </span>
+              <div className="mention-share-bar">
+                <div
+                  className={`mention-share-bar-fill ${row.isYou ? 'bg-positive-500/70' : 'bg-mono-500/60'}`}
+                  style={{ width: `${share > 0 ? Math.max(share, 1.5) : 0}%` }}
+                />
+              </div>
+              <span className="mention-share-count">{row.mentions}</span>
+              <span className="mention-share-share">{share.toFixed(1)}%</span>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+/**
+ * Mention share as a single object: one chrome line that names the metric and
+ * owns the class, one figure, one list. Branded and non-brand are never on
+ * screen together, so they can never be read against one denominator. The class
+ * name is duplicated into the caption on purpose: a crop that contains the
+ * number contains the name of its denominator.
+ */
+export function MentionShare({
+  summary,
+  projectLabel,
+  competitorDomains,
+}: {
+  summary: ProjectCommandCenterVm['mentionShareSummary']
+  projectLabel: string
+  competitorDomains: string[]
+}) {
+  const [selected, setSelected] = useState<MentionClassKey>('non-brand')
+  const labelId = useId()
+
+  const pooled = summary.scope === 'pooled'
+  // `pooled` means no split ever happened, so the branded tally is structurally
+  // empty and there is nothing to switch to. The explicit guard also stops a
+  // future server change from ever putting a "Non-brand" chip on a pooled figure.
+  const hasBranded = !pooled && summary.branded.snapshotsTotal > 0
+  const activeKey: MentionClassKey = hasBranded ? selected : 'non-brand'
+  const scopeKey: MentionScopeKey = pooled ? 'pooled' : activeKey
+  const active = activeKey === 'branded' ? summary.branded : summary.breakdown
+
+  const figures = mentionClassFigures(active, {
+    hasCompetitors: competitorDomains.length > 0,
+    unavailable: summary.unavailable === true,
+    noRun: summary.breakdown.snapshotsTotal === 0 && summary.branded.snapshotsTotal === 0,
+  })
+  // Tone bands are calibrated for competitive placement. Branded sits near 100
+  // by construction and pooled is not a competitive read at all, so neither is
+  // ever tone-coloured: a structural high number must not render as a green win.
+  const toneClass = scopeKey === 'non-brand' ? METRIC_TONE_TEXT_CLASS[summary.tone] : 'text-secondary'
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    const index = MENTION_CLASS_OPTIONS.findIndex(o => o.value === activeKey)
+    let next: number | null = null
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') next = (index + 1) % MENTION_CLASS_OPTIONS.length
+    else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') next = (index - 1 + MENTION_CLASS_OPTIONS.length) % MENTION_CLASS_OPTIONS.length
+    else if (event.key === 'Home') next = 0
+    else if (event.key === 'End') next = MENTION_CLASS_OPTIONS.length - 1
+    if (next === null) return
+    event.preventDefault()
+    setSelected(MENTION_CLASS_OPTIONS[next]!.value)
+    event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="radio"]')[next]?.focus()
+  }
+
+  return (
+    <div className="mention-share">
+      <div className="mention-share-head">
+        {/* The tooltip is a SIBLING of the heading, matching SiteHealthSection.
+            A heading takes its accessible name from its content, and InfoTooltip
+            puts its whole text on the trigger's aria-label, so nesting it made
+            the h3 announce the entire methodology paragraph as the heading. */}
+        <div className="mention-share-label">
+          <h3 id={labelId} className="mention-share-label-text">Mention share</h3>
+          <InfoTooltip text={MENTION_SCOPE_TOOLTIP[scopeKey]} />
+        </div>
+        {hasBranded ? (
+          <div
+            role="radiogroup"
+            aria-labelledby={labelId}
+            className="segmented flex-wrap"
+            onKeyDown={handleKeyDown}
+          >
+            {MENTION_CLASS_OPTIONS.map(option => {
+              const checked = option.value === activeKey
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={checked}
+                  tabIndex={checked ? 0 : -1}
+                  onClick={() => setSelected(option.value)}
+                  className={`segmented-option min-h-11 ${checked ? 'segmented-option-active' : ''}`}
+                >
+                  {option.label}
+                </button>
+              )
+            })}
+          </div>
+        ) : (
+          <span className="mention-share-class">{MENTION_SCOPE_WORD[scopeKey]}</span>
+        )}
+      </div>
+
+      {figures.numeric ? (
+        <p className={`mention-share-value ${toneClass}`}>
+          {figures.headline}
+          <span className="text-faint">%</span>
+        </p>
+      ) : (
+        <p className="mention-share-value-text">{figures.headline}</p>
+      )}
+
+      <p className="mention-share-caption">
+        <span className="mention-share-caption-scope">{MENTION_SCOPE_WORD[scopeKey]}</span>
+        {` · ${figures.detail}`}
+      </p>
+
+      {pooled && (
+        <p className="mention-share-note">Set a brand name to split branded from non-brand.</p>
+      )}
+
+      {figures.showRows && (
+        <MentionShareRows
+          breakdown={active}
+          projectLabel={projectLabel}
+          competitorDomains={competitorDomains}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/project/MentionShare.tsx
+++ b/apps/web/src/components/project/MentionShare.tsx
@@ -39,7 +39,7 @@ const MENTION_COUNT_TOOLTIP = 'Mentioned = brand in the answer. Cited = domain i
  */
 export function mentionClassFigures(
   breakdown: MentionShareBreakdownVm,
-  opts: { hasCompetitors: boolean; noRun: boolean; unavailable: boolean },
+  opts: { hasCompetitors: boolean; noRun: boolean; unavailable: boolean; otherClassHasData: boolean },
 ): { headline: string; numeric: boolean; detail: string; showRows: boolean } {
   // Checked BEFORE `noRun`, because the two produce an identical all-zero
   // payload. `/overview` failing is swallowed by the dashboard fan-out, so
@@ -52,7 +52,14 @@ export function mentionClassFigures(
     return { headline: 'No data', numeric: false, detail: 'no sweep has run yet', showRows: false }
   }
   if (breakdown.snapshotsTotal === 0) {
-    return { headline: 'No queries', numeric: false, detail: 'none tracked', showRows: false }
+    // "none tracked" is only true when NOTHING is tracked. A basket that is
+    // entirely branded has real snapshots one click away, and the server says
+    // so — `buildMentionShare` returns the value 'No non-brand queries' for
+    // exactly this case. Saying "none tracked" there contradicts the control
+    // sitting beside it.
+    return opts.otherClassHasData
+      ? { headline: 'No non-brand queries', numeric: false, detail: 'every tracked query names your brand', showRows: false }
+      : { headline: 'No queries', numeric: false, detail: 'none tracked', showRows: false }
   }
   if (breakdown.snapshotsWithAnswerText === 0) {
     return { headline: 'No answers', numeric: false, detail: 'no answer text in this run', showRows: false }
@@ -111,38 +118,48 @@ function MentionShareRows({
     })),
   ].sort((a, b) => b.mentions - a.mentions || (a.label < b.label ? -1 : 1))
 
+  // A real table, not a header div over an unlabelled list. The columns carry
+  // meaning that only the visual arrangement was expressing, so a screen reader
+  // was reading "9" and "30.0%" with nothing to attach them to. `scope` on each
+  // header is what associates them; the bar is decorative and aria-hidden,
+  // since its width is the share the next cell already states.
   return (
-    <div className="mention-share-table">
-      <div className="mention-share-row mention-share-row-head">
-        <span />
-        <span />
-        <span className="mention-share-count">
-          Mentions
-          <InfoTooltip text={MENTION_COUNT_TOOLTIP} />
-        </span>
-        <span className="mention-share-share">Share</span>
-      </div>
-      <ul className="mention-share-rows">
+    <table className="mention-share-table">
+      <caption className="sr-only">Brand mentions by domain, most mentioned first</caption>
+      <thead>
+        <tr className="mention-share-row mention-share-row-head">
+          <th scope="col" className="mention-share-row-label">Domain</th>
+          <th aria-hidden="true" />
+          <th scope="col" className="mention-share-count">
+            Mentions
+            <InfoTooltip text={MENTION_COUNT_TOOLTIP} />
+          </th>
+          <th scope="col" className="mention-share-share">Share</th>
+        </tr>
+      </thead>
+      <tbody className="mention-share-rows">
         {rows.map(row => {
           const share = (row.mentions / total) * 100
           return (
-            <li key={row.label} className="mention-share-row">
-              <span className={`mention-share-row-label ${row.isYou ? 'text-heading font-medium' : 'text-secondary'}`}>
+            <tr key={row.label} className="mention-share-row">
+              <th scope="row" className={`mention-share-row-label ${row.isYou ? 'text-heading font-medium' : 'text-secondary'}`}>
                 {row.label}
-              </span>
-              <div className="mention-share-bar">
-                <div
-                  className={`mention-share-bar-fill ${row.isYou ? 'bg-positive-500/70' : 'bg-mono-500/60'}`}
-                  style={{ width: `${share > 0 ? Math.max(share, 1.5) : 0}%` }}
-                />
-              </div>
-              <span className="mention-share-count">{row.mentions}</span>
-              <span className="mention-share-share">{share.toFixed(1)}%</span>
-            </li>
+              </th>
+              <td aria-hidden="true">
+                <div className="mention-share-bar">
+                  <div
+                    className={`mention-share-bar-fill ${row.isYou ? 'bg-positive-500/70' : 'bg-mono-500/60'}`}
+                    style={{ width: `${share > 0 ? Math.max(share, 1.5) : 0}%` }}
+                  />
+                </div>
+              </td>
+              <td className="mention-share-count">{row.mentions}</td>
+              <td className="mention-share-share">{share.toFixed(1)}%</td>
+            </tr>
           )
         })}
-      </ul>
-    </div>
+      </tbody>
+    </table>
   )
 }
 
@@ -174,10 +191,12 @@ export function MentionShare({
   const scopeKey: MentionScopeKey = pooled ? 'pooled' : activeKey
   const active = activeKey === 'branded' ? summary.branded : summary.breakdown
 
+  const other = activeKey === 'branded' ? summary.breakdown : summary.branded
   const figures = mentionClassFigures(active, {
     hasCompetitors: competitorDomains.length > 0,
     unavailable: summary.unavailable === true,
     noRun: summary.breakdown.snapshotsTotal === 0 && summary.branded.snapshotsTotal === 0,
+    otherClassHasData: other.snapshotsTotal > 0,
   })
   // Tone bands are calibrated for competitive placement. Branded sits near 100
   // by construction and pooled is not a competitive read at all, so neither is

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -12,6 +12,7 @@ import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { WriteButton } from '../components/shared/AccessControls.js'
 import { InfoTooltip } from '../components/shared/InfoTooltip.js'
+import { MentionShare } from '../components/project/MentionShare.js'
 import { CitationBadge } from '../components/shared/CitationBadge.js'
 import { ProviderBadge } from '../components/shared/ProviderBadge.js'
 import { RunRow } from '../components/shared/RunRow.js'
@@ -1317,138 +1318,6 @@ function OverviewDisclosure({
   )
 }
 
-/**
- * One class's bars. Never renders two classes into one denominator: `share` is
- * always a percentage of the class it was passed, and the caller labels which
- * class that is.
- */
-function MentionShareBreakdownRows({
-  breakdown,
-  projectLabel,
-}: {
-  breakdown: ProjectCommandCenterVm['mentionShareSummary']['breakdown']
-  projectLabel: string
-}) {
-  const combinedTotal = breakdown.projectMentionSnapshots + breakdown.competitorMentionSnapshots
-  if (combinedTotal === 0) return null
-
-  // Rows merge the project (you) with each tracked competitor, sorted by
-  // mention count. Share is computed against this class's combined total, so
-  // the rows read as "% of the brand mentions in this class".
-  const rows = [
-    { label: `${projectLabel} (you)`, mentions: breakdown.projectMentionSnapshots, isYou: true },
-    ...breakdown.perCompetitor.map(c => ({ label: c.domain, mentions: c.mentionSnapshots, isYou: false })),
-  ].sort((a, b) => b.mentions - a.mentions)
-  const maxMentions = rows[0]?.mentions ?? 1
-
-  return (
-    <ul className="mention-share-breakdown-rows">
-      {rows.map(row => {
-        const share = (row.mentions / combinedTotal) * 100
-        return (
-          <li key={row.label} className="mention-share-breakdown-row">
-            <span className={`mention-share-breakdown-label ${row.isYou ? 'text-heading font-medium' : 'text-secondary'}`}>
-              {row.label}
-            </span>
-            <div className="mention-share-breakdown-bar">
-              <div
-                className={`mention-share-breakdown-bar-fill ${row.isYou ? 'bg-positive-500/70' : 'bg-mono-500/60'}`}
-                style={{ width: `${Math.max((row.mentions / maxMentions) * 100, 2)}%` }}
-              />
-            </div>
-            <span className="mention-share-breakdown-count">{row.mentions}</span>
-            <span className="mention-share-breakdown-share">{share.toFixed(1)}%</span>
-          </li>
-        )
-      })}
-    </ul>
-  )
-}
-
-/**
- * Two labelled sections, never one pooled chart.
- *
- * Non-brand leads because it is the competitive question. Branded is kept in
- * view — dropping it would hide real data — but in its own section with its own
- * denominator, because a query that contains the brand's own name is one the
- * brand is named on nearly always and a competitor structurally cannot win.
- */
-function MentionShareBreakdown({
-  summary,
-  projectLabel,
-  hasCompetitiveFrame,
-}: {
-  summary: ProjectCommandCenterVm['mentionShareSummary']
-  projectLabel: string
-  hasCompetitiveFrame: boolean
-}) {
-  const breakdown = summary.breakdown
-  const branded = summary.branded
-  const nonBrandTotal = breakdown.projectMentionSnapshots + breakdown.competitorMentionSnapshots
-  const brandedTotal = branded.projectMentionSnapshots + branded.competitorMentionSnapshots
-  if (nonBrandTotal === 0 && brandedTotal === 0) return null
-
-  // `pooled` is only reachable when the project has no brand name or domain to
-  // classify against, so the title and the tooltip both say what the reader is
-  // actually looking at rather than claiming a split that did not happen.
-  const isNonBrand = summary.scope === 'non-brand'
-  const scopeTitle = isNonBrand
-    ? 'Mention share breakdown · non-brand queries · latest run'
-    : 'Mention share breakdown · all tracked queries · latest run'
-  const scopeTooltip = isNonBrand
-    ? 'Queries that do not contain your name. This is where competitive placement is decided: on a branded query you are named almost always and a competitor cannot be, so counting both in one total would rank you on your own brand recall instead of on your category.'
-    : 'Branded and non-brand queries could not be separated because this project has no brand name or domain to match against. Set a display name or aliases to split them — until then this figure pools both and is not a competitive read.'
-
-  // Preserve useful recognition evidence when no competitors are configured,
-  // but never turn the project-only denominator into a 100% share chart.
-  if (!hasCompetitiveFrame) {
-    const answerLabel = isNonBrand ? 'non-brand answers' : 'pooled answers'
-    return (
-      <div className="mention-share-breakdown">
-        <p className="mention-share-breakdown-title">
-          Brand mention counts · {isNonBrand ? 'non-brand queries' : 'pooled queries · classification unavailable'} · latest run
-          <InfoTooltip text={scopeTooltip} />
-        </p>
-        <p className="mention-share-breakdown-empty">
-          Your brand was named in {breakdown.projectMentionSnapshots} of {breakdown.snapshotsWithAnswerText} {answerLabel}.
-          {' '}Add tracked competitors to calculate mention share.
-        </p>
-        {brandedTotal > 0 && (
-          <p className="mention-share-breakdown-empty">
-            On branded queries, your brand was named in {branded.projectMentionSnapshots} of {branded.snapshotsWithAnswerText} answers — recognition, not competitive placement.
-          </p>
-        )}
-      </div>
-    )
-  }
-
-  return (
-    <div className="mention-share-breakdown">
-      <p className="mention-share-breakdown-title">
-        {scopeTitle}
-        <InfoTooltip text={scopeTooltip} />
-      </p>
-      {nonBrandTotal > 0 ? (
-        <MentionShareBreakdownRows breakdown={breakdown} projectLabel={projectLabel} />
-      ) : (
-        <p className="mention-share-breakdown-empty">
-          No brand mentions on non-brand queries in this run.
-        </p>
-      )}
-
-      {brandedTotal > 0 && (
-        <div className="mention-share-breakdown-branded">
-          <p className="mention-share-breakdown-title">
-            Branded queries · recognition, not placement
-            <InfoTooltip text="Queries containing your own name. Counted separately and never pooled with the figure above: these measure whether AI knows you when asked about you by name, not where you place against competitors." />
-          </p>
-          <MentionShareBreakdownRows breakdown={branded} projectLabel={projectLabel} />
-        </div>
-      )}
-    </div>
-  )
-}
-
 function OverviewSignals({
   insights,
   suggestedQueries,
@@ -2524,33 +2393,29 @@ function ProjectPageContent({
             </div>
 
             <div className="aeo-hero competitive-summary">
-              <div className="aeo-hero-rows">
-                <OverviewMetricRow
-                  label="Mention share"
-                  summary={model.mentionShareSummary}
-                  tooltip={model.mentionShareSummary.tooltip || (model.mentionShareSummary.scope === 'non-brand'
-                    ? 'Of the brand mentions in answer text on your non-brand queries (you + tracked competitors), the percentage that were you. Branded queries are counted separately below.'
-                    : 'Classification is unavailable, so all tracked queries remain pooled. This is not a competitive category read.')}
-                />
-                <OverviewMetricRow
-                  label="Mention gaps"
-                  summary={model.mentionGaps}
-                  displayValue={<><span className="text-primary">{model.mentionGaps.value}</span><span className="text-faint"> / {model.queryCounts.total}</span></>}
-                  tooltip="Queries where a competitor was mentioned in the answer but your brand was not."
-                />
-                <OverviewMetricRow
-                  label="Citation gaps"
-                  summary={model.gapQueries}
-                  displayValue={<><span className="text-primary">{model.gapQueries.value}</span><span className="text-faint"> / {model.queryCounts.total}</span></>}
-                  tooltip="Queries where a competitor was cited as a source but you were not."
-                />
-              </div>
-
-              <MentionShareBreakdown
+              <MentionShare
+                key={model.project.name}
                 summary={model.mentionShareSummary}
                 projectLabel={model.project.displayName || model.project.name}
-                hasCompetitiveFrame={model.competitors.length > 0}
+                competitorDomains={competitorDomains}
               />
+
+              <div className="competitive-gaps">
+                <div className="aeo-hero-rows">
+                  <OverviewMetricRow
+                    label="Mention gaps"
+                    summary={model.mentionGaps}
+                    displayValue={<><span className="text-primary">{model.mentionGaps.value}</span><span className="text-faint"> / {model.queryCounts.total}</span></>}
+                    tooltip="Queries where a competitor was mentioned in the answer but your brand was not."
+                  />
+                  <OverviewMetricRow
+                    label="Citation gaps"
+                    summary={model.gapQueries}
+                    displayValue={<><span className="text-primary">{model.gapQueries.value}</span><span className="text-faint"> / {model.queryCounts.total}</span></>}
+                    tooltip="Queries where a competitor was cited as a source but you were not."
+                  />
+                </div>
+              </div>
             </div>
 
             {addingCompetitor && (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1441,8 +1441,23 @@
     @apply text-[13px] text-secondary;
   }
 
+  /* A real <table> for semantics, laid out as the same four-column grid it was
+     before. `display: block` on the table and its sections hands layout back to
+     the per-row grid; the columns are still declared in one place. */
   .mention-share-table {
-    @apply pt-1;
+    @apply block pt-1;
+  }
+
+  .mention-share-table thead,
+  .mention-share-table tbody {
+    @apply block;
+  }
+
+  /* A `th` defaults to bold and centred; the row header must look exactly like
+     the span it replaced, so weight comes from the row's own classes. */
+  .mention-share-table th {
+    @apply text-left;
+    font-weight: inherit;
   }
 
   .mention-share-rows {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1283,9 +1283,6 @@
     @apply rounded-xl border border-default bg-surface px-5 py-5;
   }
 
-  .aeo-hero-title {
-    @apply text-[10px] font-medium uppercase tracking-[0.12em] text-muted mb-3;
-  }
 
   .aeo-hero-rows {
     @apply space-y-4 sm:space-y-3;
@@ -1327,9 +1324,6 @@
     grid-area: detail;
   }
 
-  .aeo-hero-context {
-    @apply text-[11px] text-secondary mt-4;
-  }
 
   /* ── Project overview ── */
 
@@ -1397,60 +1391,118 @@
     @apply px-5 py-4;
   }
 
-  .mention-share-breakdown {
-    @apply mt-4 pt-4 border-t border-mono-800/50;
+  /* Mention share: one chrome line (metric + class control), one figure, one
+     ranked list. The class control owns the denominator for everything above
+     `.competitive-gaps`, so branded and non-brand figures are never on screen
+     together. */
+  .mention-share {
+    @apply space-y-2;
   }
 
-  .mention-share-breakdown-title {
-    @apply flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted mb-2;
+  .mention-share-head {
+    @apply flex flex-wrap items-center justify-between gap-x-3 gap-y-2;
   }
 
-  /* Branded sits under its own rule and its own heading so the two classes
-     never read as one chart with one denominator. */
-  .mention-share-breakdown-branded {
-    @apply mt-4 pt-3 border-t border-mono-800/40;
+  .mention-share-label {
+    @apply inline-flex items-center gap-1.5;
   }
 
-  .mention-share-breakdown-empty {
-    @apply text-xs text-muted;
+  .mention-share-label-text {
+    @apply text-sm font-medium text-strong;
   }
 
-  .mention-share-breakdown-rows {
+  /* Scope label when there is no control. Load bearing, so 13px text-secondary,
+     never a 10px muted eyebrow. */
+  .mention-share-class {
+    @apply text-[13px] font-medium text-secondary;
+  }
+
+  .mention-share-value {
+    @apply text-2xl font-bold tracking-tight tabular-nums;
+  }
+
+  /* Non-numeric states are sentences, not figures, so they never take the 24px
+     numeral size. */
+  .mention-share-value-text {
+    @apply text-[15px] font-medium text-secondary;
+  }
+
+  /* Carries the denominator's name next to its counts, so a crop of the figure
+     is still self-describing. */
+  .mention-share-caption {
+    @apply text-[13px] text-secondary tabular-nums;
+  }
+
+  .mention-share-caption-scope {
+    @apply font-medium text-heading;
+  }
+
+  .mention-share-note {
+    @apply text-[13px] text-secondary;
+  }
+
+  .mention-share-table {
+    @apply pt-1;
+  }
+
+  .mention-share-rows {
     @apply space-y-1.5;
   }
 
-  .mention-share-breakdown-row {
-    @apply grid items-center gap-x-3 text-xs;
-    /* Floors relaxed on mobile so the four columns never exceed a narrow
-       viewport; the truncating label absorbs the squeeze. ≥480px restores the
-       roomier desktop track sizes. */
-    grid-template-columns: minmax(0, 1fr) minmax(56px, 2fr) 28px 48px;
+  /* Under 480px the bar track COLLAPSES to zero width rather than the bar being
+     `display: none`. Two reasons, both learned by measuring:
+     - The bar is redundant with the share percentage printed beside it, but the
+       competitor's name is not redundant with anything. At 390px a 1fr label
+       against a 2fr bar truncated `rival-one.example` and `rival-two.example`
+       to the same `rival-...`, which destroys the one thing this list says.
+     - `display: none` removes a grid ITEM from the grid, it does not leave its
+       track empty. Hiding the bar that way reflowed each row's remaining three
+       cells into columns 1-3 while the header kept four, putting the `Share`
+       heading 68px right of the numbers under it. A zero-width track keeps
+       every row and the header on the same four columns.
+     `.mention-share-bar` is `w-full overflow-hidden`, so at a zero-width track
+     it paints nothing. */
+  .mention-share-row {
+    @apply grid items-center gap-x-3 text-[13px];
+    grid-template-columns: minmax(0, 1fr) 0 64px 56px;
   }
 
   @media (min-width: 480px) {
-    .mention-share-breakdown-row {
-      grid-template-columns: minmax(140px, 1fr) minmax(80px, 2fr) 32px 56px;
+    .mention-share-row {
+      grid-template-columns: minmax(140px, 1fr) minmax(80px, 2fr) 64px 60px;
     }
   }
 
-  .mention-share-breakdown-label {
+  /* MUST stay after `.mention-share-row` and its media query: equal specificity,
+     so source order decides the font size. */
+  .mention-share-row-head {
+    @apply mb-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted;
+  }
+
+  .mention-share-row-label {
     @apply truncate;
   }
 
-  .mention-share-breakdown-bar {
+  .mention-share-bar {
     @apply h-1.5 w-full rounded-full bg-surface-inset overflow-hidden;
   }
 
-  .mention-share-breakdown-bar-fill {
+  .mention-share-bar-fill {
     @apply h-full rounded-full;
   }
 
-  .mention-share-breakdown-count {
-    @apply text-secondary tabular-nums text-right;
+  .mention-share-count {
+    @apply inline-flex items-center justify-end gap-1 text-secondary tabular-nums text-right;
   }
 
-  .mention-share-breakdown-share {
-    @apply text-muted tabular-nums text-right;
+  .mention-share-share {
+    @apply text-primary tabular-nums text-right;
+  }
+
+  /* The gap rows sit below a rule because the class control has no authority
+     over them: `mentionGaps` and `gapQueries` have no class split in the DTO. */
+  .competitive-gaps {
+    @apply mt-5 pt-4 border-t border-mono-800/50;
   }
 
   /* ── Movement banner (Since Last Run) ── */

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -216,7 +216,11 @@ export interface ProjectCommandCenterVm {
   visibilitySummary: ScoreSummaryVm
   /** Mention Share — head-to-head competitive metric. Carries breakdown so
    *  the hero drilldown can render the per-competitor table without re-fetching. */
-  mentionShareSummary: MentionShareDto
+  /** `unavailable` marks the client-side placeholder built when the /overview
+   *  fetch failed. Its counters are all zero, which is indistinguishable from a
+   *  project that has never swept, so the distinction has to be carried
+   *  explicitly rather than inferred. */
+  mentionShareSummary: MentionShareDto & { unavailable?: boolean }
   queryCounts: QueryCountsVm
   gapQueries: ScoreSummaryVm
   mentionGaps: ScoreSummaryVm

--- a/apps/web/test/mention-share-class-toggle.test.tsx
+++ b/apps/web/test/mention-share-class-toggle.test.tsx
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { MentionShare, type MentionShareBreakdownVm } from '../src/components/project/MentionShare.js'
+import { METRIC_TONE_TEXT_CLASS } from '../src/lib/tone-helpers.js'
+import type { ProjectCommandCenterVm } from '../src/view-models.js'
+
+afterEach(cleanup)
+
+type Summary = ProjectCommandCenterVm['mentionShareSummary']
+
+function breakdown(over: Partial<MentionShareBreakdownVm> = {}): MentionShareBreakdownVm {
+  return {
+    projectMentionSnapshots: 0,
+    competitorMentionSnapshots: 0,
+    perCompetitor: [],
+    snapshotsWithAnswerText: 0,
+    snapshotsTotal: 0,
+    score: null,
+    ...over,
+  }
+}
+
+function summary(over: Partial<Summary> = {}): Summary {
+  return {
+    label: 'Mention Share',
+    value: '38',
+    delta: '',
+    tone: 'caution',
+    description: '',
+    tooltip: '',
+    trend: [],
+    scope: 'non-brand',
+    breakdown: breakdown(),
+    branded: breakdown(),
+    ...over,
+  } as Summary
+}
+
+/**
+ * The lopsided shape this whole feature exists for: the project is named on
+ * every branded answer and loses the category. Pooled it would read as a win.
+ */
+function lopsided(): Summary {
+  return summary({
+    tone: 'negative',
+    breakdown: breakdown({
+      projectMentionSnapshots: 1,
+      competitorMentionSnapshots: 9,
+      perCompetitor: [{ domain: 'rival-one.example', mentionSnapshots: 9, shareOfCompetitiveTotal: 100 }],
+      snapshotsWithAnswerText: 32,
+      snapshotsTotal: 32,
+      score: 10,
+    }),
+    branded: breakdown({
+      projectMentionSnapshots: 20,
+      competitorMentionSnapshots: 0,
+      perCompetitor: [],
+      snapshotsWithAnswerText: 20,
+      snapshotsTotal: 20,
+      score: 100,
+    }),
+  })
+}
+
+function renderShare(over: Partial<Summary> = {}, competitorDomains = ['rival-one.example']) {
+  return render(
+    <MentionShare
+      summary={{ ...lopsided(), ...over }}
+      projectLabel="Acme Tanks"
+      competitorDomains={competitorDomains}
+    />,
+  )
+}
+
+function block(): HTMLElement {
+  return document.querySelector('.mention-share') as HTMLElement
+}
+
+describe('MentionShare class control', () => {
+  it('defaults to non-brand and never shows the branded figure beside it', () => {
+    renderShare()
+    const group = screen.getByRole('radiogroup')
+    expect(within(group).getByRole('radio', { name: 'Non-brand' }).getAttribute('aria-checked')).toBe('true')
+    expect(within(group).getByRole('radio', { name: 'Branded' }).getAttribute('aria-checked')).toBe('false')
+
+    // The competitive figure, and only it.
+    expect(block().querySelector('.mention-share-value')?.textContent).toBe('10%')
+    expect(block().textContent).toContain('Non-brand · 1 of 10 brand mentions')
+    // 100 is the branded score. It must not be on screen while non-brand is.
+    expect(block().textContent).not.toContain('100%')
+    expect(block().textContent).not.toContain('Branded ·')
+  })
+
+  it('switching to Branded swaps the denominator, the caption word, and the rows together', () => {
+    renderShare()
+    fireEvent.click(screen.getByRole('radio', { name: 'Branded' }))
+
+    expect(block().querySelector('.mention-share-value')?.textContent).toBe('100%')
+    expect(block().textContent).toContain('Branded · 20 of 20 brand mentions')
+    // The non-brand figure is now absent, not merely de-emphasised.
+    expect(block().textContent).not.toContain('Non-brand ·')
+    expect(block().textContent).not.toContain('1 of 10')
+
+    // Every tracked competitor still gets a row, at its branded count of zero,
+    // so "no competitor was named here" is visible rather than an absent row.
+    const rows = block().querySelectorAll('.mention-share-rows .mention-share-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[1]!.textContent).toContain('rival-one.example')
+    expect(rows[1]!.textContent).toContain('0.0%')
+  })
+
+  it('never tone-colours a branded figure, because the band is calibrated for placement', () => {
+    // Resolved from the shared tone map so the assertion tracks the design
+    // tokens rather than pinning a literal colour class.
+    const negative = METRIC_TONE_TEXT_CLASS.negative
+    renderShare()
+    expect(block().querySelector('.mention-share-value')!.className).toContain(negative)
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Branded' }))
+    const brandedValue = block().querySelector('.mention-share-value')!
+    expect(brandedValue.className).toContain('text-secondary')
+    expect(brandedValue.className).not.toContain(negative)
+  })
+
+  it('pooled renders no control, says so, and offers the recovery step', () => {
+    renderShare({ scope: 'pooled' })
+    expect(screen.queryByRole('radiogroup')).toBeNull()
+    expect(block().querySelector('.mention-share-class')?.textContent).toBe('All queries')
+    expect(block().textContent).toContain('All queries · 1 of 10 brand mentions')
+    expect(block().textContent).toContain('Set a brand name to split branded from non-brand.')
+    // A pooled figure is not a competitive read, so it is never tone-coloured.
+    expect(block().querySelector('.mention-share-value')!.className).toContain('text-secondary')
+    // And it is never labelled with a class it was not split by.
+    expect(block().textContent).not.toContain('Non-brand')
+    expect(block().textContent).not.toContain('Branded')
+  })
+
+  it('hides the control when the project has no branded queries at all', () => {
+    renderShare({ branded: breakdown() })
+    expect(screen.queryByRole('radiogroup')).toBeNull()
+    expect(block().querySelector('.mention-share-class')?.textContent).toBe('Non-brand')
+    expect(block().textContent).toContain('Non-brand · 1 of 10 brand mentions')
+  })
+
+  it('renders no share figure and no ranking when there is no competitive frame', () => {
+    renderShare({}, [])
+    expect(block().textContent).not.toContain('%')
+    expect(block().querySelector('.mention-share-rows')).toBeNull()
+    expect(block().querySelector('.mention-share-value-text')?.textContent).toBe('Add competitors')
+    expect(block().textContent).toContain('you were named in 1 of 32 answers')
+  })
+
+  it('arrow keys move the selection across the two classes and wrap', () => {
+    renderShare()
+    const group = screen.getByRole('radiogroup')
+    const branded = within(group).getByRole('radio', { name: 'Branded' })
+
+    fireEvent.keyDown(group, { key: 'ArrowRight' })
+    expect(branded.getAttribute('aria-checked')).toBe('true')
+    expect(block().textContent).toContain('Branded ·')
+
+    // Wraps back around rather than dead-ending.
+    fireEvent.keyDown(group, { key: 'ArrowRight' })
+    expect(within(group).getByRole('radio', { name: 'Non-brand' }).getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('distinguishes a failed overview fetch from a project that has never swept', () => {
+    // Both produce all-zero counters. The dashboard fan-out swallows an
+    // /overview rejection, so there is no error banner to contradict a false
+    // "no sweep has run yet" on a project with a year of sweeps.
+    const empty = { breakdown: breakdown(), branded: breakdown() }
+
+    renderShare({ ...empty, unavailable: true })
+    expect(block().querySelector('.mention-share-value-text')?.textContent).toBe('No data')
+    expect(block().textContent).toContain('could not load, refresh to retry')
+    expect(block().textContent).not.toContain('no sweep has run yet')
+
+    cleanup()
+    renderShare(empty)
+    expect(block().textContent).toContain('no sweep has run yet')
+    expect(block().textContent).not.toContain('could not load')
+  })
+
+  it('keeps the heading name free of the tooltip paragraph', () => {
+    renderShare()
+    const heading = screen.getByRole('heading', { level: 3 })
+    // A heading takes its accessible name from its content, so the tooltip has
+    // to be a sibling. Nesting it made the h3 announce the whole methodology.
+    expect(heading.textContent).toBe('Mention share')
+    expect(heading.querySelector('button')).toBeNull()
+    // And the radiogroup is still labelled by it.
+    expect(screen.getByRole('radiogroup').getAttribute('aria-labelledby')).toBe(heading.id)
+  })
+
+  it('renders a truthful state instead of vanishing when a run named nobody', () => {
+    // The old component returned null here and silently deleted real evidence.
+    renderShare({
+      breakdown: breakdown({ snapshotsWithAnswerText: 24, snapshotsTotal: 24 }),
+      branded: breakdown(),
+    })
+    expect(block().querySelector('.mention-share-value-text')?.textContent).toBe('No mentions')
+    expect(block().textContent).toContain('no brand named in 24 answers')
+    expect(block().querySelector('.mention-share-rows')).toBeNull()
+  })
+})

--- a/apps/web/test/mention-share-class-toggle.test.tsx
+++ b/apps/web/test/mention-share-class-toggle.test.tsx
@@ -203,3 +203,56 @@ describe('MentionShare class control', () => {
     expect(block().querySelector('.mention-share-rows')).toBeNull()
   })
 })
+
+describe('MentionShare empty-class copy', () => {
+  it('an all-branded basket says so instead of claiming nothing is tracked', () => {
+    // The default selection is non-brand, which is empty here, but 20 branded
+    // snapshots sit one click away. "none tracked" would contradict the control
+    // beside it, and the server already names this state.
+    renderShare({ breakdown: breakdown() })
+    expect(block().querySelector('.mention-share-value-text')?.textContent).toBe('No non-brand queries')
+    expect(block().textContent).toContain('every tracked query names your brand')
+    expect(block().textContent).not.toContain('none tracked')
+    // The branded data is reachable, and reads normally once selected.
+    fireEvent.click(screen.getByRole('radio', { name: 'Branded' }))
+    expect(block().querySelector('.mention-share-value')?.textContent).toBe('100%')
+  })
+
+  it('still says "none tracked" when the project really tracks nothing', () => {
+    renderShare({ breakdown: breakdown({ snapshotsTotal: 0 }), branded: breakdown({ snapshotsTotal: 0 }) })
+    expect(block().textContent).toContain('no sweep has run yet')
+
+    cleanup()
+    // A run happened for branded, none for non-brand, and no branded queries
+    // either: nothing is tracked in either class beyond the run itself.
+    renderShare({ breakdown: breakdown(), branded: breakdown() , unavailable: false })
+    expect(block().textContent).not.toContain('No non-brand queries')
+  })
+})
+
+describe('MentionShare ranking semantics', () => {
+  it('exposes the columns to assistive tech, not just to the eye', () => {
+    renderShare()
+    const table = screen.getByRole('table')
+    expect(table).toBeTruthy()
+
+    // Column headers exist and are associated by scope, so a value is announced
+    // with what it means rather than as a bare number.
+    const columnHeaders = within(table).getAllByRole('columnheader')
+    expect(columnHeaders.map(h => h.textContent?.replace(/\s+/g, ' ').trim())).toEqual(
+      expect.arrayContaining(['Domain', 'Share']),
+    )
+    for (const header of columnHeaders) {
+      if (header.getAttribute('aria-hidden') === 'true') continue
+      expect(header.getAttribute('scope')).toBe('col')
+    }
+
+    // Each row is identified by its domain, as a row header.
+    const rowHeaders = within(table).getAllByRole('rowheader')
+    expect(rowHeaders[0]!.getAttribute('scope')).toBe('row')
+    expect(rowHeaders.map(h => h.textContent)).toContain('rival-one.example')
+
+    // The bar restates the share cell, so it is decorative and hidden.
+    expect(table.querySelector('.mention-share-bar')!.closest('[aria-hidden="true"]')).toBeTruthy()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.173.0",
+  "version": "4.174.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.173.0",
+  "version": "4.174.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.173.0",
+  "version": "4.174.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.173.0",
+  "version": "4.174.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.173.0",
+  "version": "4.174.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## What

Mention share rendered as two stacked sections, one per query class, each with its own heading, its own explanatory sentence and its own denominator. This replaces them with one unit: a chrome line that names the metric and owns the class, one figure, one ranked list.

```
Mention share ⓘ                    [ Non-brand │ Branded ]
3%
Non-brand · 1 of 30 brand mentions
                                     MENTIONS ⓘ    SHARE
  rival-one.example  ▓▓▓▓▓▓▓▓▓            9       30.0%
  Acme Tanks (you)   ▓                    1        3.3%
─────────────────────────────────────────────────────────
Mention gaps ⓘ   14 / 46
Citation gaps ⓘ   9 / 46
```

In the healthy case the unit renders zero sentences of prose. Every methodology clause moved into a tooltip.

## Why these specific choices

**The control owns the whole denominator.** Figure, caption and list switch together, so the two classes are never on screen at once and cannot be read against one total. That is the pooling bug enforced structurally rather than by labelling.

**The class name is visible text in the caption, not only the selected chip.** A crop that contains the number contains the name of its denominator.

**Branded is never tone-coloured.** It sits near 100% by construction; painting that green would read as a win. The tone bands are calibrated for competitive placement, so only non-brand gets them. `pooled` is not a competitive read either, so it is also never toned.

**`pooled` renders no control at all, not a disabled one.** A disabled segmented control with "Non-brand" lit would label a pooled figure non-brand.

**The headline gauge is deleted.** The list is the chart, and the gauge was drawing a number the list already draws. This also retires a progress bar on a metric whose scale the gauge did not really bound.

**The gap rows drop below a rule** because the class control has no authority over them: `mentionGaps` and `gapQueries` have no class split in the DTO.

## DESIGN.md violations closed

- Methodology copy is in tooltips, not the default view.
- No 10px uppercase scope titles; the only remaining 10px text is a real table header.
- No recovery copy in `text-muted`; the one degraded-state line is 13px `text-secondary`.
- The share percentage moves from 12px `text-muted` to 13px `text-primary`.
- One control owns the class choice instead of it being duplicated across headings.
- Both em dashes on this surface are gone with the strings that held them.
- `Mention share breakdown` no longer restates `Mention share`.

## Two bugs the screenshots caught

Rendered the real component with the compiled stylesheet and drove Chrome over CDP at 760px and 390px.

1. At 390px the bar column took `2fr` against the label's `1fr`, so `rival-one.example` and `rival-two.example` both truncated to `rival-...`. Naming who beats you is the one thing this list exists to do. The bar track now collapses to zero width under 480px; the printed share already carries what the bar carried.

2. Fixing that with `display: none` on the bar introduced a worse one: that removes a grid ITEM from the grid rather than leaving its track empty, so each row's remaining three cells reflowed into columns 1-3 while the header kept four. The `Share` heading landed 68px right of the numbers under it. Measured, not eyeballed: header right edges and row right edges are now identical at both viewports.

## Structure

`MentionShare` is extracted to `apps/web/src/components/project/MentionShare.tsx`, where the repo keeps units of this size, rather than staying inline in the 2,900-line page. That is also what makes the tests below focused rather than full-page renders.

## Tests

Eight new tests in `apps/web/test/mention-share-class-toggle.test.tsx`, covering the invariants that had no coverage on this surface:

- default is non-brand, and the branded score appears nowhere while it is selected
- switching swaps figure, caption word and rows together, and the non-brand figure is then absent rather than de-emphasised
- a branded figure is never tone-coloured
- `pooled` renders no control, says `All queries`, offers the recovery step, and is never labelled with a class it was not split by
- no control when the project has no branded queries
- no `%` and no ranking when there is no competitive frame
- arrow keys move selection across the classes and wrap
- a run that recorded answers but named nobody renders `No mentions` instead of vanishing (the old component returned `null` and silently deleted real evidence)

Full suite, typecheck and lint are green.
