### PR TITLE
Hide inactive model evidence and single-sweep notes

### DIFF
--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -244,6 +244,8 @@ function ModelEvidenceSummary({
   const descriptionId = useId()
   const servedEntries = Object.entries(served).sort(([a], [b]) => a.localeCompare(b))
   const hasChanges = partition.buckets.length > 0 || partition.beforeWindow.length > 0
+  if (!available || !hasChanges) return null
+
   return (
     <aside className="trend-model-evidence" aria-labelledby="trend-model-evidence-title" aria-describedby={descriptionId}>
       <div className="trend-model-evidence-head">
@@ -254,57 +256,49 @@ function ModelEvidenceSummary({
         Model evidence is recorded from the exact snapshots that produced each trend bucket. It is not the project’s configured provider model.
         {counts.total > 0 ? ` ${counts.shown} of ${counts.total} recorded changes are listed.` : ''}
       </p>
-      {!available ? (
-        <p className="trend-model-evidence-empty">Attribution unavailable from this API version.</p>
-      ) : !hasChanges ? (
-        <p className="trend-model-evidence-empty">No model evidence changes in this window.</p>
-      ) : (
+      {partition.buckets.length > 0 && (
+        <ul className="trend-model-evidence-list">
+          {partition.buckets.flatMap(({ bucketStartDate, events: bucketEvents }) => bucketEvents.map(({ provider, event }) => (
+            <li key={`${provider}-${event.observedAt}-${event.bucketStartDate}`} className="trend-model-evidence-item">
+              <span className="trend-model-evidence-date">{modelEventDateLabel(buckets, bucketStartDate, event.observedAt)}</span>
+              <span>{providerDisplayName(provider)}: {formatModelEvidence(event.from)} → {formatModelEvidence(event.to)}</span>
+            </li>
+          )))}
+        </ul>
+      )}
+      {/* These changes happened before the chart starts. They are listed so
+          nothing is lost, but they get no chart marker — a marker would put
+          a date on a change that did not happen on that date. */}
+      {partition.beforeWindow.length > 0 && (
         <>
-          {partition.buckets.length > 0 && (
-            <ul className="trend-model-evidence-list">
-              {partition.buckets.flatMap(({ bucketStartDate, events: bucketEvents }) => bucketEvents.map(({ provider, event }) => (
-                <li key={`${provider}-${event.observedAt}-${event.bucketStartDate}`} className="trend-model-evidence-item">
-                  <span className="trend-model-evidence-date">{modelEventDateLabel(buckets, bucketStartDate, event.observedAt)}</span>
-                  <span>{providerDisplayName(provider)}: {formatModelEvidence(event.from)} → {formatModelEvidence(event.to)}</span>
-                </li>
-              )))}
-            </ul>
-          )}
-          {/* These changes happened before the chart starts. They are listed so
-              nothing is lost, but they get no chart marker — a marker would put
-              a date on a change that did not happen on that date. */}
-          {partition.beforeWindow.length > 0 && (
-            <>
-              <p className="trend-model-evidence-note">Changed before this date range</p>
-              <ul className="trend-model-evidence-list">
-                {partition.beforeWindow.map(({ provider, event }) => (
-                  <li key={`before-${provider}-${event.observedAt}`} className="trend-model-evidence-item">
-                    <span className="trend-model-evidence-date">
-                      on or before {formatObservedInstantLabel(observedInstant(event.observedAt))}
-                    </span>
-                    <span>
-                      {providerDisplayName(provider)}: {formatModelEvidence(event.from)} → {formatModelEvidence(event.to)}
-                      {event.anchorObservedAt
-                        ? ` (last seen ${formatModelEvidence(event.from)} on ${formatObservedInstantLabel(observedInstant(event.anchorObservedAt))})`
-                        : ''}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </>
-          )}
-          {truncated.map(entry => (
-            <p key={`truncated-${entry.provider}`} className="trend-model-evidence-note">
-              {providerDisplayName(entry.provider)}: showing the most recent {entry.shown} of {entry.total} changes.
-            </p>
-          ))}
-          {incompleteHistory.map(provider => (
-            <p key={`incomplete-${provider}`} className="trend-model-evidence-note">
-              We did not look far enough back to be sure this is every {providerDisplayName(provider)} change.
-            </p>
-          ))}
+          <p className="trend-model-evidence-note">Changed before this date range</p>
+          <ul className="trend-model-evidence-list">
+            {partition.beforeWindow.map(({ provider, event }) => (
+              <li key={`before-${provider}-${event.observedAt}`} className="trend-model-evidence-item">
+                <span className="trend-model-evidence-date">
+                  on or before {formatObservedInstantLabel(observedInstant(event.observedAt))}
+                </span>
+                <span>
+                  {providerDisplayName(provider)}: {formatModelEvidence(event.from)} → {formatModelEvidence(event.to)}
+                  {event.anchorObservedAt
+                    ? ` (last seen ${formatModelEvidence(event.from)} on ${formatObservedInstantLabel(observedInstant(event.anchorObservedAt))})`
+                    : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
         </>
       )}
+      {truncated.map(entry => (
+        <p key={`truncated-${entry.provider}`} className="trend-model-evidence-note">
+          {providerDisplayName(entry.provider)}: showing the most recent {entry.shown} of {entry.total} changes.
+        </p>
+      ))}
+      {incompleteHistory.map(provider => (
+        <p key={`incomplete-${provider}`} className="trend-model-evidence-note">
+          We did not look far enough back to be sure this is every {providerDisplayName(provider)} change.
+        </p>
+      ))}
       {servedEntries.length > 0 && (
         <>
           <p className="trend-model-evidence-note">What the engines answered with</p>
@@ -571,9 +565,8 @@ export function VisibilityTrendSection({
   )
   const servedAttribution = useMemo(() => (data ? readServedModelAttribution(data) : {}), [data])
   const serviceMismatch = useMemo(() => (data ? readModelServiceMismatch(data) : {}), [data])
-  // Null on an older API and on a project whose engines are all on fixed model
-  // ids. An engine that CAN be moved but has no update on record is a separate,
-  // quieter state — see `buildModelChangeNotice`.
+  // Only a recorded update is surfaced in the dashboard. A moving model id
+  // with no update on record does not add persistent commentary to the chart.
   const modelChangeNotice = useMemo(
     () => (data ? buildModelChangeNotice(readModelPointerChanges(data)) : null),
     [data],
@@ -669,17 +662,6 @@ export function VisibilityTrendSection({
         )}
         <Segmented options={WINDOW_OPTIONS} value={window} onChange={setWindow} ariaLabel="Time window" className="sm:ml-auto" />
       </div>
-      {/* The common case, and the reason it is a bare muted line under the
-          controls rather than a tinted box above the head: it caveats nothing,
-          it only refuses to let an un-updated record read as proof that nothing
-          happened. Untinted, one line, with the explanation in the tooltip so
-          the surface stays a data surface. */}
-      {modelChangeNotice?.kind === 'no-known-change' && (
-        <p className="mt-3 text-[11px] leading-snug text-muted">
-          {modelChangeNotice.text}
-          <InfoTooltip text={modelChangeNotice.detail} />
-        </p>
-      )}
     </>
   )
 
@@ -693,7 +675,7 @@ export function VisibilityTrendSection({
   } else if (!data || !trend) {
     body = null
   } else {
-    const { rows, series, hasData, singleBucket } = trend
+    const { rows, series, hasData } = trend
     const caption = formatQueryChangeCaption(data.queryChanges)
     if (!hasData) {
       body = (
@@ -817,13 +799,6 @@ export function VisibilityTrendSection({
             mismatch={serviceMismatch}
             buckets={buckets}
           />
-          {singleBucket && (
-            <p className="visibility-trend-note">
-              {metric === 'mentionShare'
-                ? `Only one ${mentionShareScopeLabel(mentionShareScope)} mention-share point so far. The trend line fills in after another sweep with brand mentions.`
-                : 'Only one sweep so far. The trend line fills in after the next run.'}
-            </p>
-          )}
           {caption && <p className="visibility-trend-note">{caption}</p>}
         </>
       )

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -419,6 +419,52 @@ test('says nothing about served models when the API omits them', async () => {
   expect(screen.queryByText('What the engines answered with')).toBeNull()
 })
 
+test('hides model details and sweep commentary when there are no model changes', async () => {
+  const unchanged = metricsDto([TWO_BUCKETS[0]])
+  Object.assign(unchanged, {
+    modelAttribution: {
+      gemini: {
+        latestObservation: {
+          observedAt: '2026-04-03T14:20:00.000Z',
+          state: { status: 'known', model: 'gemini-2.0-flash' },
+        },
+        events: [],
+      },
+    },
+    servedModelAttribution: {
+      gemini: {
+        latestObservation: {
+          observedAt: '2026-04-03T14:20:00.000Z',
+          state: { status: 'known', model: 'gemini-2.0-flash' },
+        },
+        events: [],
+        eventTotal: 0,
+        latestServedModelIds: ['gemini-2.0-flash'],
+      },
+    },
+  })
+
+  const restore = mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      return jsonResponse(unchanged)
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restore)
+
+  renderSection(['competitor.com'])
+
+  await screen.findByRole('list', { name: 'Engines' })
+  expect(screen.queryByText('Model evidence changes')).toBeNull()
+  expect(screen.queryByText('No model evidence changes in this window.')).toBeNull()
+  expect(screen.queryByText('What the engines answered with')).toBeNull()
+  expect(screen.queryByText('Only one sweep so far. The trend line fills in after the next run.')).toBeNull()
+
+  act(() => { fireEvent.click(screen.getByRole('button', { name: 'Mention share' })) })
+  expect(screen.queryByText(/Only one .* mention-share point so far/)).toBeNull()
+})
+
 const CLOSING_LINE = 'rather than from a real change in how AI answers about you, so compare periods carefully.'
 
 /** One confirmed update. The `summary` is a LEGACY field an older server used
@@ -494,22 +540,15 @@ test('states one fact per affected engine and closes with a single consequence',
   expect(new Set(sentences).size).toBe(sentences.length)
 })
 
-test('reports an engine that can be updated with nothing on record, quietly', async () => {
+test('does not render model-pointer commentary when no update is on record', async () => {
   onTestFinished(mockMetrics({
     modelPointerChanges: { openai: { modelIds: ['chat-latest'], changeCount: 0, unverifiedChangeCount: 0 } },
   }))
 
   renderSection()
 
-  const line = await screen.findByText('No model updates are on record for ChatGPT in this period.')
-  // Quiet: no caution box, and the explanation is in a tooltip rather than set
-  // as prose on the surface. This renders on every load for anyone on a moving
-  // model id, so weight matters as much as the words.
-  expect(line.className).not.toContain('caution')
-  expect(within(line).getByRole('button')).toBeTruthy()
-  // And it does NOT jump the headline — nothing is being caveated.
-  const headline = document.querySelector('.visibility-trend-current-value')!
-  expect(line.compareDocumentPosition(headline) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy()
+  await screen.findByRole('list', { name: 'Engines' })
+  expect(screen.queryByText('No model updates are on record for ChatGPT in this period.')).toBeNull()
 })
 
 test('renders nothing at all when the API omits the field or reports no exposure', async () => {
@@ -532,51 +571,4 @@ test('renders nothing at all when the API omits the field or reports no exposure
   await screen.findByRole('list', { name: 'Engines' })
   expect(screen.queryByText(/The model behind/)).toBeNull()
   expect(screen.queryByText(/No model updates are on record/)).toBeNull()
-})
-
-test('tells the reader how recently the update record was checked', async () => {
-  // The quiet line on its own is indistinguishable from a record nobody has
-  // updated in six months. The date is what separates "we looked and found
-  // nothing" from "nobody has looked", so it has to reach the reader — not
-  // merely ride on the DTO, which is where an earlier cut left it.
-  onTestFinished(mockMetrics({
-    modelPointerChanges: {
-      openai: {
-        modelIds: ['chat-latest'],
-        changeCount: 0,
-        unverifiedChangeCount: 0,
-        knownGoodAsOf: '2026-07-20',
-        checkedThroughPeriodEnd: true,
-      },
-    },
-  }))
-
-  renderSection()
-
-  const line = await screen.findByText('No model updates are on record for ChatGPT in this period.')
-  const tip = within(line).getByRole('button')
-  expect(tip.getAttribute('aria-label')).toContain('We last checked for model updates on 2026-07-20.')
-})
-
-test('says when the period runs past the last time the record was checked', async () => {
-  onTestFinished(mockMetrics({
-    modelPointerChanges: {
-      openai: {
-        modelIds: ['chat-latest'],
-        changeCount: 0,
-        unverifiedChangeCount: 0,
-        knownGoodAsOf: '2026-07-20',
-        checkedThroughPeriodEnd: false,
-      },
-    },
-  }))
-
-  renderSection()
-
-  const line = await screen.findByText('No model updates are on record for ChatGPT in this period.')
-  const tip = within(line).getByRole('button')
-  expect(tip.getAttribute('aria-label')).toContain(
-    'We last checked for model updates on 2026-07-20, and this period runs past that date,'
-    + ' so there may be later updates we do not know about.',
-  )
 })


### PR DESCRIPTION
## Summary

- Hide no-change moving-pointer commentary and the model-evidence panel when the selected window has no recorded attribution transitions.
- Preserve warnings and evidence for actual model changes.
- Remove both dynamic single-bucket trend notes.
- Add regression coverage for the hidden states.

## Root cause

The dashboard surfaced ChatGPT-only metadata because `chat-latest` was the sole moving alias, then rendered baseline served-model rows even though no model transition had occurred. The single-bucket copy also described transient state and could be semantically incorrect because one bucket can contain multiple sweeps.

## Validation

- `pnpm --filter @ainyc/canonry-web test` (104 files, 1,092 tests)
- `pnpm --filter @ainyc/canonry-web typecheck`
- `pnpm --filter @ainyc/canonry-web lint` (0 errors; baseline warnings only)
- `pnpm --filter @ainyc/canonry-web build`
- `git diff --check`