### PR TITLE
fix(brand-matching): fold accents, so an accented brand is not invisible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.172.4",
+  "version": "4.173.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.172.4",
+  "version": "4.173.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/brand-matching.ts
+++ b/packages/contracts/src/brand-matching.ts
@@ -18,9 +18,53 @@ const WORD_SEGMENTER = new Intl.Segmenter('en', { granularity: 'word' })
 const NON_WORD = /[^\p{L}\p{N}]+/gu
 const WORD_RUNS = /[\p{L}\p{N}]+/gu
 
-/** Fold presentation variants without changing spelling. */
+/**
+ * The combining marks NFKD produces when it decomposes a precomposed LATIN,
+ * GREEK or CYRILLIC letter: `Totême` -> `tote` + U+0302 + `me`.
+ *
+ * `Script=Inherited` is what confines this to accents. A mark in that script
+ * takes its identity from the base letter it sits on, which is exactly what an
+ * accent is; a mark that belongs to a script of its own is part of that
+ * script's spelling instead. So a Devanagari matra and Hebrew niqqud survive
+ * this step, while the acute on `É` does not.
+ *
+ * `Script=Inherited` also covers ZWJ and ZWNJ, the only two codepoints where it
+ * differs from intersecting with `\p{Mark}` (checked across the whole codepoint
+ * range). Dropping them here changes nothing, because `WORD_RUNS` keeps only
+ * `\p{L}\p{N}` and would drop them a step later regardless. The intersection is
+ * the more exact spelling of the intent but needs the `v` flag, which needs an
+ * ES2024 target; the repo is on ES2022.
+ *
+ * That is a scope limit on THIS regex, not a claim about the module: `WORD_RUNS`
+ * below keeps only `\p{L}\p{N}`, so marks of every script are already dropped
+ * when word tokens are built. Whether that is right for Devanagari, Thai or
+ * Hebrew is a real question and a separate one; it predates accent folding and
+ * is unchanged by it.
+ */
+const ACCENT_MARKS = /\p{Script=Inherited}+/gu
+
+/**
+ * Fold presentation variants without changing spelling.
+ *
+ * ACCENTS ARE A PRESENTATION VARIANT, in the same family as `Demand-IQ` vs
+ * `DemandIQ`. A brand written `Totême` or `Éterne` on its own site is written
+ * `Toteme` and `Eterne` by half the prose that mentions it, and the alias
+ * derived from its domain has no accents at all, so without folding an accented
+ * brand is invisible to every mention metric. Measured on a real run: a
+ * competitor named in two answers scored zero, and another was undercounted.
+ *
+ * NFKD rather than NFKC, so the accents become separate marks this can drop.
+ * The two induce the same equivalence classes (`NFKC(a) === NFKC(b)` exactly
+ * when `NFKD(a) === NFKD(b)`), and both the alias and the text pass through
+ * here, so the comparison stays symmetric.
+ *
+ * The cost, accepted: a brand distinguished from an ordinary word ONLY by its
+ * accents now matches that word. Complete-adjacent-word matching still applies,
+ * so this widens what counts as the same spelling, never what counts as a
+ * similar one.
+ */
 function normalizeForMatch(value: string): string {
-  return value.normalize('NFKC').toLocaleLowerCase('en')
+  return value.normalize('NFKD').replace(ACCENT_MARKS, '').toLocaleLowerCase('en')
 }
 
 /** The word tokens of an already-normalized string. */

