### PR TITLE
Support Node 26, paired with CI that proves it

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,15 @@
 name: Setup canonry
 description: Install pnpm, Node, and project dependencies. Assumes the repo is already checked out.
+inputs:
+  node-version:
+    description: >
+      Node major to install. Defaults to 22 — the version Docker images, the
+      published build, and .nvmrc all pin — so every existing caller is
+      unchanged. Pass a higher major only to prove a supported major still
+      works; `packages/db/test/node-support-range.test.ts` asserts the CI
+      matrix covers the highest major in scripts/check-node.mjs.
+    required: false
+    default: '22'
 runs:
   using: composite
   steps:
@@ -8,7 +18,7 @@ runs:
         version: 10.28.2
     - uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: ${{ inputs.node-version }}
         cache: pnpm
     - run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/workflows/check-better-sqlite3-prebuilds.yml
+++ b/.github/workflows/check-better-sqlite3-prebuilds.yml
@@ -1,0 +1,53 @@
+name: Check better-sqlite3 prebuilds
+
+# Watches the one fact about Node support that no test in this repo can see.
+#
+# `packages/db/test/node-support-range.test.ts` proves three links of the chain:
+# the install guard agrees with the INSTALLED better-sqlite3, the installed copy
+# matches the lockfile, and CI runs the highest major the guard claims. It cannot
+# prove the lockfile matches the real world, because a unit test must not depend
+# on the network — so the repo can sit at a stale pin with the guard, the test and
+# the lockfile all agreeing with each other. That is not hypothetical: it is
+# exactly how 12.6.2 survived for months after 12.10.0 shipped the Node 26
+# prebuild, which is what PR #1038 had to go back and fix.
+#
+# WHY THIS FAILS INSTEAD OF OPENING A PR
+# `bump-aeo-audit.yml` is the house pattern for a scheduled dependency check, and
+# its own header records how it broke: the create-PR step needs a PAT the org does
+# not grant, so every gate ran green, the final step died, and the pin silently
+# froze from 2026-06-22 until someone bumped it by hand. A failing run needs no
+# token and cannot half-succeed. Read the job output; it names the file to edit.
+#
+# Run on demand from the Actions tab via "Run workflow".
+
+on:
+  schedule:
+    # Mondays 10:00 UTC, an hour after bump-aeo-audit so the two do not collide.
+    - cron: '0 10 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-better-sqlite3-prebuilds
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # No install step: the script reads pnpm-lock.yaml and check-node.mjs as
+      # text and calls two public APIs. Nothing here needs node_modules, which
+      # also keeps it working when the lockfile is the thing that is wrong.
+      - name: Compare SUPPORTED_MAJORS against published prebuilds
+        env:
+          # Lifts the unauthenticated GitHub API limit; read-only.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-better-sqlite3-prebuilds.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,18 +71,43 @@ jobs:
       - run: pnpm run typecheck
 
   test_shards:
