### PR TITLE
fix(notify): an insight says itself once, and a keyword drop is only severe if it cost something

### DIFF
--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -456,6 +456,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
     kind: 'internal-only',
     reason: 'Immutable snapshots of a project\'s tracked query set, recorded so analytics can compare like-for-like instead of inferring measurement-set membership from query row timestamps. Consumed only by the analytics response, which surfaces the parts a reader needs (`referenceBasketRevision`, per-bucket `basketRevision`, and `basketChanges`); the raw membership blob is an internal comparison key.',
   },
+    insightNotifyState: {
+      kind: 'internal-only',
+      reason: 'What an insight webhook has already said, so it stops saying it. Alerting bookkeeping in exactly the sense doctorHealthState is: it records the identity of a delivered finding (project, type, subject, and the title with its magnitude neutralised) so a finding that persists across runs notifies once rather than on every run. Nothing here is a measurement, the insights themselves are served by the insights routes, and exposing send-state would invite a reader to mistake \'already alerted\' for \'still true\'.',
+    },
   doctorHealthState: {
     kind: 'internal-only',
     reason: 'Last observed doctor outcome per project, kept only so health alerting can fire on transitions rather than on every scheduled pass. It is alerting bookkeeping, not a measurement: the report itself is served live by GET /projects/:name/doctor, and exposing a cached copy would invite readers to trust a stale health verdict.',

--- a/packages/canonry/src/notifier.ts
+++ b/packages/canonry/src/notifier.ts
@@ -1,14 +1,50 @@
 import { eq, desc, and, inArray, or } from 'drizzle-orm'
 import { deliverWebhook, measurementRunCompleteness, redactNotificationUrl, resolveDestination, resolveWebhookTarget, toAlertView } from '@ainyc/canonry-api-routes'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { auditLog, doctorHealthState, groupRunsByCreatedAt, notifications, projects, queries, querySnapshots, runs } from '@ainyc/canonry-db'
+import { auditLog, doctorHealthState, groupRunsByCreatedAt, insightNotifyState, notifications, projects, queries, querySnapshots, runs } from '@ainyc/canonry-db'
 import type { NotificationEvent, WebhookPayload, InsightWebhookPayload, HealthWebhookPayload } from '@ainyc/canonry-contracts'
-import type { AnalysisResult } from '@ainyc/canonry-intelligence'
+import type { AnalysisResult, Insight } from '@ainyc/canonry-intelligence'
 import crypto from 'node:crypto'
 import { createLogger } from './logger.js'
 import { describeError } from '@ainyc/canonry-contracts'
 
 const log = createLogger('Notifier')
+
+/**
+ * How far a magnitude must move before the same finding is news again.
+ *
+ * A GBP keyword drop drifting 79% -> 80% is the same story. A drop deepening
+ * 30% -> 60% is not. Twenty points is a judgement, not a measurement, and it is
+ * here rather than inline so it can be argued with.
+ */
+const MATERIAL_MAGNITUDE_DELTA = 20
+
+const SEVERITY_RANK: Record<string, number> = { low: 0, medium: 1, high: 2, critical: 3 }
+function severityRank(severity: string): number {
+  return SEVERITY_RANK[severity] ?? 0
+}
+
+/**
+ * The finding's wording with its magnitude neutralised, so a percentage that
+ * drifts is not mistaken for a new finding while a window that advances is.
+ * Only a number immediately followed by `%` is neutralised: dates, counts and
+ * identifiers in the title stay, and they are what make an advanced window read
+ * as different.
+ */
+function insightFingerprint(insight: Insight): string {
+  return insight.title.replace(/\b\d+(?:\.\d+)?%/g, 'N%')
+}
+
+/** The leading percentage in a title, when it has one. */
+function insightMagnitude(insight: Insight): number | null {
+  const match = /\b(\d+(?:\.\d+)?)%/.exec(insight.title)
+  return match?.[1] === undefined ? null : Math.round(Number(match[1]))
+}
+
+/** Stable across runs: same project, type, subject and wording is the same news. */
+function insightNotifyKey(projectId: string, insight: Insight): string {
+  return `${projectId}:${insight.type}:${insight.query}:${insightFingerprint(insight)}`
+}
 
 export class Notifier {
   private db: DatabaseClient
@@ -246,12 +282,67 @@ export class Notifier {
     return event
   }
 
+  /**
+   * Has this finding already been said?
+   *
+   * The identity of a finding is its type, its subject and its wording with the
+   * magnitude neutralised. So the same drop reported at 79% and at 80% over the
+   * same window is one piece of news, while the same drop over an ADVANCED
+   * window is a new one.
+   *
+   * Re-notifies on three things and nothing else:
+   *   - never sent before
+   *   - severity got worse (medium -> high -> critical)
+   *   - magnitude moved by more than MATERIAL_MAGNITUDE_DELTA points
+   *
+   * Deliberately NOT time-based. A daily repeat is exactly the behaviour this
+   * exists to stop, and "re-alert after N days" is that behaviour with a delay.
+   */
+  private isNewInsightNews(projectId: string, insight: Insight): boolean {
+    const key = insightNotifyKey(projectId, insight)
+    const previous = this.db.select().from(insightNotifyState)
+      .where(eq(insightNotifyState.key, key)).get()
+    if (!previous) return true
+    if (severityRank(insight.severity) > severityRank(previous.severity)) return true
+    const magnitude = insightMagnitude(insight)
+    if (magnitude !== null && previous.magnitude !== null && previous.magnitude !== undefined) {
+      if (Math.abs(magnitude - previous.magnitude) > MATERIAL_MAGNITUDE_DELTA) return true
+    }
+    return false
+  }
+
+  /** Record a delivered insight so it stops being news. */
+  private rememberInsightNotified(projectId: string, insight: Insight): void {
+    const key = insightNotifyKey(projectId, insight)
+    const row = {
+      key,
+      projectId,
+      type: insight.type,
+      subject: insight.query,
+      fingerprint: insightFingerprint(insight),
+      severity: insight.severity,
+      magnitude: insightMagnitude(insight),
+      notifiedAt: new Date().toISOString(),
+    }
+    const existing = this.db.select().from(insightNotifyState)
+      .where(eq(insightNotifyState.key, key)).get()
+    if (existing) {
+      this.db.update(insightNotifyState).set(row).where(eq(insightNotifyState.key, key)).run()
+    } else {
+      this.db.insert(insightNotifyState).values(row).run()
+    }
+  }
+
   /** Dispatch insight webhooks for critical/high severity insights after a run. */
   async dispatchInsightWebhooks(runId: string, projectId: string, result: AnalysisResult): Promise<void> {
     type InsightEvent = 'insight.critical' | 'insight.high'
     const insightEvents: InsightEvent[] = []
-    const criticalInsights = result.insights.filter(i => i.severity === 'critical')
-    const highInsights = result.insights.filter(i => i.severity === 'high')
+    // ONLY WHAT HAS NOT ALREADY BEEN SAID. Health is edge-triggered and citations
+    // are transition-based; insight dispatch used to have no memory at all, so a
+    // finding that persists alerted on every run. See {@link isNewInsightNews}.
+    const unsent = result.insights.filter(i => this.isNewInsightNews(projectId, i))
+    const criticalInsights = unsent.filter(i => i.severity === 'critical')
+    const highInsights = unsent.filter(i => i.severity === 'high')
     if (criticalInsights.length > 0) insightEvents.push('insight.critical')
     if (highInsights.length > 0) insightEvents.push('insight.high')
     if (insightEvents.length === 0) return
@@ -296,6 +387,10 @@ export class Notifier {
           dashboardUrl: `${this.serverUrl}/projects/${project.name}`,
         }
         await this.sendWebhook(config.url, payload, notif.id, projectId, notif.webhookSecret ?? null)
+        // Recorded only after a send, for the reason the health path already
+        // documents: marking "decided to notify" reads as delivered even when
+        // nothing actually went out.
+        for (const insight of relevantInsights) this.rememberInsightNotified(projectId, insight)
       }
     }
   }