--- a/packages/contracts/src/brand-matching.ts
+++ b/packages/contracts/src/brand-matching.ts
@@ -51,6 +51,14 @@ function foldAccents(value: string): string {
   if (!NON_ASCII.test(value)) return value
   let folded = ''
   for (const character of value) {
+    // An ASCII character can carry no accent, and answer prose is overwhelmingly
+    // ASCII. Without this, one curly quote anywhere in the text sends every
+    // other character through `normalize`, and this runs once per competitor
+    // per answer.
+    if (character.charCodeAt(0) < 0x80) {
+      folded += character
+      continue
+    }
     const decomposed = character.normalize('NFD')
     const base = decomposed[0]!
     folded += decomposed.length > 1 && ACCENT_BEARING_SCRIPT.test(base) ? base : character

--- a/packages/contracts/src/brand-matching.ts
+++ b/packages/contracts/src/brand-matching.ts
@@ -19,29 +19,44 @@ const NON_WORD = /[^\p{L}\p{N}]+/gu
 const WORD_RUNS = /[\p{L}\p{N}]+/gu
 
 /**
- * The combining marks NFKD produces when it decomposes a precomposed LATIN,
- * GREEK or CYRILLIC letter: `Totême` -> `tote` + U+0302 + `me`.
- *
- * `Script=Inherited` is what confines this to accents. A mark in that script
- * takes its identity from the base letter it sits on, which is exactly what an
- * accent is; a mark that belongs to a script of its own is part of that
- * script's spelling instead. So a Devanagari matra and Hebrew niqqud survive
- * this step, while the acute on `É` does not.
- *
- * `Script=Inherited` also covers ZWJ and ZWNJ, the only two codepoints where it
- * differs from intersecting with `\p{Mark}` (checked across the whole codepoint
- * range). Dropping them here changes nothing, because `WORD_RUNS` keeps only
- * `\p{L}\p{N}` and would drop them a step later regardless. The intersection is
- * the more exact spelling of the intent but needs the `v` flag, which needs an
- * ES2024 target; the repo is on ES2022.
- *
- * That is a scope limit on THIS regex, not a claim about the module: `WORD_RUNS`
- * below keeps only `\p{L}\p{N}`, so marks of every script are already dropped
- * when word tokens are built. Whether that is right for Devanagari, Thai or
- * Hebrew is a real question and a separate one; it predates accent folding and
- * is unchanged by it.
+ * The alphabets that write an accent OVER a base letter which stands on its own.
+ * Folding is decided by this base, never by the mark, because "is this mark an
+ * accent" has no script-independent answer: `Script=Inherited` contains the
+ * Japanese dakuten and the Arabic hamza, and stripping those turns `が` into
+ * `か` and `أ` into `ا`, which are different letters, not styled ones.
  */
-const ACCENT_MARKS = /\p{Script=Inherited}+/gu
+const ACCENT_BEARING_SCRIPT = /[\p{Script=Latin}\p{Script=Greek}\p{Script=Cyrillic}]/u
+
+/**
+ * Cheap reject. Accents live above U+007F, so pure ASCII can skip the fold
+ * entirely, and this runs over every answer text of every project.
+ */
+const NON_ASCII = /\P{ASCII}/u
+
+/**
+ * Drop accents from Latin, Greek and Cyrillic letters, leaving every other
+ * script exactly as written.
+ *
+ * Per character, so the decision is made against the letter UNDER the mark. A
+ * blanket "delete all combining marks" cannot work: the same Unicode category
+ * holds the acute on `É`, the dakuten that separates `が` from `か`, and the
+ * hamza that separates `أ` from `ا`. Only the first is decoration.
+ *
+ * Recomposing is what keeps a key's LENGTH stable, which matters because the
+ * alias floors are counted in characters: NFKD alone explodes Hangul syllables
+ * into jamo and turns a 2-character brand into a 6-character one, sneaking it
+ * past a floor meant to reject it.
+ */
+function foldAccents(value: string): string {
+  if (!NON_ASCII.test(value)) return value
+  let folded = ''
+  for (const character of value) {
+    const decomposed = character.normalize('NFD')
+    const base = decomposed[0]!
+    folded += decomposed.length > 1 && ACCENT_BEARING_SCRIPT.test(base) ? base : character
+  }
+  return folded
+}
 
 /**
  * Fold presentation variants without changing spelling.
@@ -53,18 +68,14 @@ const ACCENT_MARKS = /\p{Script=Inherited}+/gu
  * brand is invisible to every mention metric. Measured on a real run: a
  * competitor named in two answers scored zero, and another was undercounted.
  *
- * NFKD rather than NFKC, so the accents become separate marks this can drop.
- * The two induce the same equivalence classes (`NFKC(a) === NFKC(b)` exactly
- * when `NFKD(a) === NFKD(b)`), and both the alias and the text pass through
- * here, so the comparison stays symmetric.
- *
- * The cost, accepted: a brand distinguished from an ordinary word ONLY by its
- * accents now matches that word. Complete-adjacent-word matching still applies,
- * so this widens what counts as the same spelling, never what counts as a
- * similar one.
+ * NFKC first so a decomposed input is composed before the fold sees it, and the
+ * fold itself recomposes nothing it did not decompose. The cost, accepted: a
+ * Latin brand distinguished from an ordinary word ONLY by its accents now
+ * matches that word. Complete-adjacent-word matching is untouched, so this
+ * widens what counts as the same SPELLING, never what counts as a similar one.
  */
 function normalizeForMatch(value: string): string {
-  return value.normalize('NFKD').replace(ACCENT_MARKS, '').toLocaleLowerCase('en')
+  return foldAccents(value.normalize('NFKC')).toLocaleLowerCase('en')
 }
 
 /** The word tokens of an already-normalized string. */

--- a/packages/contracts/test/brand-matching.test.ts
+++ b/packages/contracts/test/brand-matching.test.ts
@@ -119,7 +119,36 @@ describe('accent folding', () => {
     expect(textContainsBrandAlias('price', 'prime')).toBe(false)
   })
 
-  it('confines the fold to accent blocks, leaving other scripts as they already were', () => {
+  it('never folds a mark that distinguishes one letter from another', () => {
+    // The decisive cases. All three marks below sit in the SAME Unicode
+    // category as the acute on `E`, and `Script=Inherited` contains the first
+    // two, so any rule phrased over the MARK folds them. They are not accents:
+    // が/か and ぱ/は are different kana, أ/ا are different Arabic letters.
+    expect(brandKeyFromText('が')).not.toBe(brandKeyFromText('か'))
+    expect(brandKeyFromText('ガ')).not.toBe(brandKeyFromText('カ'))
+    expect(brandKeyFromText('ぱ')).not.toBe(brandKeyFromText('は'))
+    expect(brandKeyFromText('ヴ')).not.toBe(brandKeyFromText('ウ'))
+    expect(brandKeyFromText('أ')).not.toBe(brandKeyFromText('ا'))
+    expect(brandKeyFromText('إ')).not.toBe(brandKeyFromText('ا'))
+    expect(brandKeyFromText('آ')).not.toBe(brandKeyFromText('ا'))
+
+    // And they do not match each other in prose either.
+    expect(textContainsBrandAlias('がっちり', 'か')).toBe(false)
+    expect(textContainsBrandAlias('أحمد', 'ا')).toBe(false)
+  })
+
+  it('keeps key LENGTH stable, so the alias floors still gate what they were written to gate', () => {
+    // Decomposition explodes a Hangul syllable into jamo. Left decomposed, a
+    // two-character Korean brand counts as six and walks past a floor meant to
+    // reject it (MIN_BRAND_ALIAS_KEY_LENGTH is 3, MIN_DOMAIN_BRAND_KEY_LENGTH 4).
+    expect(brandKeyFromText('삼성')).toHaveLength(2)
+    expect(brandKeyFromText('한')).toHaveLength(1)
+    // Latin accents fold without changing length either.
+    expect(brandKeyFromText('Totême')).toHaveLength(6)
+    expect(brandKeyFromText('Éterne')).toHaveLength(6)
+  })
+
+  it('confines the fold to accent-bearing scripts, leaving other scripts as they already were', () => {
     // `WORD_RUNS` keeps only \p{L}\p{N}, so marks of EVERY script were already
     // dropped when word tokens are built. Accent folding must not change that
     // either way, so this pins the pre-existing behaviour rather than claiming

--- a/packages/contracts/test/brand-matching.test.ts
+++ b/packages/contracts/test/brand-matching.test.ts
@@ -88,3 +88,46 @@ describe('one segmentation for the whole alias set', () => {
     expect(brandWords('DEMAND-IQ')).toEqual(['demand', 'iq'])
   })
 })
+
+describe('accent folding', () => {
+  // An accented brand used to be invisible to every mention metric: the alias
+  // derived from its domain carries no accents, so `eterne` never matched
+  // `Éterne`. Measured on a real run, one competitor scored 0 against 2 real
+  // mentions and another was undercounted by one.
+  it('matches an accented brand from its unaccented domain alias', () => {
+    expect(textContainsBrandAlias('Éterne 90s Ribbed Tank', 'eterne')).toBe(true)
+    expect(textContainsBrandAlias('Totême is minimal', 'toteme')).toBe(true)
+    expect(textContainsBrandAlias('Loewe and Lóewe', 'loewe')).toBe(true)
+  })
+
+  it('matches in both directions, so an accented alias finds unaccented prose', () => {
+    expect(textContainsBrandAlias('Eterne makes ribbed tanks', 'Éterne')).toBe(true)
+    expect(textContainsBrandAlias('Toteme is minimal', 'Totême')).toBe(true)
+  })
+
+  it('folds accents into the brand key, so the two spellings share one identity', () => {
+    expect(brandKeyFromText('Totême')).toBe(brandKeyFromText('Toteme'))
+    expect(brandKeyFromText('Éterne')).toBe('eterne')
+    // Presentation folding still composes with the punctuation/spacing rules.
+    expect(brandKeyFromText('Café-Noir')).toBe(brandKeyFromText('Cafe Noir'))
+  })
+
+  it('still refuses substrings and spelling guesses', () => {
+    // Folding widens what counts as the SAME spelling, never as a similar one.
+    expect(textContainsBrandAlias('Eterneless brands', 'eterne')).toBe(false)
+    expect(textContainsBrandAlias('acmeology', 'acme')).toBe(false)
+    expect(textContainsBrandAlias('price', 'prime')).toBe(false)
+  })
+
+  it('confines the fold to accent blocks, leaving other scripts as they already were', () => {
+    // `WORD_RUNS` keeps only \p{L}\p{N}, so marks of EVERY script were already
+    // dropped when word tokens are built. Accent folding must not change that
+    // either way, so this pins the pre-existing behaviour rather than claiming
+    // the fold protects it. Whether dropping Devanagari matras is right is a
+    // real question, and a separate one from accents.
+    expect(brandKeyFromText('की')).toBe(brandKeyFromText('क'))
+    // The accent blocks are what this change touches, and only those.
+    expect(brandKeyFromText('Ω')).toBe('ω')
+    expect(brandKeyFromText('Ώ')).toBe(brandKeyFromText('Ω'))
+  })
+})

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.172.4",
+  "version": "4.173.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.172.4",
+  "version": "4.173.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.172.4",
+  "version": "4.173.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## What

The shared brand matcher folded case, spacing and punctuation, but not accents. A brand written `Totême` or `Éterne` therefore never matched the alias derived from its own domain, which carries no accents at all, so it was invisible to every mention metric.

Measured on a real run: one tracked competitor scored **0 against 2 genuine mentions**, another was undercounted by one. 27 competitor mentions were being reported as 24.

An accent is a presentation variant, the same family as `Demand-IQ` vs `DemandIQ` that this module already folds, and half the prose that names an accented brand spells it plain.

## How, and why it is phrased this way

**The fold is decided by the base letter, never by the mark.** Marks are dropped only when the letter underneath is Latin, Greek or Cyrillic: the alphabets that write an accent over a letter that stands on its own.

That phrasing is the whole design, and the first version of this PR got it wrong. Any rule expressed over the *mark* folds too much, because the acute on `É`, the dakuten that separates `が` from `か`, and the hamza that separates `أ` from `ا` all share a Unicode category, and `Script=Inherited` contains the latter two. That version made `が` match `か` and `أ` match `ا` — different letters reading as one identity, which is exactly the failure this module exists to prevent.

**Key length is stable.** No decomposition survives the function. Bare NFKD explodes a Hangul syllable into jamo, so `삼성` keyed as 6 characters instead of 2 and walked past the alias length floors (`MIN_BRAND_ALIAS_KEY_LENGTH` 3, `MIN_DOMAIN_BRAND_KEY_LENGTH` 4) that exist to reject tokens that short.

**This widens what counts as the same spelling, never what counts as a similar one.** Complete-adjacent-word matching is untouched, so `acmeology` still does not match `acme`. The accepted cost is that a *Latin* brand distinguished from an ordinary word only by its accents now matches that word.

## Tests

Positive: `Totême`/`Toteme` and `Éterne`/`Eterne` fold in both directions, folding composes with the existing punctuation and spacing rules, and the substring and spelling-guess refusals still hold.

Negative, one per script the first version broke: が/か, ガ/カ, ぱ/は, ヴ/ウ, أ/ا, إ/ا, آ/ا stay distinct, and they do not match each other in prose. Plus the length invariant: `삼성` keys as 2, `Totême` and `Éterne` as 6.

Full suite, typecheck and lint green.

## Blast radius

This is the matcher behind `determineAnswerMentioned`, query classification, mention share and the mention landscape, so it moves every mention metric.

**Mention share self-heals on historical runs**, because it recomputes `projectMentioned` from stored answer text rather than trusting the run-time boolean. Surfaces that read the stored `answer_mentioned` column keep their original values, so expect a one-time step between runs recorded before and after this lands. `visibility-compare` can read that step as a real move; treat the first comparison spanning the deploy accordingly.

No historical backfill is included here. That is a separate, explicit decision.

## Not in this change

`cos.com` is still invisible, for an unrelated reason: the competitor alias builder gates the registrable label on a 4-character floor. Measuring 4,000 real answers shows length is the wrong discriminator — `cos` collides with ordinary prose in 0.1% of answers while `gap` hits 3.8% and `ups` 5.5%, so no single threshold is correct for both. That wants an operator-approved per-competitor alias, not a different number.
