### PR TITLE
Fix time-of-day flake in the traffic events day-bucket test

### DIFF
--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -4434,6 +4434,11 @@ describe('GET /traffic/status', () => {
 })
 
 describe('GET /traffic/events', () => {
+  // The class-count case below pins the clock. Restore it unconditionally so a
+  // throw before that test's own `finally` cannot hand a frozen `Date` to the
+  // next test; a no-op when timers were never faked.
+  afterEach(() => { vi.useRealTimers() })
+
   async function syncedHarness() {
     const baseTime = new Date(Date.now() - 60 * 60_000)
     baseTime.setMinutes(0, 0, 0)
@@ -4895,8 +4900,23 @@ describe('GET /traffic/events', () => {
    * The events window totals must divide the same way as everything else: a
    * redirect hop's paid tags are not a paid session, or the same ad click is
    * a paid session on this surface and zero on the report.
+   *
+   * Pinned, and pinned at two instants on purpose. The default window is
+   * [now-24h, now], so at `granularity=day` the series always spans two UTC
+   * days and the bucket asserted below is `now`'s. A fixture seeded at
+   * `now - 1h` silently moves into the EARLIER of those two buckets whenever
+   * `now` falls inside the first hour of a UTC day, which emptied that point
+   * and failed every CI job between 00:00 and 01:00 UTC. The 00:30 instant is
+   * the standing guard: anything seeded relative to `now` here must survive it.
    */
-  it('window totals class-count only landed hits, keeping the full count beside them', async () => {
+  it.each([
+    '2026-05-07T13:45:00.000Z',
+    '2026-05-07T00:30:00.000Z',
+  ])('window totals class-count only landed hits, keeping the full count beside them (clock %s)', async (pinnedNow) => {
+    // Only `Date` is faked; the harness and Fastify's inject still need real
+    // timers to settle their promises.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(pinnedNow))
     const h = await buildHarness([])
     try {
       const connectRes = await h.app.inject({
@@ -4907,7 +4927,11 @@ describe('GET /traffic/events', () => {
       const sourceId = JSON.parse(connectRes.payload).id
       const projectId = h.db.select().from(trafficSources)
         .where(eq(trafficSources.id, sourceId)).get()!.projectId
-      const tsHour = new Date(Date.now() - 60 * 60 * 1000).toISOString().slice(0, 13) + ':00:00.000Z'
+      // Top of the CURRENT hour, never an hour back: that is inside both the
+      // 24h window and `now`'s UTC day at every instant of the day.
+      const hourStart = new Date()
+      hourStart.setUTCMinutes(0, 0, 0)
+      const tsHour = hourStart.toISOString()
       const now = new Date().toISOString()
       const base = {
         projectId, sourceId, tsHour, product: 'ChatGPT', operator: 'OpenAI',
@@ -4937,6 +4961,9 @@ describe('GET /traffic/events', () => {
       expect(t.aiReferralUnknownHits).toBe(0)
       // And the series charts the landed (session) figure per bucket.
       const today = JSON.parse(res.payload).series.points.at(-1)
+      // Name the bucket the last point actually is, so "today" stays a fact
+      // rather than an assumption about where the window happens to end.
+      expect(today.bucket).toBe(pinnedNow.slice(0, 10))
       expect(today.aiReferralHits).toBe(99)
       expect(today.aiReferralLandedHits).toBe(4)
     } finally { await h.close() }


### PR DESCRIPTION
## The flake

`packages/api-routes/test/traffic.test.ts` → `window totals class-count only landed hits, keeping the full count beside them` fails **deterministically for any CI run between 00:00 and 01:00 UTC**.

It took out 4 jobs on #1044 (two sharded test jobs plus the two aggregators depending on them) for a change that only touches `packages/api-routes/src/auth.ts` and `packages/canonry/src/server.ts`. It is **pre-existing and unrelated** — it reproduces unchanged at `d87aa309`.

## Root cause

The fixture seeded its rollup rows an hour back:

```ts
const tsHour = new Date(Date.now() - 60 * 60 * 1000).toISOString().slice(0, 13) + ':00:00.000Z'
```

then asserted on `series.points.at(-1)`, calling it `today`.

`completeTrafficSeries` (`src/traffic.ts:678`) floors **both** window bounds to UTC days, so the default `[now-24h, now]` window always emits two day points and `.at(-1)` is `now`'s day. When `now` is inside the first hour of a UTC day, `now - 1h` is the *previous* day — the row lands in the earlier point, and the asserted point comes back empty.

Worth noting the blast radius is narrower than it first looks: the `totals` assertions all still pass, because `since` is a rolling millisecond window and a row an hour back is always inside it. Only the day-bucketed series breaks.

## The fix

1. **Pin the clock** — `vi.useFakeTimers({ toFake: ['Date'] })`, the pattern already used in `ads-live-delivery.test.ts:1076`. Only `Date` is faked so the harness and Fastify's `inject` keep real timers.
2. **Regression guard** — `it.each` runs the case at **13:45** *and* **00:30 UTC**, so the boundary is exercised on every run rather than depending on when CI happens to fire.
3. **Fix the fixture** — seed the top of the *current* hour, which is inside both the 24h window and `now`'s UTC day at every instant of the day.
4. **Make `today` a fact** — added `expect(today.bucket).toBe(pinnedNow.slice(0, 10))`, so the variable name is asserted rather than assumed.

`it.each` (rather than a `for` wrapper) keeps the test body at its original indentation, so the diff is the substantive lines only.

## Verification

- **Reproduced first**: pinning to 00:30 UTC against the unmodified test yields the exact reported `AssertionError: expected +0 to be 99`.
- **Guard bites**: reintroducing the old `Date.now() - 1h` fixture fails the 00:30 variant while the 13:45 one passes.
- **`pnpm verify` green** — 702 files / 9166 tests.

## Sibling sweep — none found

Checked by execution, not just inspection. A setup file shifts the clock so `now` sits at 00:30 UTC while still *advancing* (a frozen clock would hang the `waitForRunComplete` poll loops). Validated against the pre-fix tree: it reproduced the known failure and flagged that test alone out of 131.

Against the fixed tree: **160 files / 2919 tests pass at 00:30 UTC** across all of `api-routes`, and `traffic.test.ts` also passes at 23:45. So there are no siblings in the package, not just this file.

That matches the static picture — `completeTrafficSeries` is the only calendar-day logic in `traffic.ts`; everything else (24h totals, retention boundaries, sync watermarks, backfill windows) is rolling milliseconds. The two `granularity=day` callers are this test and the 90-day series test, and the latter passes explicit day-floored `since`/`until`, so it is self-consistent at any hour.

The sweep harness was a scratch file and is deliberately not committed.

## Notes

- **No version bump**: 31 changed lines, test-only, under the 100-line threshold — so this takes `version-guard`'s no-bump path.
- **Left alone, adjacent**: `syncedHarness` (`traffic.test.ts:4438`) uses local-time `setMinutes(0,0,0)` rather than `setUTCMinutes`. Harmless today (minutes match UTC outside half-hour-offset zones, and it only feeds rolling windows) and not a flake, but worth knowing if that helper is ever reused for a day-bucketed assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
