### PR TITLE
fix(web): plain-language headings on the Activity tab, filter Top Landing Pages

### DIFF
--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -75,6 +75,7 @@ function aiLandingPageSearchText(row: ApiGaTrafficAiLandingPage): string {
   return urlSearchText(row.landingPage)
 }
 const AI_LANDING_PAGE_SIZE = 25
+const TOP_PAGE_SIZE = 10
 
 const EMPTY_AI_DAILY: GA4AiReferralDailyDto = {
   days: [],
@@ -378,6 +379,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
   }
 
   function handlePageSort(key: PageSortKey) {
+    topPagesTable.setPage(1)
     if (pageSortKey === key) {
       setPageSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
     } else {
@@ -415,6 +417,12 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
       return pageSortDir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number)
     })
   }, [traffic?.topPages, pageSortKey, pageSortDir])
+
+  const topPagesTable = useClientTable({
+    rows: sortedPages,
+    getSearchText: (page) => urlSearchText(page.landingPage),
+    pageSize: TOP_PAGE_SIZE,
+  })
 
   const sortedAiReferrals = useMemo(() => {
     if (!traffic?.aiReferrals) return []
@@ -761,7 +769,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
             <Card className="surface-card p-5 mb-4">
               <div className="mb-4">
                 <p className="eyebrow eyebrow-soft">Summary</p>
-                <h3 className="text-sm font-semibold text-heading">Channel breakdown</h3>
+                <h3 className="text-sm font-semibold text-heading">Sessions by channel</h3>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
@@ -787,7 +795,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
                   tooltip="Sessions with no source — bookmarks, typed URLs, untagged email, in-app browsers, and AI-driven traffic whose referrer header was stripped. Known AI referrers are removed if GA4 classified them as Direct."
                 />
                 <AttributionStat
-                  label="Known AI referrers (lower bound)"
+                  label="Visitors from AI (at least)"
                   value={aiSharePctBySessionDisplay}
                   hint={paidAiSessionsBySession > 0
                     ? `${aiSessionsBySession.toLocaleString()} sessions · ${paidAiSessionsBySession.toLocaleString()} paid`
@@ -818,7 +826,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
               <div className="mb-4 flex items-end justify-between gap-3">
                 <div>
                   <p className="eyebrow eyebrow-soft">Detail</p>
-                  <h3 className="text-sm font-semibold text-heading">Known AI referrers by source</h3>
+                  <h3 className="text-sm font-semibold text-heading">Where AI visitors came from</h3>
                 </div>
                 <p className="text-xs text-muted">
                   {traffic.aiReferrals.length > 0 ? `${aiSourceCount} unique sources, ${traffic.aiReferrals.length} rows` : 'No source rows'}
@@ -859,7 +867,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
               <div className="mb-4 flex items-end justify-between gap-3">
                 <div>
                   <p className="eyebrow eyebrow-soft">Detail</p>
-                  <h3 className="text-sm font-semibold text-heading">Known AI referrers by landing page</h3>
+                  <h3 className="text-sm font-semibold text-heading">Pages AI visitors landed on</h3>
                 </div>
                 <p className="text-xs text-muted">
                   {aiLandingRowCount}
@@ -923,9 +931,9 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
                 </>
               ) : (
                 <div className="flex flex-col items-center justify-center py-8 text-center">
-                  <p className="text-sm text-secondary mb-2">No AI landing pages detected yet</p>
+                  <p className="text-sm text-secondary mb-2">No AI visits recorded yet</p>
                   <p className="text-xs text-muted max-w-sm">
-                    Known-AI landing pages appear after a GA4 sync records visits from AI referrers.
+                    Pages appear here once a GA4 sync records a visit that arrived from an AI engine.
                   </p>
                 </div>
               )}
@@ -953,7 +961,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
                 <div className="mb-4 flex items-end justify-between gap-3">
                   <div>
                     <p className="eyebrow eyebrow-soft">Trend</p>
-                    <h3 className="text-sm font-semibold text-heading">Social sessions over time</h3>
+                    <h3 className="text-sm font-semibold text-heading">Social sessions</h3>
                   </div>
                   {socialOtherCount > 0 && (
                     <p className="text-xs text-muted">
@@ -1029,7 +1037,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
               <Card className="surface-card p-5">
                 <div className="mb-4">
                   <p className="eyebrow eyebrow-soft">Summary</p>
-                  <h3 className="text-sm font-semibold text-heading">Social media visits</h3>
+                  <h3 className="text-sm font-semibold text-heading">Visits from social</h3>
                 </div>
 
                 {traffic.socialReferrals.length > 0 ? (
@@ -1092,7 +1100,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
                 <div className="mb-4 flex items-end justify-between gap-3">
                   <div>
                     <p className="eyebrow eyebrow-soft">Breakdown</p>
-                    <h3 className="text-sm font-semibold text-heading">Source / medium</h3>
+                    <h3 className="text-sm font-semibold text-heading">Social sources</h3>
                   </div>
                   <p className="text-xs text-muted">
                     {traffic.socialReferrals.length > 0
@@ -1178,6 +1186,14 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
               </h2>
             </div>
 
+            <DataTableSearch
+              value={topPagesTable.query}
+              onChange={topPagesTable.setQuery}
+              label="Filter landing page URLs"
+              placeholder="Filter landing pages"
+              className="mb-4 max-w-md"
+            />
+
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
@@ -1189,12 +1205,25 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
                   </tr>
                 </thead>
                 <tbody>
-                  {sortedPages.map((page) => (
+                  {topPagesTable.rows.map((page) => (
                     <LandingPageRow key={page.landingPage} page={page} />
                   ))}
                 </tbody>
               </table>
             </div>
+
+            {topPagesTable.totalRows === 0 && topPagesTable.hasQuery && (
+              <p className="text-sm text-secondary mt-3">No landing pages match this filter</p>
+            )}
+
+            <DataTablePagination
+              page={topPagesTable.page}
+              pageSize={topPagesTable.pageSize}
+              visibleRows={topPagesTable.rows.length}
+              totalRows={topPagesTable.totalRows}
+              onPageChange={topPagesTable.setPage}
+              itemLabel={topPagesTable.hasQuery ? 'matches' : 'pages'}
+            />
           </section>
         </>
       )}

--- a/apps/web/test/activity-section.test.tsx
+++ b/apps/web/test/activity-section.test.tsx
@@ -228,11 +228,11 @@ test('renders five-channel breakdown with disjoint Organic, Social, Direct, Know
   renderActivitySection()
 
   await waitFor(() => {
-    expect(screen.getByText('Channel breakdown')).toBeTruthy()
+    expect(screen.getByText('Sessions by channel')).toBeTruthy()
   })
 
   // Scope queries to the breakdown card so column headers in unrelated tables don't collide.
-  const card = screen.getByText('Channel breakdown').closest('div.surface-card') as HTMLElement
+  const card = screen.getByText('Sessions by channel').closest('div.surface-card') as HTMLElement
   expect(card).toBeTruthy()
   const breakdown = within(card)
 
@@ -240,9 +240,9 @@ test('renders five-channel breakdown with disjoint Organic, Social, Direct, Know
   expect(breakdown.getByText('Organic')).toBeTruthy()
   expect(breakdown.getByText('Social')).toBeTruthy()
   expect(breakdown.getByText('Direct')).toBeTruthy()
-  expect(breakdown.getByText(/Known AI referrers/)).toBeTruthy()
+  expect(breakdown.getByText(/Visitors from AI/)).toBeTruthy()
   expect(breakdown.getByText('Other channels')).toBeTruthy()
-  expect(breakdown.getByText(/lower bound/i)).toBeTruthy()
+  expect(breakdown.getByText(/at least/i)).toBeTruthy()
 
   // Direct cell shows the share from API (25%)
   expect(breakdown.getByText('25%')).toBeTruthy()
@@ -255,7 +255,7 @@ test('renders five-channel breakdown with disjoint Organic, Social, Direct, Know
   // The misleading old framing is gone: panel title "Attributable AI visits" must not appear
   expect(screen.queryByText('Attributable AI visits')).toBeNull()
 
-  expect(screen.getByText('Known AI referrers by landing page')).toBeTruthy()
+  expect(screen.getByText('Pages AI visitors landed on')).toBeTruthy()
   const row = screen.getAllByText('/pricing')
     .map((cell) => cell.closest('tr') as HTMLElement | null)
     .find((candidate): candidate is HTMLElement => Boolean(candidate && within(candidate).queryByText('chatgpt.com')))
@@ -346,14 +346,14 @@ test('social table collapses to top 25 with show-all toggle and surfaces Other-s
   renderActivitySection()
 
   await waitFor(() => {
-    expect(screen.getByText('Source / medium')).toBeTruthy()
+    expect(screen.getByText('Social sources')).toBeTruthy()
   })
 
   // Top-N + Other notice: 30 sources, top 6 plotted, 24 collapsed into Other
   expect(screen.getByText(/Showing top 6 sources · 24 more grouped as Other/)).toBeTruthy()
 
-  // Source / medium table starts collapsed at the default limit of 25
-  const breakdownCard = screen.getByText('Source / medium').closest('div.surface-card') as HTMLElement
+  // Social sources table starts collapsed at the default limit of 25
+  const breakdownCard = screen.getByText('Social sources').closest('div.surface-card') as HTMLElement
   expect(breakdownCard).toBeTruthy()
   const breakdown = within(breakdownCard)
   expect(breakdown.getByText('Top 25 of 30')).toBeTruthy()


### PR DESCRIPTION
The Activity tab named things the way the pipeline does, not the way a reader does. "Known AI referrers by source", "Source / medium" and "Channel breakdown" are our vocabulary and GA4 field names.

## Renames

| Before | After |
|---|---|
| Channel breakdown | Sessions by channel |
| Known AI referrers by source | Where AI visitors came from |
| Known AI referrers by landing page | Pages AI visitors landed on |
| Social sessions over time | Social sessions |
| Social media visits | Visits from social |
| Source / medium | Social sources |
| Known AI referrers (lower bound) | Visitors from AI (at least) |

The section heading was already "Traffic by channel", so the chart inside it takes "Sessions by channel" rather than repeating its parent.

## Top Landing Pages

It was the only page table on the tab with no controls: every row rendered, no cap, no filter. It now uses the same `useClientTable` + `DataTableSearch` + `DataTablePagination` that the AI landing-page table three hundred lines above already uses, capped at 10 per page.

Sorting resets to page one. Without that, sorting while on a later page can strand the reader on a page that no longer exists.

## Deliberately unchanged

Tooltips keep their GA4 field names. They explain how a number was derived, and renaming `sessionDefaultChannelGrouping` there would make the method unverifiable.

"Server activity" keeps its name. It lists connected sources and is already plain language.

## Verification

`pnpm verify` green: 703 test files, 9,195 tests. Seven test selectors updated to match the new strings.

No version bump: 65 changed lines, under the 100-line threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)