### PR TITLE
fix(web): fetch the traffic series the user selected, not the newest 500 of everything

### DIFF
--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -100,6 +100,22 @@ function formatRelative(iso: string | null): string {
 }
 
 /**
+ * Which event kind to ASK THE SERVER for, given the series the user has on.
+ *
+ * Exported for test: this one value decides whether a narrow series is
+ * reachable at all. The events fetch is row-capped, so requesting 'all' returns
+ * the most recent N rows across every series and the browser then filters them.
+ * Where one series dominates, the others never make the cut and the table
+ * reports an honest but misleading "no rows".
+ */
+export function trafficFetchKind(visibleSeries: ReadonlySet<SeriesKind>): 'all' | SeriesKind {
+  // Exactly one selected is both the case that breaks and the case where the
+  // caller has already told us what it wants. Zero or several means the union,
+  // which is what 'all' returns anyway.
+  return visibleSeries.size === 1 ? [...visibleSeries][0]! : 'all'
+}
+
+/**
  * "← Back" affordance on the source detail page. Prefers browser history
  * (so a user arriving from `/projects/$id/activity` goes back to that
  * tab, not to /traffic) and falls back to a hard `/traffic` link when
@@ -170,9 +186,25 @@ export function TrafficSourceDetailPage() {
     [windowMinutes],
   )
 
+  // Ask the server for the series the user is actually looking at.
+  //
+  // `kind: 'all'` with a 500-row cap made the series checkboxes cosmetic: the
+  // fetch returned the 500 most RECENT rows regardless of selection, then the
+  // table filtered them in the browser. On a source where one series dominates
+  // that hides the others entirely. Measured on a live project: 2,199 crawler
+  // rows against 8 AI-referral rows in 24h, and every AI-referral row sat at
+  // position 640 or later, so none were ever fetched. The chart aggregates
+  // server-side and drew the bar correctly; clicking it filtered a set that had
+  // never contained the rows, and the table truthfully reported "0 of 0".
+  //
+  // A single selected series is the case worth scoping, and it is the case that
+  // breaks: the caller already knows it wants one narrow slice. With several
+  // selected the union is what 'all' already returns.
+  const selectedKind = useMemo(() => trafficFetchKind(visibleSeries), [visibleSeries])
+
   const sourceQuery = useServerTrafficSource(projectName || null, sourceId || null)
   const eventsQuery = useServerTrafficEvents(projectName || null, {
-    kind: 'all',
+    kind: selectedKind,
     sourceId: sourceId || undefined,
     sinceMinutes: windowMinutes,
     limit: activeWindow.fetchLimit,
@@ -659,7 +691,7 @@ export function TrafficSourceDetailPage() {
           </div>
         ) : null}
 
-        <EventsTable events={pagedEvents} />
+        <EventsTable events={pagedEvents} truncated={eventRows?.truncated ?? false} />
 
         {showPagination ? (
           <div className="mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-secondary">
@@ -835,9 +867,25 @@ function renderEvidence(event: TrafficEventEntry): string {
   }
 }
 
-function EventsTable({ events }: { events: readonly TrafficEventEntry[] }) {
+export function EventsTable({
+  events,
+  truncated = false,
+}: {
+  events: readonly TrafficEventEntry[]
+  /** The fetch hit its row cap, so filtering ran over a prefix of the window. */
+  truncated?: boolean
+}) {
   if (events.length === 0) {
-    return <Card className="p-6 text-center text-sm text-muted">No event rows match the current filters.</Card>
+    // A confident "nothing matched" is a lie when the filter ran over a
+    // truncated set: rows beyond the cap were never loaded, so their absence
+    // was never tested. Say which of the two it is.
+    return (
+      <Card className="p-6 text-center text-sm text-muted">
+        {truncated
+          ? 'No matches in the rows loaded so far. More rows exist beyond the load limit, so narrow the time window to search them.'
+          : 'No event rows match the current filters.'}
+      </Card>
+    )
   }
   return (
     <div className="rounded-xl border border-default bg-surface overflow-hidden">

--- a/apps/web/test/traffic-events-fetch-scope.test.tsx
+++ b/apps/web/test/traffic-events-fetch-scope.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { afterEach, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { trafficFetchKind, EventsTable } from '../src/pages/TrafficSourceDetailPage.js'
+
+afterEach(() => {
+  cleanup()
+})
+
+/**
+ * Regression for a chart you could click that always returned nothing.
+ *
+ * Measured on a live project: 2,199 crawler rows against 8 AI-referral rows in
+ * a 24h window, fetched with `kind: 'all'` under a 500-row cap. Every
+ * AI-referral row sat at position 640 or later, so none were ever fetched. The
+ * chart aggregates server-side and drew the bar correctly; clicking it filtered
+ * a client-side set that had never contained the rows.
+ */
+test('a single selected series is fetched as that series, not as everything', () => {
+  expect(trafficFetchKind(new Set(['ai-referral']))).toBe('ai-referral')
+  expect(trafficFetchKind(new Set(['ai-user-fetch']))).toBe('ai-user-fetch')
+  expect(trafficFetchKind(new Set(['crawler']))).toBe('crawler')
+})
+
+test('several or no series fall back to all, which is already their union', () => {
+  expect(trafficFetchKind(new Set(['crawler', 'ai-referral']))).toBe('all')
+  expect(trafficFetchKind(new Set(['crawler', 'ai-user-fetch', 'ai-referral']))).toBe('all')
+  expect(trafficFetchKind(new Set([]))).toBe('all')
+})
+
+test('an empty result over a TRUNCATED set does not claim nothing matched', () => {
+  // Rows past the cap were never loaded, so their absence was never tested.
+  // Reporting a confident "no rows match" for that state is what made the
+  // original bug unreadable from the UI.
+  render(<EventsTable events={[]} truncated />)
+  expect(screen.queryByText('No event rows match the current filters.')).toBeNull()
+  const msg = screen.getByText(/No matches in the rows loaded so far/)
+  expect(msg.textContent).toContain('beyond the load limit')
+})
+
+test('an empty result over a COMPLETE set still says nothing matched', () => {
+  render(<EventsTable events={[]} truncated={false} />)
+  expect(screen.getByText('No event rows match the current filters.')).toBeTruthy()
+})


### PR DESCRIPTION
## What

The events fetch asked for `kind: 'all'` under a per-window row cap, then filtered client-side. Where one series dominates, the others are never fetched, so the series checkboxes and the chart's click-to-filter were cosmetic for them.

## The bug, measured

Live project, 24h window:

```
rows in window:   crawler 2,199 · ai_user_fetch 125 · ai_referral 8
fetched:          the 500 most recent, kind: 'all'
ai_referral rows: positions 640, 641, 750, 751, 784, 785, 1153, 1154
```

Every AI-referral row sat past the cap. The chart aggregates **server-side**, so it correctly drew a bar at 8/17 19:00 with 14 sessions. Clicking it filtered a **client-side** set that had never contained those rows, and the table answered:

> No event rows match the current filters.

while the status line directly above it read **"loaded 500 of 751 rows"**.

Nothing was wrong with the data or the chart. The table filtered a prefix and reported as though it had filtered the window.

## Changes

**`trafficFetchKind`** picks the kind to request. One selected series is both the case that breaks and the case where the caller has already said what it wants, so it is requested directly — the cap then applies to 8 rows instead of 2,332. Zero or several selected still means the union, which is what `'all'` already returns.

**The empty state** now distinguishes "nothing matched" from "nothing matched in what we loaded". Rows past the cap were never fetched, so their absence was never tested. A confident "no rows match" for that state is what made this unreadable from the UI.

## Tests

Four, and each mutation kills only its own:

| Mutation | Fails |
|---|---|
| force `trafficFetchKind` back to `'all'` | the scoping test |
| restore the single empty-state string | the truncation test |

105 files / 1,098 web tests pass. Typecheck and lint clean.

52 insertions, under the 100-line threshold, so no version bump.

## Related

Same class as #1035, which pinned the social chart to its measured window. That was chart-vs-card disagreeing on a date range; this is chart-vs-table disagreeing on scope.