### PR TITLE
fix(web): design the one-sweep state, and stop shouting absence

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -477,7 +477,7 @@ export function RootLayout() {
   // Derive breadcrumb label from current location
   const breadcrumbLabel = (() => {
     const path = location.pathname
-    if (path === '/') return 'Portfolio'
+    if (path === '/') return null
     if (path === '/projects') return 'Projects'
     if (path === '/runs') return 'Runs'
     if (path === '/history') return 'History'
@@ -491,8 +491,10 @@ export function RootLayout() {
       const segments = path.split('/').filter(Boolean)
       const projectId = segments[1]
       if (projectId && safeDashboard) {
-        const projectVm = safeDashboard.projects.find(p => p.project.id === projectId)
-        if (projectVm) return projectVm.project.name
+        const projectVm = safeDashboard.projects.find(
+          (p) => p.project.name === projectId || p.project.id === projectId,
+        )
+        if (projectVm) return projectVm.project.displayName || projectVm.project.name
       }
       return 'Project'
     }
@@ -703,7 +705,7 @@ export function RootLayout() {
       )}
 
       {/* ── Main area ── */}
-      <div className="main-area">
+      <div className={agentBarVisible ? 'main-area pb-24' : 'main-area'}>
         {/* Topbar */}
         <header className="topbar">
           <div className="topbar-left">
@@ -731,10 +733,14 @@ export function RootLayout() {
             </div>
             <nav className="breadcrumb" aria-label="Breadcrumb">
               <Link to="/">
-                Home
+                Portfolio
               </Link>
-              <ChevronRight className="breadcrumb-sep size-3" />
-              <span className="breadcrumb-current">{breadcrumbLabel}</span>
+              {breadcrumbLabel ? (
+                <>
+                  <ChevronRight className="breadcrumb-sep size-3" />
+                  <span className="breadcrumb-current">{breadcrumbLabel}</span>
+                </>
+              ) : null}
             </nav>
           </div>
 
@@ -755,7 +761,7 @@ export function RootLayout() {
               </span>
             </div>
             <Button
-              className="nav-toggle"
+              className="nav-toggle lg:hidden"
               variant="secondary"
               size="icon"
               type="button"

--- a/apps/web/src/components/project/MentionShare.tsx
+++ b/apps/web/src/components/project/MentionShare.tsx
@@ -64,10 +64,12 @@ export function mentionClassFigures(
   if (breakdown.snapshotsWithAnswerText === 0) {
     return { headline: 'No answers', numeric: false, detail: 'no answer text in this run', showRows: false }
   }
-  // A project-only denominator is never rendered as a 100% share chart.
+  // A project-only denominator is never rendered as a 100% share chart. The
+  // headline states the situation; it is not a control, so it never carries
+  // the action's name — the panel's "+ Add competitor" button owns that.
   if (!opts.hasCompetitors) {
     return {
-      headline: 'Add competitors',
+      headline: 'No competitors tracked',
       numeric: false,
       detail: `you were named in ${breakdown.projectMentionSnapshots} of ${breakdown.snapshotsWithAnswerText} answers`,
       showRows: false,

--- a/apps/web/src/components/project/SiteHealthSection.tsx
+++ b/apps/web/src/components/project/SiteHealthSection.tsx
@@ -1998,20 +1998,22 @@ export function SiteHealthSection({
         </div>
 
         <div className="flex flex-wrap items-start gap-2">
-          <label className="grid gap-1 text-xs text-muted">
-            Scan history
-            <select
-              aria-label="View a Site Health scan"
-              value={selectedRunId ?? ''}
-              onChange={(event) => selectRun(event.target.value)}
-              className="h-9 min-w-48 rounded-md border border-base bg-bg px-3 text-sm text-primary outline-none focus:border-strong focus:ring-2 focus:ring-mono-600"
-            >
-              <option value="">Latest scan</option>
-              {selectableScans.map((scan) => (
-                <option key={scan.runId} value={scan.runId}>{scanOptionLabel(scan)}</option>
-              ))}
-            </select>
-          </label>
+          {selectableScans.length > 0 && (
+            <label className="grid gap-1 text-xs text-muted">
+              Scan history
+              <select
+                aria-label="View a Site Health scan"
+                value={selectedRunId ?? ''}
+                onChange={(event) => selectRun(event.target.value)}
+                className="h-9 min-w-48 rounded-md border border-base bg-bg px-3 text-sm text-primary outline-none focus:border-strong focus:ring-2 focus:ring-mono-600"
+              >
+                <option value="">Latest scan</option>
+                {selectableScans.map((scan) => (
+                  <option key={scan.runId} value={scan.runId}>{scanOptionLabel(scan)}</option>
+                ))}
+              </select>
+            </label>
+          )}
 
           {!embedded && (
             <div className="flex items-end gap-2 pt-5">
@@ -2091,7 +2093,7 @@ export function SiteHealthSection({
         </section>
       )}
 
-      {!explicitOnboarding && <div className="flex flex-wrap items-center justify-between gap-3 border-b border-default">
+      {!explicitOnboarding && (crawl?.hasCrawlData || crawl?.legacyAuditAvailable) && <div className="flex flex-wrap items-center justify-between gap-3 border-b border-default">
         <div role="tablist" aria-label="Site Health views" aria-orientation="horizontal" className="flex min-w-0 gap-5">
           {SITE_HEALTH_VIEWS.map((item, index) => (
             <button
@@ -2240,8 +2242,14 @@ export function SiteHealthSection({
                   ? 'A full-site scan has not been run for this project.'
                   : 'Run a scan to discover pages, site sections, and internal links.'}
             </p>
-            {(crawl?.legacyAuditAvailable || explicitOnboarding) && (
+            {(crawl?.legacyAuditAvailable || explicitOnboarding || !embedded) && (
               <div className="mt-4 flex flex-wrap justify-center gap-2">
+                {!explicitOnboarding && !embedded && (
+                  <WriteButton onClick={startScan} disabled={scanBusy}>
+                    {scanBusy ? <LoaderCircle className="size-4 motion-safe:animate-spin" aria-hidden="true" /> : <Play className="size-4" aria-hidden="true" />}
+                    Run scan
+                  </WriteButton>
+                )}
                 {crawl?.legacyAuditAvailable && !explicitOnboarding && (
                   <Button variant="secondary" size="sm" onClick={() => setView('technical')}>View page health</Button>
                 )}

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -23,6 +23,7 @@ import {
 } from '../shared/ChartPrimitives.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { fetchAnalyticsMetrics } from '../../api.js'
+import { formatWholePercent } from '../../lib/format-helpers.js'
 import { STATIC_VISIBILITY_STALE_MS } from '../../queries/query-client.js'
 import {
   buildSelectedTrendRows,
@@ -590,7 +591,7 @@ export function VisibilityTrendSection({
       : CHART_SERIES_COLORS[1]!
   // In by-engine mode the headline is the blended rate across every engine,
   // which no single line on the chart matches — neutralize the swatch (so it
-  // doesn't read as one engine's color) and tag it "avg".
+  // doesn't read as one engine's color) and tag it "engine avg".
   const headlineDotColor = byProviderMode ? CHART_NEUTRAL.textDim : metricColor
   // The x-axis KEY stays `startDate` (monotonic, and what the model-evidence
   // reference lines are positioned by), but the tick a reader sees is resolved
@@ -641,8 +642,8 @@ export function VisibilityTrendSection({
           <div className="visibility-trend-current">
             <span className="visibility-trend-current-dot" style={{ backgroundColor: headlineDotColor }} aria-hidden="true" />
             <span className="visibility-trend-current-label">{currentMetricLabel}</span>
-            {byProviderMode && <span className="visibility-trend-current-qualifier">avg</span>}
-            <span className="visibility-trend-current-value">{latestPct}%</span>
+            {byProviderMode && <span className="visibility-trend-current-qualifier">engine avg</span>}
+            <span className="visibility-trend-current-value">{formatWholePercent(latestPct)}</span>
             {deltaPts !== null && (
               <span
                 className={`visibility-trend-current-delta ${
@@ -675,7 +676,7 @@ export function VisibilityTrendSection({
   } else if (!data || !trend) {
     body = null
   } else {
-    const { rows, series, hasData } = trend
+    const { rows, series, hasData, singleBucket } = trend
     const caption = formatQueryChangeCaption(data.queryChanges)
     if (!hasData) {
       body = (
@@ -692,7 +693,7 @@ export function VisibilityTrendSection({
         </p>
       )
     } else {
-      const srSummary = `${currentMetricLabel} rate across ${rows.length} ${rows.length === 1 ? 'sweep' : 'sweeps'}. Latest ${latestPct}%${
+      const srSummary = `${currentMetricLabel} rate across ${rows.length} ${rows.length === 1 ? 'sweep' : 'sweeps'}. Latest ${latestPct === null ? 'unavailable' : formatWholePercent(latestPct)}${
         deltaPts !== null ? `, ${deltaPts >= 0 ? 'up' : 'down'} ${Math.abs(deltaPts).toFixed(1)} points over the period` : ''
       }.`
       body = (
@@ -723,72 +724,81 @@ export function VisibilityTrendSection({
                       <span className="trend-legend-name">{seriesLabel(key)}</span>
                       <span className="trend-legend-model"><span aria-hidden="true">· </span>{evidenceLabel}</span>
                     </span>
-                    {value !== null && <span className="trend-legend-value">{value}%</span>}
+                    {value !== null && <span className="trend-legend-value">{formatWholePercent(value)}</span>}
                   </li>
                 )
               })}
             </ul>
           )}
-          <div
-            className="visibility-trend-chart"
-            role="img"
-            aria-label={`${currentMetricLabel} trend chart over ${rows.length} ${rows.length === 1 ? 'bucket' : 'buckets'}`}
-          >
-            <ResponsiveContainer width="100%" height="100%">
-              <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
-                <CartesianGrid stroke={CHART_GRID_STROKE} vertical={false} />
-                <XAxis
-                  dataKey="date"
-                  tick={CHART_AXIS_TICK}
-                  tickLine={false}
-                  axisLine={{ stroke: CHART_AXIS_STROKE }}
-                  tickFormatter={bucketTickFormatter}
-                  minTickGap={24}
-                />
-                <YAxis
-                  domain={[0, 100]}
-                  ticks={[0, 25, 50, 75, 100]}
-                  tickFormatter={(v: number) => `${v}%`}
-                  tick={CHART_AXIS_TICK}
-                  tickLine={false}
-                  axisLine={false}
-                  width={40}
-                />
-                <RechartsTooltip
-                  cursor={{ stroke: CHART_AXIS_STROKE, strokeWidth: 1 }}
-                  content={<TrendTooltip metric={metric} mode={effectiveMode} buckets={buckets} />}
-                />
-                {modelEvents.buckets.map(({ bucketStartDate, events }) => (
-                  <ReferenceLine
-                    key={`model-evidence-${bucketStartDate}`}
-                    x={bucketStartDate}
-                    stroke={modelEventMarkerColor(events)}
-                    strokeDasharray="4 4"
-                    strokeWidth={1.5}
-                    ifOverflow="extendDomain"
+          {/* One plotted point cannot make a line: a full-height grid with a
+              stranded dot or two reads as a broken chart, not a baseline. Say
+              what the reader has and what fills it in instead of drawing it. */}
+          {rows.length < 2 || singleBucket ? (
+            <p className="text-sm text-secondary">
+              Baseline captured. The trend line appears after the next sweep.
+            </p>
+          ) : (
+            <div
+              className="visibility-trend-chart"
+              role="img"
+              aria-label={`${currentMetricLabel} trend chart over ${rows.length} ${rows.length === 1 ? 'bucket' : 'buckets'}`}
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+                  <CartesianGrid stroke={CHART_GRID_STROKE} vertical={false} />
+                  <XAxis
+                    dataKey="date"
+                    tick={CHART_AXIS_TICK}
+                    tickLine={false}
+                    axisLine={{ stroke: CHART_AXIS_STROKE }}
+                    tickFormatter={bucketTickFormatter}
+                    minTickGap={24}
                   />
-                ))}
-                {series.map((key, i) => (
-                  <Line
-                    key={key}
-                    type="monotone"
-                    dataKey={key}
-                    name={key}
-                    stroke={seriesColor(key, i)}
-                    strokeDasharray={key === MENTION_SHARE_KEY ? '5 4' : undefined}
-                    strokeWidth={isOverallSeries(key) ? 2.5 : 2}
-                    // A solid marker on every run/bucket point so the readings are visible.
-                    dot={key === MENTION_SHARE_KEY
-                      ? { r: 2.75, fill: 'var(--chart-tooltip-bg)', stroke: seriesColor(key, i), strokeWidth: 1.5 }
-                      : { r: 2.5, fill: seriesColor(key, i), strokeWidth: 0 }}
-                    activeDot={{ r: 4, strokeWidth: 2, stroke: ACTIVE_DOT_RING }}
-                    connectNulls={key !== MENTION_SHARE_KEY}
-                    isAnimationActive={false}
+                  <YAxis
+                    domain={[0, 100]}
+                    ticks={[0, 25, 50, 75, 100]}
+                    tickFormatter={(v: number) => `${v}%`}
+                    tick={CHART_AXIS_TICK}
+                    tickLine={false}
+                    axisLine={false}
+                    width={40}
                   />
-                ))}
-              </ComposedChart>
-            </ResponsiveContainer>
-          </div>
+                  <RechartsTooltip
+                    cursor={{ stroke: CHART_AXIS_STROKE, strokeWidth: 1 }}
+                    content={<TrendTooltip metric={metric} mode={effectiveMode} buckets={buckets} />}
+                  />
+                  {modelEvents.buckets.map(({ bucketStartDate, events }) => (
+                    <ReferenceLine
+                      key={`model-evidence-${bucketStartDate}`}
+                      x={bucketStartDate}
+                      stroke={modelEventMarkerColor(events)}
+                      strokeDasharray="4 4"
+                      strokeWidth={1.5}
+                      ifOverflow="extendDomain"
+                    />
+                  ))}
+                  {series.map((key, i) => (
+                    <Line
+                      key={key}
+                      type="monotone"
+                      dataKey={key}
+                      name={key}
+                      stroke={seriesColor(key, i)}
+                      strokeDasharray={key === MENTION_SHARE_KEY ? '5 4' : undefined}
+                      strokeWidth={isOverallSeries(key) ? 2.5 : 2}
+                      // A solid marker on every run/bucket point so the readings are visible.
+                      dot={key === MENTION_SHARE_KEY
+                        ? { r: 2.75, fill: 'var(--chart-tooltip-bg)', stroke: seriesColor(key, i), strokeWidth: 1.5 }
+                        : { r: 2.5, fill: seriesColor(key, i), strokeWidth: 0 }}
+                      activeDot={{ r: 4, strokeWidth: 2, stroke: ACTIVE_DOT_RING }}
+                      connectNulls={key !== MENTION_SHARE_KEY}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </ComposedChart>
+              </ResponsiveContainer>
+            </div>
+          )}
           <ModelEvidenceSummary
             partition={modelEvents}
             available={modelAttribution !== null}

--- a/apps/web/src/components/shared/AeroBar.tsx
+++ b/apps/web/src/components/shared/AeroBar.tsx
@@ -56,6 +56,9 @@ interface ToolTrail {
 
 interface AeroBarProps {
   projectName: string
+  /** Pretty label for visible copy (sidebar-style `displayName || name`).
+   *  `projectName` stays the slug — it keys API routes and localStorage. */
+  displayName?: string
 }
 
 const STARTER_PROMPTS: Array<{ label: string; prompt: string }> = [
@@ -127,7 +130,7 @@ const SLASH_COMMANDS: Array<SlashCommand> = [
 const PROVIDER_PREF_KEY = (project: string) => `canonry:aero:provider:${project}`
 const SCOPE_PREF_KEY = (project: string) => `canonry:aero:scope:${project}`
 
-export function AeroBar({ projectName }: AeroBarProps) {
+export function AeroBar({ projectName, displayName }: AeroBarProps) {
   const [open, setOpen] = useState(false)
   const [expanded, setExpanded] = useState(false)
   const [messages, setMessages] = useState<AeroMessage[]>([])
@@ -584,7 +587,7 @@ export function AeroBar({ projectName }: AeroBarProps) {
           >
             <span className="flex items-center gap-2">
               <Radio className="h-4 w-4 text-positive-400" aria-hidden="true" />
-              Ask Aero about {projectName}…
+              Ask Aero about {displayName ?? projectName}…
             </span>
           </button>
         )}
@@ -1207,5 +1210,11 @@ export function AeroBarHost() {
     projects.find((p) => p.id === urlSegment) ?? projects.find((p) => p.name === urlSegment)
 
   if (!resolved) return null
-  return <AeroBar key={resolved.name} projectName={resolved.name} />
+  return (
+    <AeroBar
+      key={resolved.name}
+      projectName={resolved.name}
+      displayName={resolved.displayName || resolved.name}
+    />
+  )
 }

--- a/apps/web/src/components/shared/Sparkline.tsx
+++ b/apps/web/src/components/shared/Sparkline.tsx
@@ -50,9 +50,10 @@ export function Sparkline({ points, tone }: { points: number[]; tone: MetricTone
   // of the box rather than being stretched across it.
   const span = Math.max(max - min, MIN_SPAN)
   const low = (max + min) / 2 - span / 2
-  const coordinates = points
-    .map((point, index) => `${xOf(index)},${padding + (1 - (point - low) / span) * plotHeight}`)
-    .join(' ')
+  const yOf = (point: number): number => padding + (1 - (point - low) / span) * plotHeight
+  const coordinates = points.map((point, index) => `${xOf(index)},${yOf(point)}`).join(' ')
+  // Single-reading dot position (see the render branch below).
+  const dotY = yOf(points[0])
 
   return (
     <svg
@@ -66,7 +67,23 @@ export function Sparkline({ points, tone }: { points: number[]; tone: MetricTone
         </clipPath>
       </defs>
       <line className="sparkline-guide" x1={padding} x2={width - padding} y1={height - padding} y2={height - padding} />
-      <polyline clipPath={`url(#${clipId})`} points={coordinates} vectorEffect="non-scaling-stroke" />
+      {points.length === 1 ? (
+        // A one-coordinate polyline draws nothing, so a first-sweep row showed
+        // only the guide line — a blank rectangle with a stray dash. Render the
+        // single reading as a dot instead: a zero-length segment with a round
+        // cap, centred horizontally, at the value's y. The stroke colour still
+        // comes from the `.sparkline-<tone> polyline` CSS, so the tone class
+        // keeps working; the inline style only widens the cap into a visible
+        // marker and defeats the provisional dash pattern (a dashed dot can
+        // render as nothing).
+        <polyline
+          clipPath={`url(#${clipId})`}
+          points={`${width / 2},${dotY} ${width / 2},${dotY}`}
+          style={{ strokeWidth: 7, strokeDasharray: 'none' }}
+        />
+      ) : (
+        <polyline clipPath={`url(#${clipId})`} points={coordinates} vectorEffect="non-scaling-stroke" />
+      )}
     </svg>
   )
 }

--- a/apps/web/src/lib/format-helpers.ts
+++ b/apps/web/src/lib/format-helpers.ts
@@ -124,3 +124,13 @@ export function localTimeZoneLabel(): string {
     .find((part) => part.type === 'timeZoneName')?.value
   return formatTimeZoneLabel(zone, abbrev)
 }
+
+/**
+ * One rounding for every visible percent readout: whole numbers only. The same
+ * metric rendered at mixed precisions in one viewport (43.8% beside 38%) reads
+ * as a contradiction, not as extra accuracy — decimals stay in tooltips and
+ * the sr-only data table, where the exact fraction has room to explain itself.
+ */
+export function formatWholePercent(value: number): string {
+  return `${Math.round(value)}%`
+}

--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -30,7 +30,7 @@ function OverviewProjectCard({
       </div>
       <div className="project-row-primary">
         <div>
-          <p className="project-name">{project.project.name}</p>
+          <p className="project-name">{project.project.displayName || project.project.name}</p>
           <p className="project-domain">{project.project.canonicalDomain}</p>
         </div>
         <p className="project-insight">{project.insight}</p>
@@ -38,7 +38,7 @@ function OverviewProjectCard({
       <div className="project-row-stat">
         <div className="metric-inline-block">
           <p className="metric-inline-label">Mentioned</p>
-          <p className={`metric-inline-value ${project.mentionTone === 'caution' ? 'text-caution-400' : ''}`}>{project.mentionScore}</p>
+          <p className={`metric-inline-value ${project.mentionTone === 'caution' ? 'text-caution-400' : ''}`}>{project.mentionScore}<span className="text-faint">%</span></p>
           {/* `providerCoverage` is only set when the sweep covered a SUBSET of
               configured providers, and it is why the tone shifted to caution:
               the score above is built on incomplete data and is not comparable

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -12,7 +12,7 @@ import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { WriteButton } from '../components/shared/AccessControls.js'
 import { InfoTooltip } from '../components/shared/InfoTooltip.js'
-import { MentionShare } from '../components/project/MentionShare.js'
+import { MentionShare, mentionClassFigures } from '../components/project/MentionShare.js'
 import { CitationBadge } from '../components/shared/CitationBadge.js'
 import { ProviderBadge } from '../components/shared/ProviderBadge.js'
 import { RunRow } from '../components/shared/RunRow.js'
@@ -1115,7 +1115,7 @@ function OverviewBrief({
 
   const headline = (() => {
     if (sweepRunning) return 'A fresh sweep is running now'
-    if (!comparison.hasPreviousRun) return 'Baseline captured. The next sweep will show change.'
+    if (!comparison.hasPreviousRun) return 'Baseline captured'
     if (comparison.querySetChanged) return 'Tracking scope changed since the previous sweep'
     if (mentionDirection === citationDirection) {
       if (mentionDirection === 'steady') return 'Answer mentions and citation coverage held steady'
@@ -1149,7 +1149,7 @@ function OverviewBrief({
             Visibility
             <InfoTooltip text="Each sweep records two independent signals: answer mentions (your brand named in the answer text) and source citations (your domain in the engine's source list). They move separately." />
           </p>
-          <h2 id="overview-brief-title" className="overview-brief-title">{headline}</h2>
+          <h2 id="overview-brief-title" className={`overview-brief-title${!sweepRunning && !comparison.hasPreviousRun ? ' overview-brief-title-quiet' : ''}`}>{headline}</h2>
         </div>
         <p className="overview-brief-updated">
           {latestSweep ? `Updated ${latestSweep.startedAt}` : 'No completed sweep'}
@@ -1243,6 +1243,36 @@ function OverviewDisclosure({
       </summary>
       <div className="overview-disclosure-body">{children}</div>
     </details>
+  )
+}
+
+/**
+ * The competitive panel with zero tracked competitors. The full scaffolding
+ * (class toggle, share figure, gap meters reading "0 / N") implies an all-clear
+ * that nothing measured; instead this states the situation in one row and the
+ * header's "+ Add competitor" button stays the only owner of the action.
+ */
+function CompetitiveEmptyState({
+  summary,
+}: {
+  summary: ProjectCommandCenterVm['mentionShareSummary']
+}) {
+  const figures = mentionClassFigures(summary.breakdown, {
+    hasCompetitors: false,
+    unavailable: summary.unavailable === true,
+    noRun: summary.breakdown.snapshotsTotal === 0 && summary.branded.snapshotsTotal === 0,
+    otherClassHasData: summary.branded.snapshotsTotal > 0,
+  })
+  return (
+    <div className="rounded-xl border border-default bg-surface px-5 py-4">
+      <p className="text-sm text-strong">
+        No competitors tracked
+        <span className="text-faint"> · {figures.detail}</span>
+      </p>
+      <p className="mt-1 text-[13px] text-secondary">
+        Mention and citation gaps need at least one tracked competitor to measure against.
+      </p>
+    </div>
   )
 }
 
@@ -2320,31 +2350,35 @@ function ProjectPageContent({
               </div>
             </div>
 
-            <div className="aeo-hero competitive-summary">
-              <MentionShare
-                key={model.project.name}
-                summary={model.mentionShareSummary}
-                projectLabel={model.project.displayName || model.project.name}
-                competitorDomains={competitorDomains}
-              />
+            {competitorDomains.length === 0 ? (
+              <CompetitiveEmptyState summary={model.mentionShareSummary} />
+            ) : (
+              <div className="aeo-hero competitive-summary">
+                <MentionShare
+                  key={model.project.name}
+                  summary={model.mentionShareSummary}
+                  projectLabel={model.project.displayName || model.project.name}
+                  competitorDomains={competitorDomains}
+                />
 
-              <div className="competitive-gaps">
-                <div className="aeo-hero-rows">
-                  <OverviewMetricRow
-                    label="Mention gaps"
-                    summary={model.mentionGaps}
-                    displayValue={<><span className="text-primary">{model.mentionGaps.value}</span><span className="text-faint"> / {model.queryCounts.total}</span></>}
-                    tooltip="Queries where a competitor was mentioned in the answer but your brand was not."
-                  />
-                  <OverviewMetricRow
-                    label="Citation gaps"
-                    summary={model.gapQueries}
-                    displayValue={<><span className="text-primary">{model.gapQueries.value}</span><span className="text-faint"> / {model.queryCounts.total}</span></>}
-                    tooltip="Queries where a competitor was cited as a source but you were not."
-                  />
+                <div className="competitive-gaps">
+                  <div className="aeo-hero-rows">
+                    <OverviewMetricRow
+                      label="Mention gaps"
+                      summary={model.mentionGaps}
+                      displayValue={<><span className="text-primary">{model.mentionGaps.value}</span><span className="text-faint"> / {model.queryCounts.total}</span></>}
+                      tooltip="Queries where a competitor was mentioned in the answer but your brand was not."
+                    />
+                    <OverviewMetricRow
+                      label="Citation gaps"
+                      summary={model.gapQueries}
+                      displayValue={<><span className="text-primary">{model.gapQueries.value}</span><span className="text-faint"> / {model.queryCounts.total}</span></>}
+                      tooltip="Queries where a competitor was cited as a source but you were not."
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
 
             {addingCompetitor && (
               <div className="mt-4 mb-3 flex gap-2 rounded-lg border border-base bg-bg-elevated/40 p-3">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1342,6 +1342,13 @@
     @apply mt-1 max-w-3xl text-xl font-semibold tracking-[-0.02em] text-primary sm:text-2xl;
   }
 
+  /* MUST stay after `.overview-brief-title`: equal specificity, the later
+     font-size wins. Routine status lines (baseline captured, no comparison
+     yet) speak at body scale; the hero face is reserved for real movement. */
+  .overview-brief-title-quiet {
+    @apply text-base sm:text-lg;
+  }
+
   .overview-brief-updated {
     @apply shrink-0 text-[13px] tabular-nums text-secondary sm:pt-2;
   }
@@ -1672,6 +1679,30 @@
 
   .overview-disclosure-body > .page-section-divider:first-child {
     @apply mt-0 border-t-0 pt-0;
+  }
+
+  /* A closed disclosure is one compact row, so a run of them reads as a
+     divided list instead of three consecutive empty section heroes. The
+     eyebrow and the full `.page-section-divider` spacing return when open;
+     `:not([open])` out-specifies `.page-section-divider` regardless of order. */
+  .overview-disclosure:not([open]) {
+    @apply mt-6 pt-0;
+  }
+
+  .overview-disclosure:not([open]) + .overview-disclosure:not([open]) {
+    @apply mt-0;
+  }
+
+  .overview-disclosure:not([open]) > .overview-disclosure-summary {
+    @apply py-3;
+  }
+
+  .overview-disclosure:not([open]) > .overview-disclosure-summary .eyebrow {
+    @apply hidden;
+  }
+
+  .overview-disclosure:not([open]) > .overview-disclosure-summary .overview-disclosure-title {
+    @apply mt-0;
   }
 
   .inline-disclosure {

--- a/apps/web/test/mention-share-class-toggle.test.tsx
+++ b/apps/web/test/mention-share-class-toggle.test.tsx
@@ -146,7 +146,7 @@ describe('MentionShare class control', () => {
     renderShare({}, [])
     expect(block().textContent).not.toContain('%')
     expect(block().querySelector('.mention-share-rows')).toBeNull()
-    expect(block().querySelector('.mention-share-value-text')?.textContent).toBe('Add competitors')
+    expect(block().querySelector('.mention-share-value-text')?.textContent).toBe('No competitors tracked')
     expect(block().textContent).toContain('you were named in 1 of 32 answers')
   })
 

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -363,6 +363,38 @@ test('a Simple project keeps the existing Overview without advertising advanced 
   expect(html).not.toContain('Latest measurement')
 })
 
+test('zero tracked competitors collapses the competitive panel to one state row', async () => {
+  const fixture = createDashboardFixture({})
+  const entry = fixture.dashboard.projects.find(project => project.project.id === 'project_citypoint')!
+  entry.competitors = []
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData(
+    getApiV1ProjectsByNameQueriesQueryKey({ client: heyClient, path: { name: entry.project.name } }),
+    [],
+  )
+  queryClient.setQueryData(
+    getApiV1ProjectsByNameMeasurementPlanQueryKey({ client: heyClient, path: { name: entry.project.name } }),
+    { active: null },
+  )
+  const router = createAppRouter(queryClient, { initialEntries: ['/projects/project_citypoint'] })
+  await router.load()
+  const html = renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+
+  // The scaffolding (gap meters at "0 / N", class toggle, share figure) implies
+  // an all-clear that nothing measured; a single state row replaces it.
+  expect(html).toContain('No competitors tracked')
+  expect(html).not.toContain('Mention gaps')
+  expect(html).not.toContain('Citation gaps')
+  // The section header's button stays the only owner of the add action.
+  expect(html).toContain('+ Add competitor')
+})
+
 test('project navigation ignores stale Site Health onboarding markers', async () => {
   const html = await renderAt('/projects/project_citypoint/technical-aeo?onboarding=site-health')
   const doc = new DOMParser().parseFromString(html, 'text/html')

--- a/apps/web/test/sparkline.test.tsx
+++ b/apps/web/test/sparkline.test.tsx
@@ -70,4 +70,23 @@ describe('Sparkline', () => {
   it('renders nothing at all for an empty series', () => {
     expect(renderToStaticMarkup(<Sparkline points={[]} tone="neutral" />)).toBe('')
   })
+
+  it('draws a single reading as a visible dot, not a blank box', () => {
+    // With one point the polyline got one coordinate and drew nothing, leaving
+    // only the guide line as a stray dash in the row's reserved chart column —
+    // every trial project's starting state. The single reading now renders as
+    // a zero-length round-capped segment (a dot), centred horizontally, with
+    // the tone class intact so the stroke colour still comes from CSS.
+    const html = renderToStaticMarkup(<Sparkline points={[38]} tone="caution" />)
+    const coords = pointsOf(html)
+
+    expect(html).toContain('sparkline-caution')
+    // Two identical coordinates = the zero-length dot segment.
+    expect(coords).toHaveLength(2)
+    expect(coords[0]).toEqual(coords[1])
+    // On the plot, not on the guide line (which would read as zero).
+    expect(coords[0]!.y).toBeLessThan(GUIDE_Y)
+    // The cap is widened inline into a visible marker.
+    expect(html).toMatch(/stroke-width\s*:\s*7/)
+  })
 })

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -138,8 +138,8 @@ test('defaults to the by-engine view with a per-engine legend, and toggles to al
   expect(allEngines.getAttribute('aria-pressed')).toBe('false')
   expect(screen.getByRole('button', { name: 'All' })).toBeTruthy()
 
-  // The headline is the blended average across engines, tagged "avg".
-  expect(screen.getByText('avg')).toBeTruthy()
+  // The headline is the blended average across engines, tagged "engine avg".
+  expect(screen.getByText('engine avg')).toBeTruthy()
 
   // The legend lists each engine with its latest value (a direct read of the
   // rightmost plotted point — gemini 50% in both buckets, openai 25% then gone).
@@ -149,12 +149,75 @@ test('defaults to the by-engine view with a per-engine legend, and toggles to al
   expect(within(legend).getByText('25%')).toBeTruthy()
 
   // Switching to All engines presses it (no refetch) and drops the per-engine
-  // legend + "avg" tag — the headline now matches the single plotted line.
+  // legend + "engine avg" tag — the headline now matches the single plotted line.
   act(() => { fireEvent.click(allEngines) })
   expect(allEngines.getAttribute('aria-pressed')).toBe('true')
   expect(byEngine.getAttribute('aria-pressed')).toBe('false')
   expect(screen.queryByRole('list', { name: 'Engines' })).toBeNull()
-  expect(screen.queryByText('avg')).toBeNull()
+  expect(screen.queryByText('engine avg')).toBeNull()
+})
+
+test('rounds the headline and legend to whole percents — one precision per viewport', async () => {
+  // Rates chosen to have a fractional percent (43.8 / 37.5) so the rounding is observable.
+  const fractional = TWO_BUCKETS.map(bucket => ({
+    ...bucket,
+    mentionRate: 0.438,
+    byProvider: { gemini: provider(0.25, 0.375) },
+  }))
+  const restore = mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      return jsonResponse(metricsDto(fractional))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restore)
+
+  renderSection()
+
+  const legend = await screen.findByRole('list', { name: 'Engines' })
+  expect(within(legend).getByText('38%')).toBeTruthy()
+  expect(document.querySelector('.visibility-trend-current-value')!.textContent).toBe('44%')
+  // The raw one-decimal values never reach a visible readout (they stay in
+  // tooltips and the sr-only data table, where the exact fraction has room).
+  expect(screen.queryByText('43.8%')).toBeNull()
+  expect(screen.queryByText('37.5%')).toBeNull()
+})
+
+test('replaces the chart with a baseline note until a second sweep exists', async () => {
+  const restore = mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      return jsonResponse(metricsDto([TWO_BUCKETS[0]]))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restore)
+
+  renderSection()
+
+  // One bucket: the per-engine legend still carries the readout, but no
+  // full-height grid renders around a single stranded point.
+  await screen.findByRole('list', { name: 'Engines' })
+  expect(screen.getByText('Baseline captured. The trend line appears after the next sweep.')).toBeTruthy()
+  expect(screen.queryByRole('img', { name: /trend chart/i })).toBeNull()
+})
+
+test('draws the chart once a second bucket exists', async () => {
+  const restore = mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      return jsonResponse(metricsDto(TWO_BUCKETS))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restore)
+
+  renderSection()
+
+  await screen.findByRole('list', { name: 'Engines' })
+  expect(screen.getByRole('img', { name: /trend chart over 2 buckets/i })).toBeTruthy()
+  expect(screen.queryByText('Baseline captured. The trend line appears after the next sweep.')).toBeNull()
 })
 
 test('labels per-engine legend entries from analytics bucket evidence and surfaces categorical model changes', async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.178.0",
+  "version": "4.178.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.178.0",
+  "version": "4.178.1",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.178.0",
+  "version": "4.178.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.178.0",
+  "version": "4.178.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.178.0",
+  "version": "4.178.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
A new instance's first week is one sweep of data, and that state was never designed. The dashboard led with blank sparkline rectangles, a full-height trend grid holding two stranded dots, hero-sized status sentences restated one panel down, gap meters reading a bold 0 / 8 over empty bars as if all-clear had been measured, and three consecutive bare collapsed headings closing the page. That is the first screen every trial user sees.

Twelve fixes from a screenshot audit against DESIGN.md, seven high / five medium:

**Sparse states now instruct instead of announcing absence**
- A one-point sparkline draws a dot instead of a blank 10rem rectangle with a stray dash
- A one-bucket trend skips the chart for a one-line note: baseline captured, the line appears after the next sweep
- Zero tracked competitors renders one state row (what happened, what a gap needs); the header button is the only owner of the add action, and the structurally-zero 0 / N meters are gone
- Site Health with no scans hides the empty history select and the sub-tab row, and gains an in-card Run scan action
- The baseline headline drops to body scale; the comparison panel carries the instruction once

**Consistency**
- Portfolio cards and the Aero pill show displayName, never the slug (the slug still keys routes, API calls, and localStorage)
- Every visible percent renders whole through one shared formatter; the same metric previously read 43.8% / 50% / 37.5% / 38% in a single viewport. Decimals stay in tooltips and sr-only tables
- Closed overview disclosures collapse to single rows stacking as one divided list; full spacing returns when open
- The fixed Aero bar reserves page padding so it no longer overlaps the last row and the footer

**Two outright bugs found by the audit**
- The breadcrumb project lookup matched `project.id` where URLs carry `name`, so every project page read "Home > Project"
- The nav-toggle's `lg:hidden` lives in the components layer and loses the cascade to the Button base's `inline-flex`, showing a hamburger beside the permanent sidebar at desktop width

Verification: `pnpm verify` green (9,351 tests across 713 files), then rebuilt the bundle and re-screenshot a seeded local instance to confirm each fix renders as intended. New targeted tests cover the conditional renders (single-point sparkline, single-bucket trend note, zero-competitor state, renamed fallback headline).

Patch bump 4.178.0 -> 4.178.1 (501 changed lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)