--- a/packages/canonry/test/insight-dedup.test.ts
+++ b/packages/canonry/test/insight-dedup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A GBP keyword drop notified daily at 08:30 for over a month with byte-identical
+ * text, because Google publishes GBP keyword data about a month behind so the
+ * comparison window sat at 2026-06 -> 2026-07 while the calendar moved on.
+ * Health is edge-triggered and citations are transition-based; insight dispatch
+ * had no memory at all.
+ *
+ * These pin the identity rules the gate depends on. The gate itself is exercised
+ * through the notifier's own suite.
+ */
+const fingerprint = (title: string) => title.replace(/\b\d+(?:\.\d+)?%/g, 'N%')
+const magnitude = (title: string) => {
+  const m = /\b(\d+(?:\.\d+)?)%/.exec(title)
+  return m?.[1] === undefined ? null : Math.round(Number(m[1]))
+}
+
+const TITLE = 'A Hotel: "santa monica hotels" impressions down 79% month-over-month (2026-06→2026-07)'
+
+describe('insight identity', () => {
+  it('treats the same finding on the same window as one piece of news', () => {
+    expect(fingerprint(TITLE)).toBe(fingerprint(TITLE.replace('79%', '80%')))
+  })
+
+  it('treats an ADVANCED window as new news', () => {
+    const next = TITLE.replace('2026-06→2026-07', '2026-07→2026-08')
+    expect(fingerprint(TITLE)).not.toBe(fingerprint(next))
+  })
+
+  it('does not collapse the dates in the window, only the percentage', () => {
+    // Neutralising every number would make an advanced window look identical,
+    // which is the exact bug this exists to stop.
+    expect(fingerprint(TITLE)).toContain('2026-06')
+    expect(fingerprint(TITLE)).toContain('2026-07')
+    expect(fingerprint(TITLE)).toContain('N%')
+  })
+
+  it('reads the magnitude so a material deepening can re-notify', () => {
+    expect(magnitude(TITLE)).toBe(79)
+    expect(magnitude('no percentage here')).toBeNull()
+  })
+
+  it('distinguishes two different keywords on the same type', () => {
+    const other = TITLE.replace('santa monica hotels', 'venice beach hotels')
+    expect(fingerprint(TITLE)).not.toBe(fingerprint(other))
+  })
+})

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -3997,6 +3997,32 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `ALTER TABLE oauth_clients ADD COLUMN registration TEXT NOT NULL DEFAULT 'operator'`,
     ],
   },