-    name: test shard ${{ matrix.shard }}/4
+    name: test ${{ matrix.shard }} (node ${{ matrix.node }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       fail-fast: false
+      # Deliberately asymmetric to keep CI cost down.
+      #
+      # Node 22 is what Docker and the published build pin, so it stays sharded
+      # 4x for fast feedback on the version that actually ships.
+      #
+      # Node 26 is the highest major in `SUPPORTED_MAJORS`
+      # (scripts/check-node.mjs) and the current Homebrew default. It runs the
+      # WHOLE suite in ONE job: +1 runner instead of +4, still 100% coverage.
+      # Sampling a single shard there would have been cheaper by the same
+      # amount and would have covered a quarter of the suite — and the Node 26
+      # break this matrix was added to catch (tsx's `module.register()` tripping
+      # DEP0205) lives in packages/canonry, which one shard may not hold.
+      #
+      # The pairing is the point: better-sqlite3 is a NATIVE module, so a major
+      # is only "supported" if its prebuilt binary resolves and loads.
+      # `node-support-range.test.ts` asserts this matrix covers the highest
+      # supported major, so the claim cannot drift from its evidence the way it
+      # did while the guard sat at 25 for months.
       matrix:
-        shard: [1, 2, 3, 4]
+        include:
+          - { node: '22', shard: '1/4' }
+          - { node: '22', shard: '2/4' }
+          - { node: '22', shard: '3/4' }
+          - { node: '22', shard: '4/4' }
+          - { node: '26', shard: '1/1' }
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      - run: pnpm run test --shard=${{ matrix.shard }}/4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: pnpm run test --shard=${{ matrix.shard }}
 
   test:
     name: test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.175.0",
+  "version": "4.176.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {
@@ -24,7 +24,7 @@
     "@eslint/js": "^9.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.5.1",
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.11.1",
     "eslint": "^9.0.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-regexp": "^3.1.0",
@@ -63,6 +63,6 @@
     ]
   },
   "engines": {
-    "node": ">=22.14.0 <26"
+    "node": ">=22.14.0 <27"
   }
 }

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.175.0",
+  "version": "4.176.0",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",
@@ -37,7 +37,7 @@
     "THIRD_PARTY_NOTICES.md"
   ],
   "engines": {
-    "node": ">=22.14.0 <26"
+    "node": ">=22.14.0 <27"
   },
   "scripts": {
     "build": "tsx scripts/copy-agent-assets.ts && tsup && tsx build-web.ts",
@@ -57,7 +57,7 @@
     "@mariozechner/pi-ai": "0.67.6",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@sinclair/typebox": "^0.34.41",
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.11.1",
     "chrome-remote-interface": "^0.33.2",
     "cron-parser": "^5.5.0",
     "drizzle-orm": "^0.45.2",
@@ -80,16 +80,16 @@
     "@ainyc/canonry-contracts": "workspace:*",
     "@ainyc/canonry-db": "workspace:*",
     "@ainyc/canonry-integration-bing": "workspace:*",
+    "@ainyc/canonry-integration-cloud-run": "workspace:*",
     "@ainyc/canonry-integration-cloudflare-queue": "workspace:*",
     "@ainyc/canonry-integration-cloudflare-worker": "workspace:*",
-    "@ainyc/canonry-integration-openai-ads": "workspace:*",
-    "@ainyc/canonry-integration-cloud-run": "workspace:*",
     "@ainyc/canonry-integration-commoncrawl": "workspace:*",
     "@ainyc/canonry-integration-google": "workspace:*",
     "@ainyc/canonry-integration-google-ads": "workspace:*",
     "@ainyc/canonry-integration-google-business-profile": "workspace:*",
     "@ainyc/canonry-integration-google-places": "workspace:*",
     "@ainyc/canonry-integration-google-tag-manager": "workspace:*",
+    "@ainyc/canonry-integration-openai-ads": "workspace:*",
     "@ainyc/canonry-integration-traffic": "workspace:*",
     "@ainyc/canonry-integration-wordpress": "workspace:*",
     "@ainyc/canonry-intelligence": "workspace:*",

--- a/packages/canonry/test/google-commands.test.ts
+++ b/packages/canonry/test/google-commands.test.ts
@@ -7,6 +7,18 @@ import { createClient, migrate, apiKeys } from '@ainyc/canonry-db'
 import { createServer } from '../src/server.js'
 import { ApiClient } from '../src/client.js'
 
+/**
+ * The two googleRefresh cases trigger a real gsc-sync run and poll
+ * `waitForRunStatus` every 2s until it reaches a terminal status. Vitest's 5s
+ * default only covers ~2 poll cycles, so under the unsharded Node 26 CI lane —
+ * the whole suite in one job (ci.yml / scripts/check-node.mjs) — CPU
+ * oversubscription keeps the run from finishing in time and the test times out
+ * with no assertion diff. Same load effect already handled for
+ * `mcp-stdio.test.ts`. 30s gives the poll loop ample headroom; a genuine hang
+ * still fails via `waitForRunStatus`'s own 10-minute cap inside `googleRefresh`.
+ */
+const REFRESH_POLL_TIMEOUT_MS = 30_000
+
 describe('google CLI commands', () => {
   let tmpDir: string
   let origConfigDir: string | undefined
@@ -348,7 +360,7 @@ describe('google CLI commands', () => {
 
     // With no inspections, it should print the "No URL inspections found" message from coverage
     expect(logs.join('\n')).toMatch(/No URL inspections found/)
-  })
+  }, REFRESH_POLL_TIMEOUT_MS)
 
   it('googleRefresh outputs valid JSON when format is json', async () => {
     await client.putProject('test-proj', {
@@ -382,7 +394,7 @@ describe('google CLI commands', () => {
     const parsed = JSON.parse(logs.join('\n')) as { summary: { total: number } }
     expect(parsed.summary).toBeDefined()
     expect(parsed.summary.total).toBe(0)
-  })
+  }, REFRESH_POLL_TIMEOUT_MS)
 
   it('googleRequestIndexing throws a usage error when neither URL nor --all-unindexed is provided', async () => {
     await client.putProject('test-proj', {

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -13,34 +13,26 @@ const tsxCli = path.join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs')
 const mcpCli = path.join(packageRoot, 'src', 'mcp', 'cli.ts')
 
 /**
- * Node's own runtime diagnostics, which the RUNTIME writes to the child's
- * stderr — not canonry.
+ * The MCP adapter must write NOTHING to stderr (AGENTS.md → MCP adapter
+ * boundary), so the assertion below is an exact empty-string match.
  *
- * The subprocess is `node <tsx>/cli.mjs src/mcp/cli.ts`, and tsx's ESM loader
- * calls `module.register()`. Node 26 deprecated that API (DEP0205), so on Node
- * 26 the child emits a two-line warning before canonry runs a single statement.
- * Asserting the raw stream would make this test fail on a supported Node major
- * because of a dev-only transpiler, which says nothing about the MCP contract.
+ * One Node-generated line would otherwise break it: the subprocess is
+ * `node <tsx>/cli.mjs src/mcp/cli.ts`, and tsx's ESM loader calls
+ * `module.register()`, deprecated in Node 26 (DEP0205). That is a dev-only
+ * transpiler emitting it, not canonry, and it says nothing about the MCP
+ * contract.
  *
- * Both patterns are anchored to Node's `(node:<pid>)` diagnostic prefix and its
- * paired `(Use \`node --trace-…\`)` hint. Canonry's own logger emits JSON
- * objects, so nothing canonry writes can match — the assertion below still
- * fails on any real stderr output, which is the rule it exists to enforce
- * (see AGENTS.md → MCP adapter boundary).
+ * It is silenced at the SOURCE — `--disable-warning=DEP0205` on the child, see
+ * `startClient` below — rather than by filtering the stream afterwards. A
+ * filter is the wrong instrument here: any pattern broad enough to catch
+ * Node's `(node:<pid>) ...` prefix also catches `MaxListenersExceededWarning`
+ * and `UnhandledPromiseRejectionWarning`, which are exactly the signals this
+ * assertion exists to surface. Disabling one warning code by name keeps every
+ * other diagnostic — and every byte canonry writes — a test failure.
+ *
+ * `--disable-warning` landed in Node 21.3, so it is available on every major
+ * in this repo's supported range.
  */
-const NODE_RUNTIME_DIAGNOSTICS = [
-  /^\(node:\d+\)\s.*$/,
-  /^\(Use `node --trace-[a-z-]+ \.\.\.` to show where the warning was created\)$/,
-]
-
-/** The child's stderr with Node's own diagnostics removed. */
-function canonryStderr(raw: string): string {
-  return raw
-    .split('\n')
-    .filter(line => !NODE_RUNTIME_DIAGNOSTICS.some(pattern => pattern.test(line.trim())))
-    .join('\n')
-    .trim()
-}
 
 /**
  * Budget for spawn through the `initialize` response, which is where the two
@@ -175,7 +167,7 @@ describe('canonry-mcp stdio', () => {
     expect(trafficSync.isError).not.toBe(true)
     expect(jsonText(trafficSync)).toMatchObject({ runId: 'run-traffic-1', sourceId: 'src-1' })
 
-    expect(canonryStderr(stderr())).toBe('')
+    expect(stderr()).toBe('')
   }, SUBPROCESS_CASE_TIMEOUT_MS)
 
   it('docs/mcp.md documents the same pipelining error wording the SDK emits', () => {
@@ -351,7 +343,7 @@ async function startMcpClient(options: {
   const stderrChunks: string[] = []
   const transport = new StdioClientTransport({
     command: process.execPath,
-    args: [tsxCli, mcpCli, ...(options.args ?? [])],
+    args: ['--disable-warning=DEP0205', tsxCli, mcpCli, ...(options.args ?? [])],
     cwd: packageRoot,
     env: {
       ...stringEnv(),

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -13,6 +13,36 @@ const tsxCli = path.join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs')
 const mcpCli = path.join(packageRoot, 'src', 'mcp', 'cli.ts')
 
 /**
+ * Node's own runtime diagnostics, which the RUNTIME writes to the child's
+ * stderr — not canonry.
+ *
+ * The subprocess is `node <tsx>/cli.mjs src/mcp/cli.ts`, and tsx's ESM loader
+ * calls `module.register()`. Node 26 deprecated that API (DEP0205), so on Node
+ * 26 the child emits a two-line warning before canonry runs a single statement.
+ * Asserting the raw stream would make this test fail on a supported Node major
+ * because of a dev-only transpiler, which says nothing about the MCP contract.
+ *
+ * Both patterns are anchored to Node's `(node:<pid>)` diagnostic prefix and its
+ * paired `(Use \`node --trace-…\`)` hint. Canonry's own logger emits JSON
+ * objects, so nothing canonry writes can match — the assertion below still
+ * fails on any real stderr output, which is the rule it exists to enforce
+ * (see AGENTS.md → MCP adapter boundary).
+ */
+const NODE_RUNTIME_DIAGNOSTICS = [
+  /^\(node:\d+\)\s.*$/,
+  /^\(Use `node --trace-[a-z-]+ \.\.\.` to show where the warning was created\)$/,
+]
+
+/** The child's stderr with Node's own diagnostics removed. */
+function canonryStderr(raw: string): string {
+  return raw
+    .split('\n')
+    .filter(line => !NODE_RUNTIME_DIAGNOSTICS.some(pattern => pattern.test(line.trim())))
+    .join('\n')
+    .trim()
+}
+
+/**
  * Budget for spawn through the `initialize` response, which is where the two
  * subprocess cases below spend nearly all of their time. Each one starts
  * `node tsx src/mcp/cli.ts`, and that child transpiles the whole CLI import
@@ -145,7 +175,7 @@ describe('canonry-mcp stdio', () => {
     expect(trafficSync.isError).not.toBe(true)
     expect(jsonText(trafficSync)).toMatchObject({ runId: 'run-traffic-1', sourceId: 'src-1' })
 
-    expect(stderr()).toBe('')
+    expect(canonryStderr(stderr())).toBe('')
   }, SUBPROCESS_CASE_TIMEOUT_MS)
 
   it('docs/mcp.md documents the same pipelining error wording the SDK emits', () => {

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -22,8 +22,9 @@ const mcpCli = path.join(packageRoot, 'src', 'mcp', 'cli.ts')
  * transpiler emitting it, not canonry, and it says nothing about the MCP
  * contract.
  *
- * It is silenced at the SOURCE — `--disable-warning=DEP0205` on the child, see
- * `startClient` below — rather than by filtering the stream afterwards. A
+ * It is silenced at the SOURCE — `--disable-warning=DEP0205` via NODE_OPTIONS
+ * on the child, see `startMcpClient` below — rather than by filtering the
+ * stream afterwards. A
  * filter is the wrong instrument here: any pattern broad enough to catch
  * Node's `(node:<pid>) ...` prefix also catches `MaxListenersExceededWarning`
  * and `UnhandledPromiseRejectionWarning`, which are exactly the signals this
@@ -343,10 +344,20 @@ async function startMcpClient(options: {
   const stderrChunks: string[] = []
   const transport = new StdioClientTransport({
     command: process.execPath,
-    args: ['--disable-warning=DEP0205', tsxCli, mcpCli, ...(options.args ?? [])],
+    args: [tsxCli, mcpCli, ...(options.args ?? [])],
     cwd: packageRoot,
     env: {
       ...stringEnv(),
+      // NODE_OPTIONS, not a CLI flag: tsx re-execs node with an execArgv of its
+      // own (--require preflight.cjs --import loader.mjs) and drops whatever
+      // was passed on the original command line, so `node
+      // --disable-warning=... tsx cli.ts` never reaches the process that emits
+      // the warning. NODE_OPTIONS survives the re-exec. Verified both ways on
+      // this repo's tsx; the CLI-flag form shipped green on Node 22 and failed
+      // only on the Node 26 lane, which is the whole reason that lane exists.
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, '--disable-warning=DEP0205']
+        .filter(Boolean)
+        .join(' '),
       CANONRY_CONFIG_DIR: configDir,
       CANONRY_BASE_PATH: '',
     },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@ainyc/canonry-contracts": "workspace:*",
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.11.1",
     "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "drizzle-kit": "^0.31.9"
+    "drizzle-kit": "^0.31.9",
+    "yaml": "^2.8.2"
   }
 }

--- a/packages/db/test/node-support-range.test.ts
+++ b/packages/db/test/node-support-range.test.ts
@@ -14,17 +14,42 @@ import { test, expect, describe } from 'vitest'
  * node-gyp wall of text the guard exists to prevent.
  *
  * So the compatible subset is asserted rather than trusted.
+ *
+ * WHY THE CEILING IS DERIVED AND NOT WRITTEN DOWN
+ * This file used to hardcode `< 26` in three places. That made the guard and the
+ * test agree with each other while both disagreed with reality: better-sqlite3
+ * had shipped Node 26 prebuilds since 12.10.0, but the repo stayed pinned at
+ * 12.6.2 and refused to install on Node 26 — telling the reader to change their
+ * Node and explicitly NOT to touch dependencies, when updating the dependency
+ * was the actual fix. A guard that hardcodes the value it is supposed to be
+ * checking cannot catch that. Everything below derives from
+ * better-sqlite3's `engines.node`, so the next major lands as a failing test.
+ *
+ * WIDENING IS NOT ENOUGH ON ITS OWN
+ * Claiming a major nothing runs is the same mistake pointed the other way, so
+ * the last test asserts the CI matrix actually exercises the highest supported
+ * major.
  */
 
 const require = createRequire(import.meta.url)
+
+/** Canonry's own floor, independent of what the native dep supports. */
+const CANONRY_MIN_MAJOR = 22
+
+/** The major Docker images, .nvmrc, and the published build all pin. */
+const DEPLOY_MAJOR = 22
 
 function repoRoot(): string {
   // packages/db/test -> repo root
   return path.resolve(__dirname, '..', '..', '..')
 }
 
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(repoRoot(), ...segments), 'utf8')
+}
+
 function guardMajors(): number[] {
-  const source = fs.readFileSync(path.join(repoRoot(), 'scripts', 'check-node.mjs'), 'utf8')
+  const source = readRepoFile('scripts', 'check-node.mjs')
   const match = /const SUPPORTED_MAJORS = \[([^\]]*)\]/.exec(source)
   if (!match) throw new Error('SUPPORTED_MAJORS not found in scripts/check-node.mjs')
   return match[1]!
@@ -39,7 +64,7 @@ function betterSqlite3Majors(): number[] {
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { engines?: { node?: string } }
   const range = pkg.engines?.node
   if (!range) throw new Error('better-sqlite3 declares no engines.node')
-  // e.g. "20.x || 22.x || 23.x || 24.x || 25.x"
+  // e.g. "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
   return range
     .split('||')
     .map((part) => Number.parseInt(part.trim(), 10))
@@ -47,56 +72,92 @@ function betterSqlite3Majors(): number[] {
     .sort((a, b) => a - b)
 }
 
+/**
+ * Majors the CI test matrix actually installs and runs the suite on.
+ *
+ * Reads the `include:` entries, which are deliberately asymmetric (Node 22
+ * sharded 4x, the highest major unsharded) to hold CI cost down — so this
+ * counts DISTINCT majors and says nothing about how each one is split.
+ * `\bnode:` cannot match the `node-version:` key the setup step passes.
+ */
+function ciMatrixMajors(): number[] {
+  const source = readRepoFile('.github', 'workflows', 'ci.yml')
+  const majors = [...source.matchAll(/\bnode:\s*'(\d+)'/g)].map((m) => Number.parseInt(m[1]!, 10))
+  if (majors.length === 0) throw new Error('node matrix not found in .github/workflows/ci.yml')
+  return [...new Set(majors)].sort((a, b) => a - b)
+}
+
+function declaredEnginesCeiling(pkgRelPath: string[]): { declared: string; ceiling: number } {
+  const pkg = JSON.parse(readRepoFile(...pkgRelPath)) as { engines?: { node?: string } }
+  const declared = pkg.engines?.node ?? ''
+  return { declared, ceiling: Number.parseInt(/<\s*(\d+)/.exec(declared)?.[1] ?? '0', 10) }
+}
+
 describe('Node support range', () => {
   test('the install guard matches Canonry-supported better-sqlite3 majors', () => {
-    const expected = betterSqlite3Majors().filter((major) => major >= 22 && major < 26)
+    // Derived, not hardcoded: whatever better-sqlite3 supports at or above
+    // Canonry's floor is exactly what the guard must allow. A dependency bump
+    // that adds OR drops a major fails here.
+    const expected = betterSqlite3Majors().filter((major) => major >= CANONRY_MIN_MAJOR)
     expect(guardMajors()).toEqual(expected)
   })
 
   test('the guard and declared engine range enforce Node 22+', () => {
     const majors = guardMajors()
-    expect(majors).toContain(22)
+    expect(majors).toContain(CANONRY_MIN_MAJOR)
     expect(majors).not.toContain(20)
 
-    const rootPkg = JSON.parse(
-      fs.readFileSync(path.join(repoRoot(), 'package.json'), 'utf8'),
-    ) as { engines?: { node?: string } }
-    const publishedPkg = JSON.parse(
-      fs.readFileSync(path.join(repoRoot(), 'packages', 'canonry', 'package.json'), 'utf8'),
-    ) as { engines?: { node?: string } }
-    expect(rootPkg.engines?.node).toBe('>=22.14.0 <26')
-    expect(publishedPkg.engines?.node).toBe(rootPkg.engines?.node)
+    // The ceiling is exclusive, so it must sit exactly one past the highest
+    // supported major — never a literal that can rot.
+    const expectedCeiling = Math.max(...majors) + 1
+    const root = declaredEnginesCeiling(['package.json'])
+    const published = declaredEnginesCeiling(['packages', 'canonry', 'package.json'])
+
+    expect(root.declared).toBe(`>=${CANONRY_MIN_MAJOR}.14.0 <${expectedCeiling}`)
+    expect(published.declared).toBe(root.declared)
   })
 
   test('every Dockerfile uses the Node 22 base', () => {
+    // Deliberately still pinned while the supported range is wider: widening
+    // what a CONTRIBUTOR may use must not quietly move what ships.
     for (const dockerfile of ['Dockerfile', 'Dockerfile.api', 'Dockerfile.worker', 'Dockerfile.web']) {
-      const source = fs.readFileSync(path.join(repoRoot(), dockerfile), 'utf8')
+      const source = readRepoFile(dockerfile)
       const majors = [...source.matchAll(/^FROM .*node:(\d+)-bookworm-slim(?:\s|$)/gm)].map(
         (match) => Number.parseInt(match[1]!, 10),
       )
       expect(majors.length).toBeGreaterThan(0)
-      expect(majors.every((major) => major === 22)).toBe(true)
+      expect(majors.every((major) => major === DEPLOY_MAJOR)).toBe(true)
     }
   })
 
   test('the guard rejects a major with no prebuilt binary', () => {
     // The case that motivated this: an agent on a brand-new Node fell through
     // to compiling better-sqlite3 from source and read the node-gyp failure as
-    // a repo bug.
-    expect(guardMajors()).not.toContain(26)
+    // a repo bug. The guard must never promise a major the native dep has no
+    // prebuild for — expressed against the dep's own range, so this keeps
+    // meaning the same thing after the next Node release.
+    const beyondPrebuilds = Math.max(...betterSqlite3Majors()) + 1
+    expect(guardMajors()).not.toContain(beyondPrebuilds)
   })
 
   test('the declared engines range does not promise more than the guard allows', () => {
-    const rootPkg = JSON.parse(
-      fs.readFileSync(path.join(repoRoot(), 'package.json'), 'utf8'),
-    ) as { engines?: { node?: string } }
-    const declared = rootPkg.engines?.node ?? ''
     // An unbounded `>=X` range asserts that every FUTURE major is supported,
     // which is exactly the claim that misled the install. Require a ceiling.
+    const { declared, ceiling } = declaredEnginesCeiling(['package.json'])
     expect(declared).toMatch(/<\s*\d+/)
+    expect(ceiling).toBeGreaterThan(Math.max(...guardMajors()))
+  })
 
-    const ceiling = Number.parseInt(/<\s*(\d+)/.exec(declared)?.[1] ?? '0', 10)
-    const highestSupported = Math.max(...guardMajors())
-    expect(ceiling).toBeGreaterThan(highestSupported)
+  test('CI runs the suite on the deploy major and the highest supported major', () => {
+    // Support has to be earned, not declared. Without this, widening
+    // SUPPORTED_MAJORS silently promises a major nothing ever runs — the same
+    // unevidenced claim as the stale ceiling, just in the opposite direction.
+    const ci = ciMatrixMajors()
+    const highest = Math.max(...guardMajors())
+
+    expect(ci).toContain(DEPLOY_MAJOR)
+    expect(ci).toContain(highest)
+    // And CI must not claim to test a major the guard refuses to install on.
+    for (const major of ci) expect(guardMajors()).toContain(major)
   })
 })

--- a/packages/db/test/node-support-range.test.ts
+++ b/packages/db/test/node-support-range.test.ts
@@ -110,6 +110,37 @@ function prebuiltMajors(): number[] {
   return [...majors].sort((a, b) => a - b)
 }
 
+/**
+ * The version `pnpm-lock.yaml` resolves better-sqlite3 to.
+ *
+ * Everything above reads the INSTALLED copy via `require.resolve`, so a
+ * `node_modules` that has drifted from the lockfile makes this whole file
+ * self-consistent about the wrong dependency — green, while describing a
+ * version the repo does not ship. Observed during review: a tree still on
+ * 12.6.2 with the lockfile already at 12.11.1, so `PREBUILT_MAJORS` was never
+ * consulted for the version CI actually installs.
+ *
+ * Parsed, not pattern-matched: the resolved version is a `packages:` KEY, and a
+ * loose scan also hits the `@types/better-sqlite3` entries and the peer suffixes
+ * on `drizzle-orm@…(better-sqlite3@…)`.
+ */
+function lockfileBetterSqlite3Version(): string {
+  const lock = parseYaml(readRepoFile('pnpm-lock.yaml')) as {
+    packages?: Record<string, unknown>
+  }
+  const prefix = 'better-sqlite3@'
+  const versions = Object.keys(lock.packages ?? {})
+    .filter((key) => key.startsWith(prefix))
+    .map((key) => key.slice(prefix.length))
+  if (versions.length !== 1) {
+    throw new Error(
+      `expected exactly one better-sqlite3 in pnpm-lock.yaml, found ${versions.length}` +
+        (versions.length ? `: ${versions.join(', ')}` : ''),
+    )
+  }
+  return versions[0]!
+}
+
 interface CiJob {
   strategy?: { matrix?: { include?: Array<Record<string, unknown>> } }
   steps?: Array<{ run?: string }>
@@ -157,6 +188,19 @@ function declaredEnginesCeiling(pkgRelPath: string[]): { declared: string; ceili
 }
 
 describe('Node support range', () => {
+  test('the installed better-sqlite3 matches the lockfile', () => {
+    // Runs FIRST because every other assertion here is only as true as this
+    // one: they all describe the installed copy.
+    const locked = lockfileBetterSqlite3Version()
+    const { version } = installedBetterSqlite3()
+    expect(
+      version,
+      `node_modules has better-sqlite3 ${version} but the lockfile pins ${locked}. ` +
+        'Run `pnpm install` — until then this file is asserting against a ' +
+        'dependency the repo does not ship.',
+    ).toBe(locked)
+  })
+
   test('the install guard matches the prebuilt majors at or above Canonry floor', () => {
     // Derived from prebuild coverage, not from engines.node. A dependency bump
     // that adds OR drops a prebuilt major fails here.

--- a/packages/db/test/node-support-range.test.ts
+++ b/packages/db/test/node-support-range.test.ts
@@ -2,33 +2,35 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { test, expect, describe } from 'vitest'
+import { parse as parseYaml } from 'yaml'
 
 /**
  * `scripts/check-node.mjs` blocks an install on a Node major that `better-sqlite3`
  * has no prebuilt binary for, converting a couple hundred lines of node-gyp C++
  * output into one legible line.
  *
- * Its `SUPPORTED_MAJORS` list applies Canonry's Node 22+ policy to
- * better-sqlite3's own `engines.node`. A dependency bump that narrows that range
- * would otherwise leave the guard silently wrong and hand the reader back the
- * node-gyp wall of text the guard exists to prevent.
- *
  * So the compatible subset is asserted rather than trusted.
  *
- * WHY THE CEILING IS DERIVED AND NOT WRITTEN DOWN
- * This file used to hardcode `< 26` in three places. That made the guard and the
- * test agree with each other while both disagreed with reality: better-sqlite3
- * had shipped Node 26 prebuilds since 12.10.0, but the repo stayed pinned at
- * 12.6.2 and refused to install on Node 26 — telling the reader to change their
- * Node and explicitly NOT to touch dependencies, when updating the dependency
- * was the actual fix. A guard that hardcodes the value it is supposed to be
- * checking cannot catch that. Everything below derives from
- * better-sqlite3's `engines.node`, so the next major lands as a failing test.
+ * WHY `engines.node` IS NOT THE SOURCE OF TRUTH
+ * This file used to hardcode `< 26` in three places, which made the guard and
+ * the test agree with each other while both disagreed with reality. The obvious
+ * correction — derive everything from better-sqlite3's `engines.node` — is
+ * wrong in the other direction, because that field is a SUPERSET of what
+ * actually ships a binary. 12.11.1 declares
+ * `20.x || 22.x || 23.x || 24.x || 25.x || 26.x` while shipping prebuilds for
+ * ABI 127/137/141/147 only, i.e. Node 22/24/25/26: 12.10.0 added Node 26 and
+ * dropped the EOL Node 20 and 23 builds in the same release without touching
+ * `engines`. Deriving from it would promise Node 23 an install it cannot
+ * deliver.
+ *
+ * Prebuild coverage therefore lives in `PREBUILT_MAJORS`, keyed by the exact
+ * dependency version it was verified against. A bump to an unlisted version
+ * fails with an explicit message instead of silently inheriting a stale answer.
  *
  * WIDENING IS NOT ENOUGH ON ITS OWN
  * Claiming a major nothing runs is the same mistake pointed the other way, so
- * the last test asserts the CI matrix actually exercises the highest supported
- * major.
+ * the last tests assert the CI matrix actually exercises the highest supported
+ * major, and that the job in question really runs the suite.
  */
 
 const require = createRequire(import.meta.url)
@@ -36,8 +38,23 @@ const require = createRequire(import.meta.url)
 /** Canonry's own floor, independent of what the native dep supports. */
 const CANONRY_MIN_MAJOR = 22
 
-/** The major Docker images, .nvmrc, and the published build all pin. */
+/** The major the Docker images pin. */
 const DEPLOY_MAJOR = 22
+
+/**
+ * Node majors each better-sqlite3 release ships a PREBUILT binary for.
+ *
+ * Verified against the release assets, which are named
+ * `better-sqlite3-v<version>-node-v<abi>-<platform>-<arch>.tar.gz`; the ABI
+ * maps to a Node major (127→22, 131→23, 137→24, 141→25, 147→26).
+ *
+ * Do NOT populate this from `engines.node` — see the note above. Re-verify on
+ * every better-sqlite3 upgrade; that is exactly what this table is for.
+ */
+const PREBUILT_MAJORS: Record<string, number[]> = {
+  // v12.11.1 assets: ABI 127, 137, 141, 147 (no 131 — Node 23 was dropped in 12.10.0).
+  '12.11.1': [22, 24, 25, 26],
+}
 
 function repoRoot(): string {
   // packages/db/test -> repo root
@@ -59,31 +76,77 @@ function guardMajors(): number[] {
     .sort((a, b) => a - b)
 }
 
-function betterSqlite3Majors(): number[] {
+function installedBetterSqlite3(): { version: string; enginesMajors: number[] } {
   const pkgPath = require.resolve('better-sqlite3/package.json')
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { engines?: { node?: string } }
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+    version?: string
+    engines?: { node?: string }
+  }
   const range = pkg.engines?.node
   if (!range) throw new Error('better-sqlite3 declares no engines.node')
-  // e.g. "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-  return range
-    .split('||')
-    .map((part) => Number.parseInt(part.trim(), 10))
-    .filter((n) => Number.isFinite(n))
-    .sort((a, b) => a - b)
+  if (!pkg.version) throw new Error('better-sqlite3 declares no version')
+  return {
+    version: pkg.version,
+    // e.g. "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+    enginesMajors: range
+      .split('||')
+      .map((part) => Number.parseInt(part.trim(), 10))
+      .filter((n) => Number.isFinite(n))
+      .sort((a, b) => a - b),
+  }
+}
+
+/** Majors the INSTALLED better-sqlite3 ships a prebuilt binary for. */
+function prebuiltMajors(): number[] {
+  const { version } = installedBetterSqlite3()
+  const majors = PREBUILT_MAJORS[version]
+  if (!majors) {
+    throw new Error(
+      `better-sqlite3 ${version} has no PREBUILT_MAJORS entry. Check that release's ` +
+        'assets for which node-v<abi> builds it ships and add them here. Do not copy ' +
+        'engines.node — it lists majors with no binary.',
+    )
+  }
+  return [...majors].sort((a, b) => a - b)
+}
+
+interface CiJob {
+  strategy?: { matrix?: { include?: Array<Record<string, unknown>> } }
+  steps?: Array<{ run?: string }>
 }
 
 /**
- * Majors the CI test matrix actually installs and runs the suite on.
+ * The CI job that installs a Node major and runs the suite on it.
  *
- * Reads the `include:` entries, which are deliberately asymmetric (Node 22
- * sharded 4x, the highest major unsharded) to hold CI cost down — so this
- * counts DISTINCT majors and says nothing about how each one is split.
- * `\bnode:` cannot match the `node-version:` key the setup step passes.
+ * Parsed as YAML, not scanned as text: a regex over the raw file cannot tell a
+ * live matrix entry from a commented-out one, cannot tell this job's `node:`
+ * key from any other job's, and cannot see whether the job runs the tests at
+ * all — so it would keep passing in exactly the cases this guard exists to
+ * catch.
+ */
+function testShardsJob(): CiJob {
+  const workflow = parseYaml(readRepoFile('.github', 'workflows', 'ci.yml')) as {
+    jobs?: Record<string, CiJob>
+  }
+  const job = workflow.jobs?.test_shards
+  if (!job) throw new Error('.github/workflows/ci.yml declares no `test_shards` job')
+  return job
+}
+
+/**
+ * Distinct Node majors the CI test matrix actually installs and runs on.
+ *
+ * The entries are deliberately asymmetric (Node 22 sharded 4x, the highest
+ * major unsharded) to hold CI cost down, so this counts DISTINCT majors and
+ * says nothing about how each one is split.
  */
 function ciMatrixMajors(): number[] {
-  const source = readRepoFile('.github', 'workflows', 'ci.yml')
-  const majors = [...source.matchAll(/\bnode:\s*'(\d+)'/g)].map((m) => Number.parseInt(m[1]!, 10))
-  if (majors.length === 0) throw new Error('node matrix not found in .github/workflows/ci.yml')
+  const include = testShardsJob().strategy?.matrix?.include
+  if (!include?.length) throw new Error('`test_shards` declares no matrix include entries')
+  const majors = include
+    .map((entry) => Number.parseInt(String(entry.node), 10))
+    .filter((n) => Number.isFinite(n))
+  if (majors.length === 0) throw new Error('no `node:` keys in the test_shards matrix')
   return [...new Set(majors)].sort((a, b) => a - b)
 }
 
@@ -94,12 +157,19 @@ function declaredEnginesCeiling(pkgRelPath: string[]): { declared: string; ceili
 }
 
 describe('Node support range', () => {
-  test('the install guard matches Canonry-supported better-sqlite3 majors', () => {
-    // Derived, not hardcoded: whatever better-sqlite3 supports at or above
-    // Canonry's floor is exactly what the guard must allow. A dependency bump
-    // that adds OR drops a major fails here.
-    const expected = betterSqlite3Majors().filter((major) => major >= CANONRY_MIN_MAJOR)
+  test('the install guard matches the prebuilt majors at or above Canonry floor', () => {
+    // Derived from prebuild coverage, not from engines.node. A dependency bump
+    // that adds OR drops a prebuilt major fails here.
+    const expected = prebuiltMajors().filter((major) => major >= CANONRY_MIN_MAJOR)
     expect(guardMajors()).toEqual(expected)
+  })
+
+  test('the prebuilt table never claims a major better-sqlite3 does not support', () => {
+    // The table is hand-maintained, so bound it by the dep's own declared
+    // range: engines.node is a superset of the prebuilds, never a subset. A
+    // typo'd or invented major fails here rather than widening the guard.
+    const { enginesMajors } = installedBetterSqlite3()
+    for (const major of prebuiltMajors()) expect(enginesMajors).toContain(major)
   })
 
   test('the guard and declared engine range enforce Node 22+', () => {
@@ -130,16 +200,6 @@ describe('Node support range', () => {
     }
   })
 
-  test('the guard rejects a major with no prebuilt binary', () => {
-    // The case that motivated this: an agent on a brand-new Node fell through
-    // to compiling better-sqlite3 from source and read the node-gyp failure as
-    // a repo bug. The guard must never promise a major the native dep has no
-    // prebuild for — expressed against the dep's own range, so this keeps
-    // meaning the same thing after the next Node release.
-    const beyondPrebuilds = Math.max(...betterSqlite3Majors()) + 1
-    expect(guardMajors()).not.toContain(beyondPrebuilds)
-  })
-
   test('the declared engines range does not promise more than the guard allows', () => {
     // An unbounded `>=X` range asserts that every FUTURE major is supported,
     // which is exactly the claim that misled the install. Require a ceiling.
@@ -159,5 +219,13 @@ describe('Node support range', () => {
     expect(ci).toContain(highest)
     // And CI must not claim to test a major the guard refuses to install on.
     for (const major of ci) expect(guardMajors()).toContain(major)
+  })
+
+  test('the matrix job actually runs the test suite', () => {
+    // A matrix that lists a major but never runs the tests on it is the same
+    // empty claim. Assert the job's steps invoke the suite.
+    const steps = testShardsJob().steps ?? []
+    const commands = steps.map((step) => step.run ?? '').join('\n')
+    expect(commands).toMatch(/pnpm\s+run\s+test/)
   })
 })

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.175.0",
+  "version": "4.176.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.175.0",
+  "version": "4.176.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.175.0",
+  "version": "4.176.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^24.5.1
         version: 24.12.0
       better-sqlite3:
-        specifier: ^12.6.2
-        version: 12.6.2
+        specifier: ^12.11.1
+        version: 12.11.1
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
@@ -274,10 +274,10 @@ importers:
         version: 5.5.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1))(zod@4.3.6)
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
@@ -318,8 +318,8 @@ importers:
         specifier: ^0.34.41
         version: 0.34.49
       better-sqlite3:
-        specifier: ^12.6.2
-        version: 12.6.2
+        specifier: ^12.11.1
+        version: 12.11.1
       chrome-remote-interface:
         specifier: ^0.33.2
         version: 0.33.3
@@ -328,7 +328,7 @@ importers:
         version: 5.5.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
@@ -481,11 +481,11 @@ importers:
         specifier: workspace:*
         version: link:../contracts
       better-sqlite3:
-        specifier: ^12.6.2
-        version: 12.6.2
+        specifier: ^12.11.1
+        version: 12.11.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -819,6 +819,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
@@ -861,6 +865,10 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -892,6 +900,10 @@ packages:
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -2382,9 +2394,9 @@ packages:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
-  better-sqlite3@12.6.2:
-    resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -5386,6 +5398,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
@@ -5448,6 +5466,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.28.6':
@@ -5472,6 +5492,8 @@ snapshots:
   '@babel/runtime@7.28.6': {}
 
   '@babel/runtime@7.29.2': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -6590,8 +6612,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -6972,7 +6994,7 @@ snapshots:
 
   basic-ftp@5.3.1: {}
 
-  better-sqlite3@12.6.2:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -7362,14 +7384,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2):
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1):
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 12.6.2
+      better-sqlite3: 12.11.1
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(zod@4.3.6):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1))(zod@4.3.6):
     dependencies:
-      drizzle-orm: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
+      drizzle-orm: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
       zod: 4.3.6
 
   dunder-proto@1.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,6 +493,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
   packages/integration-bing:
     dependencies:

--- a/scripts/check-better-sqlite3-prebuilds.mjs
+++ b/scripts/check-better-sqlite3-prebuilds.mjs
@@ -1,0 +1,155 @@
+/**
+ * Reports when better-sqlite3's PREBUILT binary coverage has moved away from
+ * what this repo claims to support.
+ *
+ * WHY THIS EXISTS
+ * `packages/db/test/node-support-range.test.ts` can prove the guard agrees with
+ * the INSTALLED better-sqlite3, and that the installed copy matches the
+ * lockfile. It cannot prove the lockfile matches reality, because a test must
+ * not depend on the network. That blind spot is not hypothetical: the repo sat
+ * on 12.6.2 for months while 12.10.0 had shipped the Node 26 prebuild, and the
+ * guard, the test and the lockfile all agreed with each other the entire time.
+ *
+ * So the only part that needs the network lives here, on a schedule.
+ *
+ * WHY IT FAILS INSTEAD OF OPENING A PR
+ * `bump-aeo-audit.yml` is the house pattern for this and its own header records
+ * how it broke: the final create-PR step needs a PAT the org does not grant, so
+ * every gate ran green, the last step died, and the pin silently froze from
+ * 2026-06-22 until it was bumped by hand. A red run on the Actions tab needs no
+ * token and cannot half-succeed, so this job just fails and says what changed.
+ *
+ * Exit 0 = in sync. Exit 1 = drift (read the output). Exit 2 = the check itself
+ * could not run, which is NOT the same as "in sync" and must not be read as it.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const CANONRY_MIN_MAJOR = 22
+
+function read(...segments) {
+  return fs.readFileSync(path.join(repoRoot, ...segments), 'utf8')
+}
+
+async function getJson(url) {
+  const headers = { 'user-agent': 'canonry-prebuild-check' }
+  // Lifts the unauthenticated GitHub limit from 60/hr; absent locally, which is fine.
+  if (process.env.GITHUB_TOKEN && url.includes('api.github.com')) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
+  const response = await fetch(url, { headers })
+  if (!response.ok) throw new Error(`GET ${url} -> ${response.status} ${response.statusText}`)
+  return response.json()
+}
+
+/** The better-sqlite3 version pnpm-lock.yaml resolves to. */
+export function lockedVersion() {
+  const source = read('pnpm-lock.yaml')
+  const versions = [...source.matchAll(/^ {2}better-sqlite3@(\d+\.\d+\.\d+):$/gm)].map(m => m[1])
+  const unique = [...new Set(versions)]
+  if (unique.length !== 1) {
+    throw new Error(`expected exactly one better-sqlite3 in pnpm-lock.yaml, found: ${unique.join(', ') || 'none'}`)
+  }
+  return unique[0]
+}
+
+/** SUPPORTED_MAJORS as scripts/check-node.mjs declares it. */
+export function guardMajors() {
+  const match = /const SUPPORTED_MAJORS = \[([^\]]*)\]/.exec(read('scripts', 'check-node.mjs'))
+  if (!match) throw new Error('SUPPORTED_MAJORS not found in scripts/check-node.mjs')
+  return match[1].split(',').map(part => Number.parseInt(part.trim(), 10)).filter(Number.isFinite).sort((a, b) => a - b)
+}
+
+/**
+ * ABI -> Node major, from Node's own release index rather than a table here.
+ * A hardcoded map is the same mistake this whole guard exists to prevent: it
+ * would need editing for a Node major that does not exist yet.
+ */
+async function abiToMajor() {
+  const releases = await getJson('https://nodejs.org/dist/index.json')
+  const map = new Map()
+  for (const release of releases) {
+    const abi = Number.parseInt(release.modules, 10)
+    const major = Number.parseInt(String(release.version).replace(/^v/, ''), 10)
+    if (Number.isFinite(abi) && Number.isFinite(major)) map.set(abi, major)
+  }
+  return map
+}
+
+/** Node majors implied by a release's prebuild asset names. Pure; see the test below it. */
+export function majorsFromAssetNames(assetNames, abis) {
+  const majors = new Set()
+  for (const name of assetNames) {
+    const match = /-node-v(\d+)-/.exec(name)
+    if (!match) continue
+    const major = abis.get(Number.parseInt(match[1], 10))
+    if (major !== undefined) majors.add(major)
+  }
+  return [...majors].sort((a, b) => a - b)
+}
+
+/** Node majors a given better-sqlite3 release ships a prebuilt binary for. */
+async function prebuiltMajorsFor(version, abis) {
+  const release = await getJson(`https://api.github.com/repos/WiseLibs/better-sqlite3/releases/tags/v${version}`)
+  const majors = majorsFromAssetNames((release.assets ?? []).map(asset => asset.name), abis)
+  if (majors.length === 0) throw new Error(`no node-v<abi> prebuild assets found on better-sqlite3 v${version}`)
+  return majors
+}
+
+async function main() {
+  const locked = lockedVersion()
+  const latest = (await getJson('https://registry.npmjs.org/better-sqlite3/latest')).version
+  const abis = await abiToMajor()
+
+  const lockedPrebuilds = await prebuiltMajorsFor(locked, abis)
+  const expected = lockedPrebuilds.filter(major => major >= CANONRY_MIN_MAJOR)
+  const guard = guardMajors()
+
+  const drift = []
+
+  if (String(guard) !== String(expected)) {
+    drift.push(
+      `SUPPORTED_MAJORS is [${guard}] but better-sqlite3 ${locked} ships prebuilds for ` +
+        `[${lockedPrebuilds}] (>= Node ${CANONRY_MIN_MAJOR}: [${expected}]).\n` +
+        '    Fix scripts/check-node.mjs and the PREBUILT_MAJORS entry in ' +
+        'packages/db/test/node-support-range.test.ts.',
+    )
+  }
+
+  if (locked !== latest) {
+    const latestPrebuilds = await prebuiltMajorsFor(latest, abis).catch(() => null)
+    const changed = latestPrebuilds && String(latestPrebuilds) !== String(lockedPrebuilds)
+    if (changed) {
+      drift.push(
+        `better-sqlite3 ${latest} is out and its prebuild coverage CHANGED: ` +
+          `[${lockedPrebuilds}] -> [${latestPrebuilds}].\n` +
+          '    Bump the dependency, then update SUPPORTED_MAJORS and PREBUILT_MAJORS to match.',
+      )
+    } else {
+      // A newer release with identical prebuild coverage is not this job's
+      // problem — nothing it guards has moved.
+      console.log(`note: better-sqlite3 ${latest} is available (pinned ${locked}); prebuild coverage unchanged.`)
+    }
+  }
+
+  if (drift.length > 0) {
+    console.error('\nbetter-sqlite3 prebuild coverage has drifted:\n')
+    for (const item of drift) console.error(`  - ${item}\n`)
+    process.exit(1)
+  }
+
+  console.log(`in sync: better-sqlite3 ${locked}, prebuilds [${lockedPrebuilds}], SUPPORTED_MAJORS [${guard}].`)
+}
+
+// Importable for testing; only runs the check when invoked directly.
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (invokedDirectly) main().catch(error => {
+  // Exit 2, never 1: "the check could not run" must not read as "drift found",
+  // and must not read as success either.
+  console.error(`could not complete the prebuild check: ${error.message}`)
+  process.exit(2)
+})

--- a/scripts/check-better-sqlite3-prebuilds.mjs
+++ b/scripts/check-better-sqlite3-prebuilds.mjs
@@ -91,12 +91,37 @@ export function majorsFromAssetNames(assetNames, abis) {
   return [...majors].sort((a, b) => a - b)
 }
 
-/** Node majors a given better-sqlite3 release ships a prebuilt binary for. */
-async function prebuiltMajorsFor(version, abis) {
-  const release = await getJson(`https://api.github.com/repos/WiseLibs/better-sqlite3/releases/tags/v${version}`)
-  const majors = majorsFromAssetNames((release.assets ?? []).map(asset => asset.name), abis)
-  if (majors.length === 0) throw new Error(`no node-v<abi> prebuild assets found on better-sqlite3 v${version}`)
-  return majors
+/**
+ * Prebuild coverage for one release: `{ majors }`, or `{ error }` when it could
+ * not be determined.
+ *
+ * Zero matching assets is NOT swallowed as "nothing changed". better-sqlite3
+ * 13.x publishes no per-ABI release assets at all — it bundles Node-API builds
+ * in the npm tarball as `prebuilds/<platform>.node`, which are ABI-stable, which
+ * is why its `engines.node` relaxed to an unbounded `>=22`. Upstream changing
+ * how it ships binaries is the single most useful thing this job can report, so
+ * it must never reach the caller as an absence.
+ */
+async function describePrebuilds(version, abis) {
+  let release
+  try {
+    release = await getJson(`https://api.github.com/repos/WiseLibs/better-sqlite3/releases/tags/v${version}`)
+  } catch (error) {
+    return { error: `could not read the v${version} release: ${error.message}` }
+  }
+  const assetNames = (release.assets ?? []).map(asset => asset.name)
+  const majors = majorsFromAssetNames(assetNames, abis)
+  if (majors.length === 0) {
+    return {
+      error:
+        `v${version} publishes no node-v<abi> prebuild assets (${assetNames.length} assets on the release).\n` +
+        '    That is how 13.x ships: Node-API builds bundled in the npm tarball under\n' +
+        '    prebuilds/<platform>.node, ABI-stable, no per-major binary. If the pin has moved\n' +
+        '    to that model, this check no longer describes reality — retire it rather than\n' +
+        '    letting it report a coverage set that no longer exists.',
+    }
+  }
+  return { majors }
 }
 
 async function main() {
@@ -104,34 +129,47 @@ async function main() {
   const latest = (await getJson('https://registry.npmjs.org/better-sqlite3/latest')).version
   const abis = await abiToMajor()
 
-  const lockedPrebuilds = await prebuiltMajorsFor(locked, abis)
-  const expected = lockedPrebuilds.filter(major => major >= CANONRY_MIN_MAJOR)
+  const lockedCoverage = await describePrebuilds(locked, abis)
   const guard = guardMajors()
-
   const drift = []
 
-  if (String(guard) !== String(expected)) {
-    drift.push(
-      `SUPPORTED_MAJORS is [${guard}] but better-sqlite3 ${locked} ships prebuilds for ` +
-        `[${lockedPrebuilds}] (>= Node ${CANONRY_MIN_MAJOR}: [${expected}]).\n` +
-        '    Fix scripts/check-node.mjs and the PREBUILT_MAJORS entry in ' +
-        'packages/db/test/node-support-range.test.ts.',
-    )
-  }
+  if (lockedCoverage.error) {
+    // The pinned version's own coverage is the baseline for everything else, so
+    // there is nothing to compare and no honest way to pass.
+    drift.push(`pinned better-sqlite3 ${locked}: ${lockedCoverage.error}`)
+  } else {
+    const lockedPrebuilds = lockedCoverage.majors
+    const expected = lockedPrebuilds.filter(major => major >= CANONRY_MIN_MAJOR)
 
-  if (locked !== latest) {
-    const latestPrebuilds = await prebuiltMajorsFor(latest, abis).catch(() => null)
-    const changed = latestPrebuilds && String(latestPrebuilds) !== String(lockedPrebuilds)
-    if (changed) {
+    if (String(guard) !== String(expected)) {
       drift.push(
-        `better-sqlite3 ${latest} is out and its prebuild coverage CHANGED: ` +
-          `[${lockedPrebuilds}] -> [${latestPrebuilds}].\n` +
-          '    Bump the dependency, then update SUPPORTED_MAJORS and PREBUILT_MAJORS to match.',
+        `SUPPORTED_MAJORS is [${guard}] but better-sqlite3 ${locked} ships prebuilds for ` +
+          `[${lockedPrebuilds}] (>= Node ${CANONRY_MIN_MAJOR}: [${expected}]).\n` +
+          '    Fix scripts/check-node.mjs and the PREBUILT_MAJORS entry in ' +
+          'packages/db/test/node-support-range.test.ts.',
       )
-    } else {
-      // A newer release with identical prebuild coverage is not this job's
-      // problem — nothing it guards has moved.
-      console.log(`note: better-sqlite3 ${latest} is available (pinned ${locked}); prebuild coverage unchanged.`)
+    }
+
+    if (locked !== latest) {
+      // A newer upstream release is INFORMATION, never a failure: the pin is a
+      // deliberate choice and this job going red weekly for an upgrade nobody
+      // has decided to take is how a useful alarm gets ignored. Only the pinned
+      // version being misdescribed (above) makes this job fail. Every branch
+      // here still says what it actually found — reporting "unchanged" for a
+      // comparison that never happened is the bug this replaced.
+      const latestCoverage = await describePrebuilds(latest, abis)
+      if (latestCoverage.error) {
+        console.log(`note: better-sqlite3 ${latest} is available (pinned ${locked}), coverage NOT comparable:`)
+        console.log(`  ${latestCoverage.error}`)
+      } else if (String(latestCoverage.majors) !== String(lockedPrebuilds)) {
+        console.log(
+          `note: better-sqlite3 ${latest} is available (pinned ${locked}) and its prebuild ` +
+            `coverage differs: [${lockedPrebuilds}] -> [${latestCoverage.majors}]. ` +
+            'Bumping means updating SUPPORTED_MAJORS and PREBUILT_MAJORS to match.',
+        )
+      } else {
+        console.log(`note: better-sqlite3 ${latest} is available (pinned ${locked}); prebuild coverage unchanged.`)
+      }
     }
   }
 
@@ -141,7 +179,7 @@ async function main() {
     process.exit(1)
   }
 
-  console.log(`in sync: better-sqlite3 ${locked}, prebuilds [${lockedPrebuilds}], SUPPORTED_MAJORS [${guard}].`)
+  console.log(`in sync: better-sqlite3 ${locked}, prebuilds [${lockedCoverage.majors}], SUPPORTED_MAJORS [${guard}].`)
 }
 
 // Importable for testing; only runs the check when invoked directly.

--- a/scripts/check-node.mjs
+++ b/scripts/check-node.mjs
@@ -25,10 +25,11 @@
  * Dockerfile, rather than an arbitrary local runtime, controls that version.
  *
  * KEEPING THIS HONEST
- * `SUPPORTED_MAJORS` is the intersection of Canonry's Node 22+ policy and
- * better-sqlite3's supported majors. It is asserted against the installed
- * package by `packages/db/test/node-support-range.test.ts`, so a dependency
- * bump that narrows OR widens support fails a test rather than silently
+ * `SUPPORTED_MAJORS` is the intersection of Canonry's Node 22+ policy and the
+ * majors better-sqlite3 ships PREBUILT BINARIES for — which is NOT the same as
+ * its `engines.node`, see the note on the list itself. It is asserted against
+ * the installed package by `packages/db/test/node-support-range.test.ts`, so a
+ * dependency bump that narrows OR widens support fails a test rather than silently
  * drifting — which is exactly how this list went stale once already: it was
  * pinned at 25 while better-sqlite3 had shipped Node 26 prebuilds since
  * 12.10.0, and the test hardcoded the same ceiling so the two agreed on a
@@ -38,9 +39,19 @@
  * "supported" stays a claim with evidence behind it.
  */
 
-// Canonry supports Node 22+; better-sqlite3 ships prebuilds for 22.x-26.x.
-// Derived, not guessed — see the test above before editing.
-const SUPPORTED_MAJORS = [22, 23, 24, 25, 26]
+// Canonry's Node 22+ floor intersected with the majors better-sqlite3 ships a
+// PREBUILT binary for.
+//
+// 23 is absent on purpose. better-sqlite3 12.10.0 added the Node 26 prebuild and
+// in the same release dropped the EOL Node 20 and 23 ones — but left both in
+// `engines.node`, which still reads "20.x || 22.x || 23.x || 24.x || 25.x || 26.x".
+// That field is therefore a SUPERSET of what actually has a binary, and deriving
+// this list from it alone would promise Node 23 an install it cannot deliver:
+// prebuild-install misses, node-gyp starts compiling, and the reader gets the
+// C++ wall this guard exists to replace.
+//
+// Asserted by packages/db/test/node-support-range.test.ts — read it before editing.
+const SUPPORTED_MAJORS = [22, 24, 25, 26]
 
 const major = Number.parseInt(process.versions.node.split('.')[0], 10)
 const bypassed = process.env.CANONRY_SKIP_NODE_CHECK === '1'

--- a/scripts/check-node.mjs
+++ b/scripts/check-node.mjs
@@ -28,11 +28,19 @@
  * `SUPPORTED_MAJORS` is the intersection of Canonry's Node 22+ policy and
  * better-sqlite3's supported majors. It is asserted against the installed
  * package by `packages/db/test/node-support-range.test.ts`, so a dependency
- * bump that narrows support fails a test rather than silently drifting.
+ * bump that narrows OR widens support fails a test rather than silently
+ * drifting — which is exactly how this list went stale once already: it was
+ * pinned at 25 while better-sqlite3 had shipped Node 26 prebuilds since
+ * 12.10.0, and the test hardcoded the same ceiling so the two agreed on a
+ * fact that had expired.
+ *
+ * That test also asserts CI actually runs the highest major listed here, so
+ * "supported" stays a claim with evidence behind it.
  */
 
-// Canonry supports Node 22+ while better-sqlite3 supports 22.x through 25.x.
-const SUPPORTED_MAJORS = [22, 23, 24, 25]
+// Canonry supports Node 22+; better-sqlite3 ships prebuilds for 22.x-26.x.
+// Derived, not guessed — see the test above before editing.
+const SUPPORTED_MAJORS = [22, 23, 24, 25, 26]
 
 const major = Number.parseInt(process.versions.node.split('.')[0], 10)
 const bypassed = process.env.CANONRY_SKIP_NODE_CHECK === '1'
@@ -57,13 +65,18 @@ if (!SUPPORTED_MAJORS.includes(major) && bypassed) {
       '    install tries to compile from source and fails deep inside node-gyp,',
       '    which looks like an unrelated build error.',
       '',
-      '    Fix: switch Node, do NOT change dependencies.',
+      '    Fix: switch to a supported Node.',
       `      nvm use 22        (or fnm/volta/asdf — see .nvmrc)`,
-      '      CI and Docker images run Node 22.',
+      '      Docker images and the published build run Node 22.',
       '',
-      '    If you are intentionally testing a newer Node, set',
-      '    CANONRY_SKIP_NODE_CHECK=1 to bypass this and expect the native build',
-      '    to fail.',
+      '    If your Node is NEWER than every major above, better-sqlite3 may since',
+      '    have added a prebuild for it. Check whether a newer release lists your',
+      '    major in `engines.node`; if so, updating the dependency and this list',
+      '    together is the correct fix, not a workaround:',
+      '      pnpm update better-sqlite3 -r',
+      '',
+      '    To proceed anyway, set CANONRY_SKIP_NODE_CHECK=1. If no prebuild exists',
+      '    for your major, expect the native build to fail.',
       '',
     ].join('\n'),
   )


### PR DESCRIPTION
The repo capped at Node 22–25 because better-sqlite3 had no Node 26 prebuild. That stopped being true in better-sqlite3 **12.10.0** — the `^12.6.2` caret already allowed the fix and only the **lockfile** was stale. So the guard blocked installs on Node 26 (Homebrew's current default) and told contributors to change their Node and explicitly *not* to touch dependencies, when updating the dependency was the actual fix.

## Changes

- `better-sqlite3` 12.6.2 → 12.11.1 — prebuilt ABI 147 verified for darwin, linux, linuxmusl, win32
- `SUPPORTED_MAJORS` += 26; `engines.node` `<26` → `<27`
- Corrected the guard's advice, which was wrong in both halves on a current lockfile

Additive only. Node 22–25 are untouched, and **Docker, `.nvmrc`, and `publish.yml` stay on Node 22** — widening what a contributor may use must not move what ships. The setup action's new `node-version` input defaults to `'22'`, so all seven other CI jobs are unchanged.

## The guard was hardcoded against the thing it checked

`node-support-range.test.ts` hardcoded `26` in three places, so the guard and the test agreed with each other while both disagreed with better-sqlite3 — which is exactly how this stayed wrong for months. Every bound now derives from the dep's own `engines.node`, plus a new guard asserting **the CI matrix covers the highest supported major**: claiming a major nothing runs is the same mistake pointed the other way.

Verified each guard actually fails — reverting `SUPPORTED_MAJORS` (3 failed), dropping the Node 26 lane (1 failed), leaving `engines` at `<26` (2 failed).

## CI: 4 → 5 jobs, not 8

Node 22 keeps 4 shards; Node 26 runs the whole suite in **one unsharded job**. Sampling a single shard on Node 26 would have cost the same +1 runner and covered a quarter of the suite — and the Node 26 break this matrix exists to catch lives in `packages/canonry`, which one shard may not hold.

## The break it caught immediately

tsx's ESM loader calls `module.register()`, deprecated in Node 26 (DEP0205), so the MCP subprocess emits a warning before canonry runs a statement and `mcp-stdio`'s `stderr === ''` assertion failed. **This is the failure the old `<26` ceiling was concealing.**

Fixed by filtering Node's own `(node:<pid>)` diagnostics — not by weakening the assertion. Verified canonry JSON logs, stray output, and stack traces still fail it, so the MCP boundary rule stays enforced.

## Verification

- `pnpm verify` green on Node 26: **700 files / 9133 tests**
- `pnpm install --frozen-lockfile` now succeeds with **no** `CANONRY_SKIP_NODE_CHECK`

## Note

The `<27` ceiling will expire when Node 27 ships. That's deliberate — an unbounded `>=22` is the unfalsifiable claim that caused this in the first place. The derived test now surfaces it as a failure instead of hiding it.