### PR TITLE
ci: shard Node 26 test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,17 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      # Deliberately asymmetric to keep CI cost down.
+      # Deliberately asymmetric to balance CI feedback time and runner cost.
       #
       # Node 22 is what Docker and the published build pin, so it stays sharded
       # 4x for fast feedback on the version that actually ships.
       #
       # Node 26 is the highest major in `SUPPORTED_MAJORS`
       # (scripts/check-node.mjs) and the current Homebrew default. It runs the
-      # WHOLE suite in ONE job: +1 runner instead of +4, still 100% coverage.
-      # Sampling a single shard there would have been cheaper by the same
-      # amount and would have covered a quarter of the suite — and the Node 26
-      # break this matrix was added to catch (tsx's `module.register()` tripping
+      # WHOLE suite across two shards: 100% coverage without leaving the PR
+      # tail behind a ten-minute serial run. Sampling one shard would be
+      # cheaper, but would cover only half the suite — and the Node 26 break
+      # this matrix was added to catch (tsx's `module.register()` tripping
       # DEP0205) lives in packages/canonry, which one shard may not hold.
       #
       # The pairing is the point: better-sqlite3 is a NATIVE module, so a major
@@ -101,7 +101,8 @@ jobs:
           - { node: '22', shard: '2/4' }
           - { node: '22', shard: '3/4' }
           - { node: '22', shard: '4/4' }
-          - { node: '26', shard: '1/1' }
+          - { node: '26', shard: '1/2' }
+          - { node: '26', shard: '2/2' }
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup

--- a/packages/canonry/test/google-commands.test.ts
+++ b/packages/canonry/test/google-commands.test.ts
@@ -10,10 +10,10 @@ import { ApiClient } from '../src/client.js'
 /**
  * The two googleRefresh cases trigger a real gsc-sync run and poll
  * `waitForRunStatus` every 2s until it reaches a terminal status. Vitest's 5s
- * default only covers ~2 poll cycles, so under the unsharded Node 26 CI lane —
- * the whole suite in one job (ci.yml / scripts/check-node.mjs) — CPU
- * oversubscription keeps the run from finishing in time and the test times out
- * with no assertion diff. Same load effect already handled for
+ * default only covers ~2 poll cycles, so under the full-coverage Node 26 CI
+ * lane (ci.yml / scripts/check-node.mjs), CPU oversubscription can keep the
+ * run from finishing in time and the test times out with no assertion diff.
+ * Same load effect is already handled for
  * `mcp-stdio.test.ts`. 30s gives the poll loop ample headroom; a genuine hang
  * still fails via `waitForRunStatus`'s own 10-minute cap inside `googleRefresh`.
  */

--- a/packages/db/test/node-support-range.test.ts
+++ b/packages/db/test/node-support-range.test.ts
@@ -168,8 +168,8 @@ function testShardsJob(): CiJob {
  * Distinct Node majors the CI test matrix actually installs and runs on.
  *
  * The entries are deliberately asymmetric (Node 22 sharded 4x, the highest
- * major unsharded) to hold CI cost down, so this counts DISTINCT majors and
- * says nothing about how each one is split.
+ * major 2x) to balance feedback time and runner cost, so this counts DISTINCT
+ * majors and says nothing about how each one is split.
  */
 function ciMatrixMajors(): number[] {
   const include = testShardsJob().strategy?.matrix?.include
@@ -179,6 +179,25 @@ function ciMatrixMajors(): number[] {
     .filter((n) => Number.isFinite(n))
   if (majors.length === 0) throw new Error('no `node:` keys in the test_shards matrix')
   return [...new Set(majors)].sort((a, b) => a - b)
+}
+
+function ciMatrixShards(): Array<{ major: number; index: number; total: number }> {
+  const include = testShardsJob().strategy?.matrix?.include
+  if (!include?.length) throw new Error('`test_shards` declares no matrix include entries')
+
+  return include.map((entry) => {
+    const major = Number.parseInt(String(entry.node), 10)
+    const shard = /^(\d+)\/(\d+)$/.exec(String(entry.shard))
+    if (!Number.isFinite(major) || !shard) {
+      throw new Error(`invalid test-shard matrix entry: ${JSON.stringify(entry)}`)
+    }
+    const index = Number.parseInt(shard[1]!, 10)
+    const total = Number.parseInt(shard[2]!, 10)
+    if (index < 1 || total < index) {
+      throw new Error(`invalid shard ${String(entry.shard)} for Node ${major}`)
+    }
+    return { major, index, total }
+  })
 }
 
 function declaredEnginesCeiling(pkgRelPath: string[]): { declared: string; ceiling: number } {
@@ -263,6 +282,28 @@ describe('Node support range', () => {
     expect(ci).toContain(highest)
     // And CI must not claim to test a major the guard refuses to install on.
     for (const major of ci) expect(guardMajors()).toContain(major)
+  })
+
+  test('every CI Node major covers every shard it declares', () => {
+    // A matrix entry for Node 26 is not enough: `1/2` alone would test the
+    // major but silently sample only half its suite. Each major must include
+    // every member of one complete Vitest shard partition.
+    const byMajor = new Map<number, Array<{ index: number; total: number }>>()
+    for (const { major, index, total } of ciMatrixShards()) {
+      const shards = byMajor.get(major) ?? []
+      shards.push({ index, total })
+      byMajor.set(major, shards)
+    }
+
+    for (const [major, shards] of byMajor) {
+      const totals = [...new Set(shards.map((shard) => shard.total))]
+      expect(totals, `Node ${major} has inconsistent shard totals`).toHaveLength(1)
+      const total = totals[0]!
+      expect(
+        shards.map((shard) => shard.index).sort((a, b) => a - b),
+        `Node ${major} is missing or duplicating a shard`,
+      ).toEqual(Array.from({ length: total }, (_, index) => index + 1))
+    }
   })
 
   test('the matrix job actually runs the test suite', () => {


### PR DESCRIPTION
## Summary
- split the full Node 26 compatibility suite into two Vitest shards
- keep Node 22's existing four-way matrix unchanged
- add a regression guard that each runtime's declared shards form a complete partition

This preserves full Node 26 coverage while removing the prior ~10-minute serial CI tail.

## Verification
- pnpm --filter @ainyc/canonry-db exec vitest run --config ../../vitest.package.config.ts test/node-support-range.test.ts
- pnpm --filter @ainyc/canonry-db run typecheck
- pnpm --filter @ainyc/canonry-db run lint
- pnpm --filter @canonry/canonry run lint