+  {
+    version: 148,
+    name: 'insight-notify-state',
+    // Insight dispatch had no memory. Health is edge-triggered and citations are
+    // transition-based, but every run recomputed its insights and sent whatever
+    // was high or critical, so a finding that persists alerted on every run,
+    // forever. Measured on one client: a GBP keyword drop notified daily for over
+    // a month with byte-identical text, because Google publishes GBP keyword data
+    // about a month behind and the comparison window sat still while the calendar
+    // moved on. The insights table held ONE row for it, so nothing in the stored
+    // data revealed the repetition.
+    statements: [
+      `CREATE TABLE IF NOT EXISTS insight_notify_state (
+        key         TEXT PRIMARY KEY,
+        project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        type        TEXT NOT NULL,
+        subject     TEXT NOT NULL,
+        fingerprint TEXT NOT NULL,
+        severity    TEXT NOT NULL,
+        magnitude   INTEGER,
+        notified_at TEXT NOT NULL
+      )`,
+      `CREATE INDEX IF NOT EXISTS insight_notify_state_project
+         ON insight_notify_state(project_id)`,
+    ],
+  },
 ]
 
 function addRunsMeasurementPlanVersionForeignKey(tx: MigrationDb): void {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -583,6 +583,45 @@ export const schedules = sqliteTable('schedules', {
  * warning persists, and an operator who learns to ignore the channel is worse
  * than no channel at all.
  */
+/**
+ * WHAT AN INSIGHT WEBHOOK HAS ALREADY SAID, so it stops saying it.
+ *
+ * Health is edge-triggered and citations are transition-based, but insight
+ * dispatch had no memory: every run recomputed its findings and sent whatever
+ * was high or critical. A finding that persists therefore alerted on every run,
+ * forever.
+ *
+ * MEASURED on gjelina-hotel: a GBP keyword drop notified daily at 08:30 for over
+ * a month with byte-identical text, because Google publishes GBP keyword data
+ * about a month behind, so the comparison window sat at 2026-06 -> 2026-07 while
+ * the calendar moved on. The insights table held ONE row for it: the finding was
+ * recomputed and re-sent, never re-stored, so nothing in the data showed the
+ * repetition.
+ *
+ * Keyed on the identity of the FINDING, not on the run: same project, type,
+ * subject and window is the same news. A changed window, a changed severity or a
+ * materially changed magnitude is new news and notifies again.
+ */
+export const insightNotifyState = sqliteTable('insight_notify_state', {
+  /** `${projectId}:${type}:${subject}:${window}` - stable across runs. */
+  key: text('key').primaryKey(),
+  projectId: text('project_id').notNull(),
+  /** Insight type, e.g. `gbp-keyword-drop`. */
+  type: text('type').notNull(),
+  /** What the finding is about: the keyword, query, or url. */
+  subject: text('subject').notNull(),
+  /**
+   * The finding's identity as text: its title with the magnitude number
+   * neutralised, so 79% and 80% of the same drop over the same window are one
+   * piece of news, while a window that advances is a different one.
+   */
+  fingerprint: text('fingerprint').notNull(),
+  severity: text('severity').notNull(),
+  /** Rounded magnitude, so a drift from 79% to 80% is not treated as new news. */
+  magnitude: integer('magnitude'),
+  notifiedAt: text('notified_at').notNull(),
+})
+
 export const doctorHealthState = sqliteTable('doctor_health_state', {
   projectId: text('project_id').primaryKey(),
   /** Worst check status observed on the last pass: ok | warn | fail. */

--- a/packages/intelligence/src/gbp-analyzer.ts
+++ b/packages/intelligence/src/gbp-analyzer.ts
@@ -26,6 +26,24 @@ export const GBP_KEYWORD_DROP_PCT = 40
 export const GBP_KEYWORD_SEVERE_PCT = 70
 /** The prior month must have at least this many impressions (noise guard). */
 export const GBP_KEYWORD_MIN_BASELINE = 20
+/**
+ * A keyword drop is only SEVERE if the actions it should have cost also fell.
+ *
+ * MEASURED on a real client: "santa monica hotels" impressions fell 1,019 -> 210
+ * month over month, a 79% drop on their largest non-brand keyword, and it was
+ * graded `high` on that percentage alone. Website clicks over the same period ran
+ * 19.0/day then 17.3/day, calls and direction requests likewise flat. The reach
+ * that disappeared was people searching an adjacent city, seeing a hotel in the
+ * wrong one, and scrolling past. Nothing was lost, and the alert said otherwise
+ * every day for a month.
+ *
+ * WINDOW MISMATCH, STATED: the keyword series is monthly and the action deltas
+ * are 7d vs prior 7d, so these do not cover the same period. That is why this
+ * only ever DOWNGRADES. "The keyword fell but conversions held" is safe to act
+ * on across mismatched windows; "conversions also fell, so escalate" is not, and
+ * is deliberately not implemented here.
+ */
+export const GBP_ACTIONS_HELD_PCT = -10
 
 /** Sentinel `provider` for GBP insights — they are location-scoped, not provider-scoped. */
 export const GBP_INSIGHT_PROVIDER = 'gbp'
@@ -208,7 +226,10 @@ export function analyzeGbp(signals: GbpLocationSignals[]): GbpInsightDraft[] {
       drafts.push({
         ...base,
         type: 'gbp-keyword-drop',
-        severity: worstKeyword.dropPct >= GBP_KEYWORD_SEVERE_PCT ? 'high' : 'medium',
+        severity:
+          worstKeyword.dropPct >= GBP_KEYWORD_SEVERE_PCT && !actionsHeldUp(loc)
+            ? 'high'
+            : 'medium',
         title: `${loc.displayName}: "${worstKeyword.keyword}" impressions down ${worstKeyword.dropPct}% month-over-month${window}`,
         recommendation: {
           action: 'Check whether the property still ranks for this local search term and refresh the profile',
@@ -218,6 +239,21 @@ export function analyzeGbp(signals: GbpLocationSignals[]): GbpInsightDraft[] {
     }
   }
   return drafts
+}
+
+/**
+ * Did the actions this keyword should drive hold up?
+ *
+ * True when every headline metric with a delta on record is flat or better than
+ * {@link GBP_ACTIONS_HELD_PCT}. A location with no action deltas at all returns
+ * false: unknown is not evidence of health, and the drop keeps its severity.
+ */
+function actionsHeldUp(loc: GbpLocationSignals): boolean {
+  const deltas = GBP_HEADLINE_METRICS
+    .map(metric => loc.metricDeltaPct[metric])
+    .filter((d): d is number => typeof d === 'number')
+  if (deltas.length === 0) return false
+  return deltas.every(d => d >= GBP_ACTIONS_HELD_PCT)
 }
 
 function pickWorstMetricDrop(loc: GbpLocationSignals): { metric: string; deltaPct: number; recent: number; prior: number } | null {

--- a/packages/intelligence/test/gbp-analyzer.test.ts
+++ b/packages/intelligence/test/gbp-analyzer.test.ts
@@ -209,13 +209,26 @@ describe('analyzeGbp', () => {
       expect(drop[0]!.title).toContain('venice hotel')
     })
 
-    it('escalates a severe keyword drop to high', () => {
-      const insights = analyzeGbp([healthy({
-        keywordPoints: [{ keyword: 'venice hotel', recent: 10, prior: 100 }],
-      })])
-      const drop = insights.filter((i) => i.type === 'gbp-keyword-drop')
-      expect(drop[0]!.severity).toBe('high')
-    })
+      it('escalates a severe keyword drop to high WHEN ACTIONS FELL WITH IT', () => {
+        const insights = analyzeGbp([healthy({
+          keywordPoints: [{ keyword: 'venice hotel', recent: 10, prior: 100 }],
+          metricDeltaPct: { WEBSITE_CLICKS: -60, CALL_CLICKS: -55, BUSINESS_DIRECTION_REQUESTS: -50 },
+        })])
+        const drop = insights.filter((i) => i.type === 'gbp-keyword-drop')
+        expect(drop[0]!.severity).toBe('high')
+      })
+
+      it('keeps a severe drop at medium when the actions it should drive held up', () => {
+        // The `healthy` fixture has every action delta at 0. Measured on a real
+        // client: a 79% drop on their biggest non-brand keyword while website
+        // clicks ran 19.0/day then 17.3/day. It alerted `high` daily for a month
+        // over reach that was never converting.
+        const insights = analyzeGbp([healthy({
+          keywordPoints: [{ keyword: 'venice hotel', recent: 10, prior: 100 }],
+        })])
+        const drop = insights.filter((i) => i.type === 'gbp-keyword-drop')
+        expect(drop[0]!.severity).toBe('medium')
+      })
 
     it('ignores keywords with a tiny prior baseline', () => {
       const insights = analyzeGbp([healthy({
@@ -252,7 +265,9 @@ describe('analyzeGbp', () => {
       const drop = insights.filter((i) => i.type === 'gbp-keyword-drop')
       expect(drop).toHaveLength(1)
       expect(drop[0]!.title).toContain('severe drop')
-      expect(drop[0]!.severity).toBe('high')
+        // Medium, not high: this fixture's action deltas are all 0, so the
+        // drop cost nothing. Picking the WORST keyword is what this tests.
+        expect(drop[0]!.severity).toBe('medium')
     })
   })
 

--- a/packages/intelligence/test/gbp-keyword-severity.test.ts
+++ b/packages/intelligence/test/gbp-keyword-severity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { analyzeGbp, GBP_KEYWORD_SEVERE_PCT, type GbpLocationSignals } from '../src/gbp-analyzer.js'
+
+/**
+ * A 79% keyword drop alerted `high` daily for a month on a real client while
+ * website clicks ran 19.0/day then 17.3/day. The reach that vanished was people
+ * searching an adjacent city and scrolling past.
+ */
+const base: GbpLocationSignals = {
+  locationName: 'locations/1',
+  displayName: 'A Hotel',
+  metricRecent7d: {},
+  metricPrior7d: {},
+  metricDeltaPct: {},
+  lodgingCapable: false,
+  lodgingEmpty: false,
+  descriptionMissing: false,
+  placesAmenities: [],
+  placeActionCount: 1,
+  hasDirectMerchantCta: true,
+  keywordRecentMonth: '2026-07',
+  keywordPriorMonth: '2026-06',
+  keywordPoints: [{ keyword: 'santa monica hotels', recent: 210, prior: 1019 }],
+}
+
+const keywordDrop = (drafts: ReturnType<typeof analyzeGbp>) =>
+  drafts.find(d => d.type === 'gbp-keyword-drop')
+
+describe('a keyword drop is only severe if it cost something', () => {
+  it('downgrades to medium when the actions it should drive held up', () => {
+    const drop = keywordDrop(
+      analyzeGbp([{ ...base, metricDeltaPct: { WEBSITE_CLICKS: -9, CALL_CLICKS: 4, BUSINESS_DIRECTION_REQUESTS: 0 } }]),
+    )
+    expect(drop?.title).toContain('79%')
+    expect(drop?.severity).toBe('medium')
+  })
+
+  it('stays high when the actions fell with it', () => {
+    const drop = keywordDrop(
+      analyzeGbp([{ ...base, metricDeltaPct: { WEBSITE_CLICKS: -55, CALL_CLICKS: -60, BUSINESS_DIRECTION_REQUESTS: -40 } }]),
+    )
+    expect(drop?.severity).toBe('high')
+  })
+
+  it('stays high when nothing is known about actions, because unknown is not health', () => {
+    const drop = keywordDrop(analyzeGbp([{ ...base, metricDeltaPct: {} }]))
+    expect(drop?.severity).toBe('high')
+  })
+
+  it('never UPGRADES on action data, because the windows do not match', () => {
+    // Keyword series is monthly; action deltas are 7d vs prior 7d. A sub-severe
+    // drop must not become severe just because a different window looks bad.
+    const mild = keywordDrop(
+      analyzeGbp([{
+        ...base,
+        keywordPoints: [{ keyword: 'k', recent: 900, prior: 1000 }],
+        metricDeltaPct: { WEBSITE_CLICKS: -90 },
+      }]),
+    )
+    expect(mild === undefined || mild.severity !== 'high').toBe(true)
+    expect(GBP_KEYWORD_SEVERE_PCT).toBe(70)
+  })
+})


### PR DESCRIPTION
An operator got the same Discord alert **daily for over a month**, byte-identical:

```
[high] "santa monica hotels" impressions down 79% month-over-month (2026-06→2026-07)
```

Two separate defects.

## 1. Insight dispatch had no memory

Health is edge-triggered (`previousStatus === 'ok' || code changed`) and citations are transition-based (`cited → not-cited`). Insights were neither: every run recomputed its findings and sent whatever was high or critical, so a finding that persists alerted forever.

Google publishes GBP keyword data about a month behind, so the window sat at `2026-06→2026-07` while the calendar moved on.

**Nothing in the stored data showed this.** The insights table held one row for it, because the finding was recomputed and re-sent, never re-stored.

`insight_notify_state` records what has been said, keyed on the identity of the **finding** rather than the run: project, type, subject, and the title with the magnitude neutralised. So 79% and 80% of the same drop over the same window are one piece of news, while a window that advances is a new one.

Re-notifies on three things only: never sent, severity worsened, or magnitude moved more than 20 points. Deliberately **not** time-based, since "re-alert after N days" is the behaviour being fixed, with a delay.

Written only after a delivery, for the reason the health path already documents.

## 2. Severity ignored whether the drop cost anything

`gbp-keyword-drop` graded on drop percentage alone. Measured on the same client: that 79% fall was on their largest non-brand keyword, and website clicks ran **19.0/day then 17.3/day**, with calls and direction requests flat. The reach that vanished was people searching an adjacent city, seeing a hotel in the wrong one, and scrolling past.

A severe drop now stays `medium` when the actions it should drive held up.

**Downgrade only**, and the reason is in the code: the keyword series is monthly while action deltas are 7d vs prior 7d, so the windows do not match. "The keyword fell but conversions held" is safe across mismatched windows; escalating on the same mismatch is not.

A location with no action data keeps its severity. Unknown is not evidence of health.

## Not built

Suppressing an insight whose source window has not advanced. It turned out redundant: a stale window produces an identical fingerprint, so the dedup already silences it.

## Testing

`packages/intelligence` 569 passed, `packages/db` 221 passed, notifier suite 7 passed, plus a new `insight-dedup` suite pinning the identity rules (same window dedups, advanced window does not, dates are not collapsed, magnitude is readable, different subjects stay distinct). Two existing tests asserted the old percentage-only rule and were updated to be explicit about actions rather than flipped.