### PR TITLE
docs: sharpen GitHub-facing messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Canonry <img src="https://raw.githubusercontent.com/Canonry/canonry/main/apps/web/public/favicon-32.png" alt="Canonry canary icon" width="24" />
 
-[![npm version](https://img.shields.io/npm/v/@canonry/canonry)](https://www.npmjs.com/package/@canonry/canonry) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
+[![npm version](https://img.shields.io/npm/v/@canonry/canonry)](https://www.npmjs.com/package/@canonry/canonry) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/license-FSL--1.1--ALv2%20%E2%86%92%20Apache--2.0-blue)](LICENSE)
 
 Your entire AEO/GEO/AI Visibility, technical SEO + web analytics stack. **Agent-first. Self-hosted. Local.**
+
+Think PostHog, for AI search visibility. Canonry tracks what ChatGPT, Claude, Gemini, and Perplexity say about you, joins it with your search and traffic data, and gives your agent the tools to fix what it finds.
+
+`npm install -g @canonry/canonry`. One SQLite file. All yours.
 
 Canonry gives operators and agents a full tactical view across AI visibility, site health, search, traffic, content, local presence, backlinks, and paid media.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canonry <img src="https://raw.githubusercontent.com/Canonry/canonry/main/apps/web/public/favicon-32.png" alt="Canonry canary icon" width="24" />
 
-[![npm version](https://img.shields.io/npm/v/@canonry/canonry)](https://www.npmjs.com/package/@canonry/canonry) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/license-FSL--1.1--ALv2%20%E2%86%92%20Apache--2.0-blue)](LICENSE)
+[![npm version](https://img.shields.io/npm/v/@canonry/canonry)](https://www.npmjs.com/package/@canonry/canonry) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
 
 Your entire AEO/GEO/AI Visibility, technical SEO + web analytics stack. **Agent-first. Self-hosted. Local.**
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ The dashboard, CLI, and agent tools share the same project API.
 
 *Map crawlable pages and the internal links connecting them.*
 
-You need Node.js `>=22.14` and `<26`, plus a public, crawlable site. Site Health does not need an answer-provider key.
-
 1. Install Canonry.
 
    ```bash
@@ -121,8 +119,6 @@ If a Canonry installation or connected plugin/MCP is available, use it. Do not c
 ![Canonry AI Visibility citation map across queries and answer engines](https://raw.githubusercontent.com/Canonry/canonry/main/docs/images/ai-visibility-diagnostics.png)
 
 *Map citation and answer-mention coverage across every tracked query and engine.*
-
-Add provider keys in **Settings**. Settings changes apply immediately. To import environment variables, stop Canonry and set the variables. Then run `cnry bootstrap` and restart Canonry.
 
 | Provider | Key source | Environment variable |
 |---|---|---|

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -2,7 +2,7 @@
   "name": "@canonry/canonry",
   "version": "4.174.0",
   "type": "module",
-  "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
+  "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, and server-side traffic, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",
   "homepage": "https://canonry.ai",
   "repository": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -2,7 +2,7 @@
   "name": "@canonry/canonry",
   "version": "4.174.0",
   "type": "module",
-  "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, and server-side traffic, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
+  "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",
   "homepage": "https://canonry.ai",
   "repository": {


### PR DESCRIPTION
Bundles the GitHub messaging package: the README header gains a one-line PostHog reference for developers ("Think PostHog, for AI search visibility.") and an install line, while the H1, tagline, and breadth sentence stay as they are. The npm description drops the inaccurate "open-source" claim and states the category, engines, data joins (including paid media), and agent surfaces literally, because npm and GitHub description fields get quoted verbatim by search snippets and LLM answers. Also trims two setup caveats from the README (the Node range prose, which the badge and engines field already cover, and the provider-key/env-var mechanics paragraph). The repo About field is updated separately via settings to matching literal taxonomy (no analogy in machine-consumed fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)