### PR TITLE
Set the crawl budgets so the page budget is the one that binds

### DIFF
--- a/packages/canonry/src/execute-site-audit.ts
+++ b/packages/canonry/src/execute-site-audit.ts
@@ -330,6 +330,83 @@ function partitionDeadLinks(deadLinks: SiteCrawlReport['deadLinks']): {
  * reads publish only complete snapshots as current; an explicitly selected
  * partial run remains inspectable without replacing the last known-good graph.
  */
+
+/**
+ * The crawl budgets that go with a page budget.
+ *
+ * The engine defaults are sized for a general-purpose crawl and are the reason
+ * asking for 1,000 pages used to yield 140: `maxPages` bounds how many URLs are
+ * ADMITTED to the frontier, while `maxBytes` bounds how many are actually
+ * FETCHED out of it. A site serving ~745 KB of decompressed HTML per page
+ * exhausts the 100 MB default after ~140 pages, whatever the page budget says,
+ * and gzip does not help because the cap counts decompressed bytes.
+ *
+ * Two failures follow from that, and both are worse than the truncation:
+ *
+ * - The budget latch is first-write-wins, so a soft admission-side reason
+ *   (`max-query-variants`, hit while seeding the sitemap) masks the real
+ *   byte stop. `isHardFetchStop()` stays false and the crawler keeps issuing
+ *   real requests at the audited site while discarding every response, until
+ *   the duration cap ends the run. The "safe partial audit" was the LEAST
+ *   polite mode we had.
+ * - The run then records the masked reason, so the database misreports why it
+ *   stopped.
+ *
+ * Sizing every budget from `maxPages` is what avoids both: with the byte cap
+ * out of reach, the crawl ends because it ran out of admitted URLs, which is a
+ * stop we can report honestly.
+ */
+
+/**
+ * Why the crawl actually stopped.
+ *
+ * `terminationReason` cannot be trusted on its own: the engine's budget latch
+ * is first-write-wins, so a soft admission-side reason hit while seeding the
+ * sitemap masks whatever really ended the fetch loop. A byte-capped run was
+ * being recorded as `max-query-variants`, which sent anyone reading the row
+ * looking at the wrong budget entirely.
+ *
+ * The summary carries the counters to settle it, so prefer the measurement
+ * over the label and fall back to the label only when nothing was exhausted.
+ */
+export function reportedTermination(summary: {
+  terminationReason: string | null
+  bytesRead?: number
+  elapsedMs?: number
+  fetchesStarted?: number
+  limits?: { maxBytes?: number; maxDurationMs?: number; maxFetches?: number }
+}): string {
+  const limits = summary.limits
+  if (limits) {
+    if (limits.maxBytes && (summary.bytesRead ?? 0) >= limits.maxBytes) return 'max-bytes'
+    if (limits.maxDurationMs && (summary.elapsedMs ?? 0) >= limits.maxDurationMs) return 'max-duration'
+    if (limits.maxFetches && (summary.fetchesStarted ?? 0) >= limits.maxFetches) return 'max-fetches'
+  }
+  return summary.terminationReason ?? 'complete'
+}
+
+export function crawlBudgetsFor(maxPages: number): {
+  maxBytes: number
+  maxDurationMs: number
+  maxFetches: number
+  maxQueryVariants: number
+} {
+  return {
+    // 2x the ~745 KB/page measured on a media-heavy production site, so the
+    // byte cap is headroom rather than the thing that stops the crawl.
+    maxBytes: maxPages * 1_500_000,
+    // ~5 pages/s at the engine's default concurrency of 5, doubled for slow
+    // origins, and never below the engine's own 2-minute floor.
+    maxDurationMs: Math.max(120_000, Math.ceil((maxPages / 5) * 1_000 * 2)),
+    // Redirects and dead-link probes cost fetches without producing pages.
+    maxFetches: Math.ceil(maxPages * 1.5),
+    // Raised off the default of 10 because it is an ADMISSION limit: a sitemap
+    // with many query-parameter variants trips it during seeding and latches a
+    // soft reason that then masks whatever really stops the crawl.
+    maxQueryVariants: Math.max(50, Math.ceil(maxPages / 10)),
+  }
+}
+
 export async function executeSiteAudit(
   db: DatabaseClient,
   runId: string,
@@ -695,6 +772,7 @@ export async function executeSiteAudit(
       maxEdges,
       maxDepth: opts.maxDepth ?? null,
     })
+    const budgets = crawlBudgetsFor(maxPages)
     const report: SiteCrawlReport = await runSiteCrawl(crawlRootUrl, {
       mode: 'summary',
       sitemapUrl: opts.sitemapUrl,
@@ -702,6 +780,7 @@ export async function executeSiteAudit(
       maxEdges,
       maxDepth: opts.maxDepth,
       checkDeadLinks: opts.checkDeadLinks ?? false,
+      ...budgets,
       signal: opts.signal,
       onEvent: persistEvent,
     })
@@ -852,7 +931,7 @@ export async function executeSiteAudit(
         maxDepth: opts.maxDepth ?? null,
         checkDeadLinks: opts.checkDeadLinks ?? false,
         complete: crawlSummary.complete,
-        termination: crawlSummary.terminationReason ?? 'complete',
+        termination: reportedTermination(crawlSummary),
         detailsAvailable: true,
         pagesDiscovered: crawlSummary.pagesDiscovered,
         pagesFetched: crawlSummary.pagesFetched,

--- a/packages/canonry/test/site-audit-budgets.test.ts
+++ b/packages/canonry/test/site-audit-budgets.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { crawlBudgetsFor, reportedTermination } from '../src/execute-site-audit.js'
+
+/**
+ * A 1,000-page audit used to return 140 pages, because the engine's 100 MB byte
+ * default is exhausted after ~140 pages of a site serving ~745 KB each — and
+ * the platform never set it. These lock the arithmetic that keeps the page
+ * budget the binding one, and the reporting that says so honestly.
+ */
+describe('crawl budgets', () => {
+  it('gives the byte budget enough headroom that pages, not bytes, bind', () => {
+    // The measured page weight that produced the 140-page ceiling.
+    const HEAVY_PAGE_BYTES = 745_000
+    for (const maxPages of [100, 1_000, 8_717]) {
+      const { maxBytes } = crawlBudgetsFor(maxPages)
+      const pagesAffordable = Math.floor(maxBytes / HEAVY_PAGE_BYTES)
+      expect(pagesAffordable, `${maxPages} pages`).toBeGreaterThanOrEqual(maxPages)
+    }
+  })
+
+  it('would not have saved the old default — the regression is real', () => {
+    // Sanity on the diagnosis itself: the engine default really is too small
+    // for the page budget the dashboard already asks for.
+    const ENGINE_DEFAULT_MAX_BYTES = 100 * 1024 * 1024
+    expect(Math.floor(ENGINE_DEFAULT_MAX_BYTES / 745_000)).toBeLessThan(200)
+    expect(crawlBudgetsFor(1_000).maxBytes).toBeGreaterThan(ENGINE_DEFAULT_MAX_BYTES)
+  })
+
+  it('never drops below the engine floor for a small crawl', () => {
+    expect(crawlBudgetsFor(10).maxDurationMs).toBe(120_000)
+  })
+
+  it('scales the duration with the page budget', () => {
+    // 8,717 pages at ~5/s is ~29 minutes; the budget must not cut that short.
+    const { maxDurationMs } = crawlBudgetsFor(8_717)
+    expect(maxDurationMs).toBeGreaterThan(29 * 60 * 1_000)
+  })
+
+  it('lifts maxQueryVariants off the default that caused the masking', () => {
+    // 10 is an ADMISSION limit reached while seeding a large sitemap; latching
+    // it first is what hid the real byte stop.
+    expect(crawlBudgetsFor(1_000).maxQueryVariants).toBeGreaterThan(10)
+  })
+})
+
+describe('reported termination', () => {
+  const limits = { maxBytes: 1_000, maxDurationMs: 60_000, maxFetches: 500 }
+
+  it('reports a byte stop as a byte stop even when a soft reason latched first', () => {
+    // Exactly the live case: the run recorded max-query-variants for a crawl
+    // that actually exhausted its byte budget.
+    expect(reportedTermination({
+      terminationReason: 'max-query-variants',
+      bytesRead: 1_000, elapsedMs: 30_000, fetchesStarted: 140, limits,
+    })).toBe('max-bytes')
+  })
+
+  it('reports a duration stop when the clock ran out', () => {
+    expect(reportedTermination({
+      terminationReason: 'max-pages', bytesRead: 10, elapsedMs: 60_000, fetchesStarted: 10, limits,
+    })).toBe('max-duration')
+  })
+
+  it('keeps the engine reason when nothing was exhausted', () => {
+    expect(reportedTermination({
+      terminationReason: 'max-pages', bytesRead: 10, elapsedMs: 10, fetchesStarted: 10, limits,
+    })).toBe('max-pages')
+  })
+
+  it('reports complete when the crawl simply finished', () => {
+    expect(reportedTermination({ terminationReason: null, limits })).toBe('complete')
+  })
+
+  it('falls back safely when the engine reports no counters', () => {
+    expect(reportedTermination({ terminationReason: 'max-pages' })).toBe('max-pages')
+  })
+})


### PR DESCRIPTION
A dashboard site audit asks for 1,000 pages and returns ~140 on any site whose pages are heavy.

Two runs against the same sitemap made it unambiguous: raising discovery from 1,000 to 6,788 URLs left the audited count at **141 and 140**.

## Cause

`maxPages` bounds how many URLs are **admitted** to the frontier. `maxBytes` bounds how many are actually **fetched** out of it. The engine's 100 MB default is exhausted after ~140 pages of a site serving ~745 KB of decompressed HTML each, and the platform never set it:

```
104,857,600 bytes / 745,000 per page = 140 pages     observed: 140, 141
```

gzip doesn't help; the cap counts decompressed bytes. 100 MB is a sensible general-purpose default, which is why this is fixed at the call site rather than in `aeo-audit` — the platform is the layer that knows how many pages it asked for.

## The part that matters more than the truncation

The budget latch is first-write-wins. A soft admission-side reason (`max-query-variants`, hit while seeding a large sitemap) latched first, so when the byte stop fired it was swallowed, `isHardFetchStop()` stayed false, and the crawler **kept issuing real requests at the audited site and discarding every response** until the duration cap ended the run.

On the live case that was ~91 seconds of traffic sent to a customer's origin for nothing. The "safe partial audit" was the least polite mode we had.

## What changed

Every crawl budget is now derived from `maxPages`, sized so the byte cap is headroom rather than the binding constraint. With the fetch loop able to drain, the crawl ends because it ran out of admitted URLs — a stop that can be reported honestly.

`maxQueryVariants` is lifted off its default of 10 for the same reason: it's an admission limit a large sitemap trips during seeding, and latching it first is what hid the real cause.

Termination is derived from the engine's own counters instead of copied from the masked latch, so a byte-capped run stops recording itself as `max-query-variants`.

## Scope

No migration, no new columns — this reads counters the crawl summary already carries. 10 tests covering the budget arithmetic against the measured page weight, the duration floor, and each termination case including the exact live one.

Still open, tracked separately: `topRecommendations` is a literal `[]` and `prioritizedFixes` a literal `Improve ${factorName}` map, both since #976. Those are independent of page count and unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)