### PR TITLE
feat(web): add advanced measurement portfolio pulse

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementLanding.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementLanding.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import type { MeasurementPortfolioSummaryResponse } from '@ainyc/canonry-api-client'
 
 import { Button } from '../../ui/button.js'
 import {
@@ -21,6 +22,12 @@ export interface AdvancedMeasurementLandingProps {
   onLoadMore?: (cursor: string) => void
   onPropertyExpand?: (targetKey: string) => void
   onRetryEvidence?: () => void
+  portfolioSummary?: MeasurementPortfolioSummaryResponse
+  portfolioSummaryState?: 'loading' | 'ready' | 'error'
+  onRetryPortfolioSummary?: () => void
+  projectTrend?: ReactNode
+  renderGroupLink?: (group: { id: string; name: string }) => ReactNode
+  renderPortfolioLink?: () => ReactNode
   /** Passed straight through so the overview table can link a Property to its own page. */
   renderPropertyLink?: (property: { id: string; name: string }) => ReactNode
   isRunningMeasurement?: boolean
@@ -44,6 +51,12 @@ export function AdvancedMeasurementLanding({
   onLoadMore,
   onPropertyExpand,
   onRetryEvidence,
+  portfolioSummary,
+  portfolioSummaryState,
+  onRetryPortfolioSummary,
+  projectTrend,
+  renderGroupLink,
+  renderPortfolioLink,
   renderPropertyLink,
   isRunningMeasurement,
   isOpeningSetup,
@@ -89,6 +102,12 @@ export function AdvancedMeasurementLanding({
           onLoadMore={onLoadMore}
           onPropertyExpand={onPropertyExpand}
           onRetryEvidence={onRetryEvidence}
+          portfolioSummary={portfolioSummary}
+          portfolioSummaryState={portfolioSummaryState}
+          onRetryPortfolioSummary={onRetryPortfolioSummary}
+          projectTrend={projectTrend}
+          renderGroupLink={renderGroupLink}
+          renderPortfolioLink={renderPortfolioLink}
           renderPropertyLink={renderPropertyLink}
           isRunningMeasurement={isRunningMeasurement}
           isRepublishingSetup={isOpeningSetup}

--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -1,11 +1,13 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import type { KeyboardEvent, ReactNode } from 'react'
+import type { MeasurementPortfolioSummaryResponse } from '@ainyc/canonry-api-client'
 import type { MetricTone } from '../../../view-models.js'
 
 import { InfoTooltip } from '../../shared/InfoTooltip.js'
 import { ToneBadge } from '../../shared/ToneBadge.js'
 import { Button } from '../../ui/button.js'
+import { PortfolioPulse } from './PortfolioPulse.js'
 
 /**
  * `all` is what the API has always accepted and the dashboard never offered, so
@@ -180,6 +182,13 @@ export interface AdvancedMeasurementOverviewProps {
   onLoadMore?: (cursor: string) => void
   onPropertyExpand?: (propertyId: string) => void
   onRetryEvidence?: () => void
+  /** Compact portfolio/group roll-up, pinned to the same displayed run as `report`. */
+  portfolioSummary?: MeasurementPortfolioSummaryResponse
+  portfolioSummaryState?: 'loading' | 'ready' | 'error'
+  onRetryPortfolioSummary?: () => void
+  projectTrend?: ReactNode
+  renderGroupLink?: (group: { id: string; name: string }) => ReactNode
+  renderPortfolioLink?: () => ReactNode
   /**
    * Renders the Property name as a link to its own page. The caller owns
    * routing so this component stays presentational; without it the name is
@@ -600,6 +609,12 @@ export function AdvancedMeasurementOverview({
   onLoadMore,
   onPropertyExpand,
   onRetryEvidence,
+  portfolioSummary,
+  portfolioSummaryState,
+  onRetryPortfolioSummary,
+  projectTrend,
+  renderGroupLink,
+  renderPortfolioLink,
   renderPropertyLink,
 }: AdvancedMeasurementOverviewProps) {
   const usesServerView = report.currentView != null
@@ -675,6 +690,16 @@ export function AdvancedMeasurementOverview({
   )
   const activeSort: AdvancedMeasurementSort = selectedSort
   const normalizedSearch = search.trim().toLocaleLowerCase()
+  const hasPendingOrAppliedSearch = normalizedSearch.length > 0 || Boolean(viewSearch?.trim())
+  // Search narrows the server overview's outcomes but not the portfolio
+  // summary endpoint. Hide the rollup while searching so one filtered
+  // Property is never presented beside a full-portfolio denominator. Both the
+  // local draft and the last parent-applied term matter: when a term is cleared,
+  // the parent remains filtered until the debounce completes.
+  const usesPortfolioPulse = usesServerView && portfolioSummaryState !== undefined && !hasPendingOrAppliedSearch
+  const portfolioPulseShowsOutcomes = usesPortfolioPulse
+    && portfolioSummaryState === 'ready'
+    && portfolioSummary !== undefined
   const filteredProperties = useMemo(() => (
     !usesServerView && normalizedSearch
       ? aggregate.properties.filter(property => property.name.toLocaleLowerCase().includes(normalizedSearch))
@@ -700,7 +725,7 @@ export function AdvancedMeasurementOverview({
       ?? (unavailableProperties > 0
         ? `${unavailableProperties} ${unavailableProperties === 1 ? 'property is' : 'properties are'} unavailable.`
         : flaggedResultsTotal > 0
-          ? `${flaggedResultsTotal} flagged ${flaggedResultsTotal === 1 ? 'result needs' : 'results need'} review.`
+          ? `${flaggedResultsTotal} ambiguous source-to-Property ${flaggedResultsTotal === 1 ? 'match' : 'matches'}.`
           : null)
   // Slot progress is only informative while the measurement hasn't reached a
   // terminal state — a completed run always has completedSlots === totalSlots,
@@ -820,6 +845,20 @@ export function AdvancedMeasurementOverview({
         </div>
       </div>
 
+      {usesPortfolioPulse ? (
+        <PortfolioPulse
+          summary={isViewLoading ? undefined : portfolioSummary}
+          state={isViewLoading ? 'loading' : portfolioSummaryState}
+          outcomes={isViewLoading ? undefined : report.currentView?.outcomes}
+          projectTrend={report.currentView?.scope.kind === 'all' ? projectTrend : undefined}
+          onRetry={onRetryPortfolioSummary}
+          onSelectGroup={groupKey => handleGroupChange(groupKey)}
+          onOpenPortfolio={() => handleGroupChange(ALL_PROPERTIES)}
+          renderGroupLink={renderGroupLink}
+          renderPortfolioLink={renderPortfolioLink}
+        />
+      ) : null}
+
       {!isViewLoading && showShareOfVoice ? <CompetitorShareOfVoice values={aggregate.shareOfVoice ?? []} /> : null}
 
       {!isViewLoading ? <section aria-labelledby="advanced-measurement-properties-title">
@@ -832,7 +871,7 @@ export function AdvancedMeasurementOverview({
         </div>
         {/* Directly under the count it partitions, so the unit is stated once
             and the row visibly sums to it. */}
-        {report.currentView?.outcomes ? <OutcomeCounts outcomes={report.currentView.outcomes} /> : null}
+        {!portfolioPulseShowsOutcomes && report.currentView?.outcomes ? <OutcomeCounts outcomes={report.currentView.outcomes} /> : null}
         <div className="overflow-x-auto rounded-md border border-default">
           <table className="evidence-table min-w-[720px]">
             <caption className="sr-only">Property measurement results</caption>
@@ -947,13 +986,13 @@ export function AdvancedMeasurementOverview({
       </section> : <div className="h-44 animate-pulse rounded-md bg-surface-subtle" aria-label="Updating Property results" />}
 
       {!isViewLoading && !normalizedSearch && flaggedResultsTotal > 0 ? (
-        <section aria-label="Flagged results" className="border-t border-default pt-4">
+        <section aria-label="Ambiguous source-to-Property matches" className="border-t border-default pt-4">
           <details>
-            <summary className="cursor-pointer text-sm font-medium text-heading">Flagged results ({flaggedResultsTotal})</summary>
+            <summary className="cursor-pointer text-sm font-medium text-heading">Ambiguous matches ({flaggedResultsTotal})</summary>
             <ul className="mt-3 space-y-3">
               {report.flaggedResults.slice(0, flaggedLimit).map(result => (
                 <li key={result.id} className="flex flex-wrap items-start gap-2 text-sm">
-                  <ToneBadge tone={result.tone}>Flagged</ToneBadge>
+                  <ToneBadge tone={result.tone}>Ambiguous</ToneBadge>
                   <span className="font-medium text-heading">{result.property}</span>
                   <span className="text-secondary">{result.summary}</span>
                 </li>
@@ -961,12 +1000,12 @@ export function AdvancedMeasurementOverview({
             </ul>
             {flaggedLimit < report.flaggedResults.length ? (
               <div className="mt-3 flex items-center gap-3 text-sm text-secondary">
-                <span>Showing details for {report.flaggedResults.slice(0, flaggedLimit).reduce((total, result) => total + (result.count ?? 1), 0)} of {flaggedResultsTotal} flagged results</span>
+                <span>Showing details for {report.flaggedResults.slice(0, flaggedLimit).reduce((total, result) => total + (result.count ?? 1), 0)} of {flaggedResultsTotal} ambiguous matches</span>
                 <Button size="sm" variant="outline" onClick={() => setFlaggedLimit(limit => Math.min(report.flaggedResults.length, limit + FLAGGED_RESULTS_INCREMENT))}>Show 50 more</Button>
               </div>
             ) : loadedFlaggedCount < flaggedResultsTotal ? (
               <div className="mt-3 flex items-center gap-3 text-sm text-secondary">
-                <span>Showing details for {loadedFlaggedCount} of {flaggedResultsTotal} flagged results</span>
+                <span>Showing details for {loadedFlaggedCount} of {flaggedResultsTotal} ambiguous matches</span>
                 {usesServerView && report.currentView!.nextCursor && onLoadMore ? (
                   <Button size="sm" variant="outline" disabled={isLoadingMore} onClick={() => onLoadMore(report.currentView!.nextCursor!)}>
                     {isLoadingMore ? 'Loading…' : isLoadMoreError ? 'Retry loading more Properties' : 'Load more Properties'}

--- a/apps/web/src/components/project/advanced-measurement/PortfolioPulse.tsx
+++ b/apps/web/src/components/project/advanced-measurement/PortfolioPulse.tsx
@@ -1,0 +1,293 @@
+import type {
+  MeasurementOverviewResponse,
+  MeasurementPortfolioSummaryResponse,
+} from '@ainyc/canonry-api-client'
+import type { ReactNode } from 'react'
+
+import { InfoTooltip } from '../../shared/InfoTooltip.js'
+import { ToneBadge } from '../../shared/ToneBadge.js'
+import { Button } from '../../ui/button.js'
+
+type PulseMetric = MeasurementPortfolioSummaryResponse['metrics']['mentionCoverage']
+type PulseOutcomes = MeasurementOverviewResponse['outcomes']
+
+export interface PortfolioPulseProps {
+  summary?: MeasurementPortfolioSummaryResponse
+  state: 'loading' | 'ready' | 'error'
+  outcomes?: PulseOutcomes
+  /** Reuses the existing project-wide trend without implying Group-level history. */
+  projectTrend?: ReactNode
+  onRetry?: () => void
+  onSelectGroup?: (groupKey: string) => void
+  onOpenPortfolio?: () => void
+  renderGroupLink?: (group: { id: string; name: string }) => ReactNode
+  renderPortfolioLink?: () => ReactNode
+}
+
+const unavailableLabels: Record<Extract<PulseMetric, { state: 'unavailable' }>['reason'], string> = {
+  no_completed_run: 'Not measured',
+  plan_v1: 'Update setup',
+  no_population: 'No matching queries',
+  evidence_incomplete: 'Evidence incomplete',
+  not_applicable: 'Not applicable',
+}
+
+function percentage(value: number): string {
+  return `${Math.round(value * 100)}%`
+}
+
+function metricParts(metric: PulseMetric, kind: 'count' | 'coverage'): { value: string; detail?: string } {
+  if (metric.state === 'unavailable') return { value: unavailableLabels[metric.reason] }
+
+  if (kind === 'count') {
+    const value = metric.numerator !== undefined && metric.denominator !== undefined
+      ? `${metric.numerator} of ${metric.denominator}`
+      : String(metric.value)
+    const detail = metric.rate !== undefined
+      ? percentage(metric.rate)
+      : undefined
+    return { value, ...(detail ? { detail } : {}) }
+  }
+
+  return {
+    value: percentage(metric.value),
+    ...(metric.numerator !== undefined && metric.denominator !== undefined
+      ? { detail: `${metric.numerator} of ${metric.denominator} answers` }
+      : {}),
+  }
+}
+
+function PulseMetricValue({ metric, kind = 'coverage', compact = false }: {
+  metric: PulseMetric
+  kind?: 'count' | 'coverage'
+  compact?: boolean
+}) {
+  const parts = metricParts(metric, kind)
+  return (
+    <div>
+      <span className={`${compact ? 'text-sm' : 'font-mono text-2xl'} font-semibold tabular-nums text-heading`}>
+        {parts.value}
+      </span>
+      {parts.detail ? <span className={`block ${compact ? 'text-[11px]' : 'mt-1 text-xs'} text-faint`}>{parts.detail}</span> : null}
+    </div>
+  )
+}
+
+function OutcomeStrip({ outcomes }: { outcomes: PulseOutcomes }) {
+  const entries = [
+    { key: 'both', label: 'Mentioned and cited', count: outcomes.bothSignals, color: 'bg-positive-400' },
+    // The one-signal states are independent categories, not better/worse
+    // statuses. Categorical series colors keep citation from reading as a warning.
+    { key: 'mention', label: 'Mention only', count: outcomes.mentionedOnly, color: 'bg-[var(--chart-series-2)]' },
+    { key: 'citation', label: 'Citation only', count: outcomes.citedOnly, color: 'bg-[var(--chart-series-3)]' },
+    { key: 'neither', label: 'Neither', count: outcomes.neither, color: 'bg-negative-400' },
+    ...(outcomes.notMeasured > 0
+      ? [{ key: 'unmeasured', label: 'Not measured', count: outcomes.notMeasured, color: 'bg-mono-600' }]
+      : []),
+  ] as const
+  const total = entries.reduce((sum, entry) => sum + entry.count, 0)
+
+  if (total === 0) return null
+
+  return (
+    <section aria-labelledby="portfolio-pulse-outcomes" className="border-b border-default pb-5">
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <h3 id="portfolio-pulse-outcomes" className="text-sm font-medium text-heading">Outcomes</h3>
+        <span className="text-xs tabular-nums text-faint">{outcomes.total} {outcomes.total === 1 ? 'Property' : 'Properties'}</span>
+      </div>
+      <div className="flex h-1.5 overflow-hidden rounded-full bg-mono-800" aria-hidden="true">
+        {entries.filter(entry => entry.count > 0).map(entry => (
+          <span
+            key={entry.key}
+            data-outcome={entry.key}
+            className={entry.color}
+            style={{ width: `${(entry.count / total) * 100}%` }}
+          />
+        ))}
+      </div>
+      <dl aria-label="Property outcomes" className="mt-3 grid grid-cols-2 gap-x-5 gap-y-3 sm:grid-cols-5">
+        {entries.map(entry => (
+          <div key={entry.key}>
+            <dt className="text-xs text-secondary">
+              {entry.label}
+              {entry.key === 'unmeasured' ? (
+                <InfoTooltip text="One or both signals missing. Not the same as neither." />
+              ) : null}
+            </dt>
+            <dd className="mt-0.5 font-mono text-base font-semibold tabular-nums text-heading">{entry.count}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  )
+}
+
+function GroupName({
+  id,
+  name,
+  renderGroupLink,
+  onSelectGroup,
+}: {
+  id: string
+  name: string
+  renderGroupLink?: PortfolioPulseProps['renderGroupLink']
+  onSelectGroup?: PortfolioPulseProps['onSelectGroup']
+}) {
+  if (renderGroupLink) return renderGroupLink({ id, name })
+  if (onSelectGroup) {
+    return (
+      <button
+        type="button"
+        className="rounded-sm text-left font-medium text-link outline-none hover:underline focus-visible:ring-2 focus-visible:ring-mono-400"
+        onClick={() => onSelectGroup(id)}
+      >
+        {name}
+      </button>
+    )
+  }
+  return <span className="font-medium text-heading">{name}</span>
+}
+
+function GroupTable({
+  summary,
+  renderGroupLink,
+  onSelectGroup,
+}: Pick<PortfolioPulseProps, 'renderGroupLink' | 'onSelectGroup'> & { summary: MeasurementPortfolioSummaryResponse }) {
+  if (summary.markets.length === 0) {
+    return <p className="py-5 text-sm text-secondary">No Groups configured.</p>
+  }
+
+  return (
+    <section aria-labelledby="portfolio-pulse-groups">
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <h3 id="portfolio-pulse-groups" className="text-sm font-medium text-heading">Groups</h3>
+        <span className="text-xs tabular-nums text-faint">{summary.markets.length}</span>
+      </div>
+      <div className="overflow-x-auto rounded-md border border-default">
+        <table className="evidence-table min-w-[620px]">
+          <caption className="sr-only">Advanced measurement Groups, ordered by the server from weakest mention coverage</caption>
+          <thead>
+            <tr>
+              <th scope="col">Group</th>
+              <th scope="col">Properties</th>
+              <th scope="col">Mention</th>
+              <th scope="col">Citation</th>
+            </tr>
+          </thead>
+          <tbody>
+            {summary.markets.map(group => (
+              <tr key={group.groupKey}>
+                <td>
+                  <GroupName
+                    id={group.groupKey}
+                    name={group.label}
+                    renderGroupLink={renderGroupLink}
+                    onSelectGroup={onSelectGroup}
+                  />
+                </td>
+                <td className="font-mono text-sm tabular-nums text-secondary">{group.propertyCount}</td>
+                <td><PulseMetricValue metric={group.mentionCoverage} compact /></td>
+                <td><PulseMetricValue metric={group.citationCoverage} compact /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function ProjectTrend({ children }: { children?: ReactNode }) {
+  if (!children) return null
+  return (
+    <div className="border-b border-default pb-5">
+      <p className="mb-2 text-xs text-secondary">Project-wide · all tracked queries</p>
+      {children}
+    </div>
+  )
+}
+
+export function PortfolioPulse({
+  summary,
+  state,
+  outcomes,
+  projectTrend,
+  onRetry,
+  onSelectGroup,
+  onOpenPortfolio,
+  renderGroupLink,
+  renderPortfolioLink,
+}: PortfolioPulseProps) {
+  if (state === 'loading') {
+    return (
+      <div className="space-y-5">
+        <section aria-label="Loading Portfolio pulse" className="space-y-4">
+          <div className="h-20 animate-pulse rounded-md bg-surface-subtle" />
+          <div className="h-40 animate-pulse rounded-md bg-surface-subtle" />
+        </section>
+        <ProjectTrend>{projectTrend}</ProjectTrend>
+      </div>
+    )
+  }
+
+  if (state === 'error' || !summary) {
+    return (
+      <div className="space-y-5">
+        <section role="alert" aria-label="Portfolio pulse" className="border-y border-negative-800/40 bg-negative-950/20 py-4 text-sm text-negative">
+          <span>Could not load the portfolio summary.</span>
+          {onRetry ? <Button className="ml-3" type="button" size="sm" variant="outline" onClick={onRetry}>Retry</Button> : null}
+        </section>
+        <ProjectTrend>{projectTrend}</ProjectTrend>
+      </div>
+    )
+  }
+
+  const isGroup = summary.portfolio.groupKey !== null
+  const title = isGroup ? summary.portfolio.label ?? 'Group pulse' : 'Portfolio pulse'
+
+  return (
+    <section aria-labelledby="portfolio-pulse-title" className="space-y-5">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="min-w-0">
+          {isGroup ? (
+            <div className="mb-1 text-xs text-secondary">
+              {renderPortfolioLink ? renderPortfolioLink() : onOpenPortfolio ? (
+                <button type="button" className="rounded-sm text-link outline-none hover:underline focus-visible:ring-2 focus-visible:ring-mono-400" onClick={onOpenPortfolio}>
+                  Portfolio
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 id="portfolio-pulse-title" className="truncate text-lg font-semibold text-heading">{title}</h2>
+            {summary.portfolio.measurementScope === 'spot_check' ? <ToneBadge tone="caution">Spot check</ToneBadge> : null}
+          </div>
+        </div>
+        <span className="text-sm tabular-nums text-secondary">
+          {summary.totalProperties} {summary.totalProperties === 1 ? 'Property' : 'Properties'}
+        </span>
+      </div>
+
+      <dl className="grid border-y border-default sm:grid-cols-3">
+        <div className="py-4 sm:pr-5">
+          <dt className="text-xs font-medium text-secondary">Properties mentioned</dt>
+          <dd className="mt-2"><PulseMetricValue metric={summary.metrics.propertiesMentioned} kind="count" /></dd>
+        </div>
+        <div className="border-t border-default py-4 sm:border-l sm:border-t-0 sm:px-5">
+          <dt className="text-xs font-medium text-secondary">Mentioned answers</dt>
+          <dd className="mt-2"><PulseMetricValue metric={summary.metrics.mentionCoverage} /></dd>
+        </div>
+        <div className="border-t border-default py-4 sm:border-l sm:border-t-0 sm:pl-5">
+          <dt className="text-xs font-medium text-secondary">Cited answers</dt>
+          <dd className="mt-2"><PulseMetricValue metric={summary.metrics.citationCoverage} /></dd>
+        </div>
+      </dl>
+
+      {outcomes ? <OutcomeStrip outcomes={outcomes} /> : null}
+      {!isGroup ? <ProjectTrend>{projectTrend}</ProjectTrend> : null}
+      {!isGroup ? (
+        <GroupTable summary={summary} renderGroupLink={renderGroupLink} onSelectGroup={onSelectGroup} />
+      ) : null}
+    </section>
+  )
+}

--- a/apps/web/src/components/project/advanced-measurement/v2-overview-adapter.ts
+++ b/apps/web/src/components/project/advanced-measurement/v2-overview-adapter.ts
@@ -111,7 +111,7 @@ export function indexV2EvidenceByTarget(
 }
 
 function propertyStatus(row: MeasurementOverviewResponse['properties']['items'][number]): AdvancedMeasurementProperty['status'] {
-  if (row.flags > 0) return { label: 'Review', tone: 'caution' }
+  if (row.flags > 0) return { label: 'Ambiguous match', tone: 'caution' }
   const reasons = [row.mentionCoverage, row.citationCoverage]
     .filter((value): value is Extract<typeof value, { state: 'unavailable' }> => value.state === 'unavailable')
     .map(value => value.reason)
@@ -141,7 +141,7 @@ function reportDate(value?: string): string {
 
 function nextActionText(overview: MeasurementOverviewResponse): string | undefined {
   const count = overview.nextAction.count ?? overview.flags.total
-  if (overview.nextAction.kind === 'review_flags') return `${count} flagged ${count === 1 ? 'result needs' : 'results need'} review.`
+  if (overview.nextAction.kind === 'review_flags') return `${count} ambiguous source-to-Property ${count === 1 ? 'match' : 'matches'}.`
   if (overview.nextAction.kind === 'complete_setup') return 'Finish setup.'
   if (overview.nextAction.kind === 'republish_setup') return 'Setup update required.'
   if (overview.nextAction.kind === 'run_measurement') return 'Ready to measure.'
@@ -232,7 +232,7 @@ export function adaptV2MeasurementOverview({
   const flaggedResults = overview.properties.items.flatMap(row => row.flags > 0 ? [{
     id: `property:${row.targetKey}`,
     property: row.label,
-    summary: `${row.flags} ${row.flags === 1 ? 'result needs' : 'results need'} review.`,
+    summary: `${row.flags} ambiguous source-to-Property ${row.flags === 1 ? 'match' : 'matches'}.`,
     tone: 'caution' as const,
     count: row.flags,
   }] : [])

--- a/apps/web/src/lib/measurement-view-url.ts
+++ b/apps/web/src/lib/measurement-view-url.ts
@@ -19,12 +19,11 @@ export interface MeasurementViewState {
 }
 
 /**
- * All queries, not non-brand. Branded and non-brand answer different questions
- * and are never pooled into one rate, but an operator arriving at the page has
- * not yet said which one he is asking — and defaulting to non-brand silently
- * hid half the basket behind a control he had no reason to touch.
+ * Non-brand is the actionable default. Branded and non-brand answer different
+ * questions, so the first view must not pool them into one headline rate. All
+ * queries remains an explicit option for operators who need that combined scope.
  */
-export const DEFAULT_MEASUREMENT_VIEW: MeasurementViewState = { scope: 'all', queryClass: 'all' }
+export const DEFAULT_MEASUREMENT_VIEW: MeasurementViewState = { scope: 'all', queryClass: 'non-brand' }
 
 const QUERY_CLASSES: readonly MeasurementQueryClass[] = ['all', 'non-brand', 'branded']
 

--- a/apps/web/src/pages/MeasurementPropertyPage.tsx
+++ b/apps/web/src/pages/MeasurementPropertyPage.tsx
@@ -175,8 +175,8 @@ function AnswerSources({ row }: { row: AnswerRow }) {
  *
  * The row above it can only ever say whether this Property was named. It cannot
  * say what the engine actually recommended, and that is the thing an operator
- * opens the row to find out: a "not mentioned" row on a Buckhead query turns
- * out to be an answer recommending two OTHER buildings from the same brand.
+ * opens the row to find out: a "not mentioned" row on a local-market query can
+ * turn out to be an answer recommending two other properties from the brand.
  * None of that is visible in a signal badge or a source count.
  *
  * Fetched per row rather than with the list because an answer runs to several
@@ -732,7 +732,7 @@ function PropertyUrls({ urls }: { urls: readonly string[] }) {
         <div>
           <h2 id="property-urls" className="text-base font-semibold text-heading">
             URLs that count as this Property
-            <InfoTooltip text="A cited source URL is credited to this Property when it matches one of these. The most specific matcher wins, so a URL covered by two Properties at the same specificity is flagged for review instead of being credited to either." />
+            <InfoTooltip text="A cited source URL is credited to this Property when it matches one of these. The most specific matcher wins, so a URL covered by two Properties at the same specificity is recorded as an ambiguous source-to-Property match instead of being credited to either." />
           </h2>
         </div>
         <p className="supporting-copy">{urls.length} configured</p>
@@ -952,7 +952,7 @@ export function MeasurementPropertyPage() {
             </ToneBadge>
           ) : null}
           {selectedRow && selectedRow.flags > 0 ? (
-            <ToneBadge tone="caution">{selectedRow.flags} flagged</ToneBadge>
+            <ToneBadge tone="caution">{selectedRow.flags} ambiguous {selectedRow.flags === 1 ? 'match' : 'matches'}</ToneBadge>
           ) : null}
         </div>
       </div>

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, RefreshCw, Trash2 } from 'lucide-react'
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 
-import { measurementViewSearch, parseMeasurementViewSearch, shouldResetMeasurementView } from '../lib/measurement-view-url.js'
+import { DEFAULT_MEASUREMENT_VIEW, measurementViewSearch, parseMeasurementViewSearch, shouldResetMeasurementView } from '../lib/measurement-view-url.js'
 import { useQueryClient } from '@tanstack/react-query'
 import { RunKinds, RunStatuses } from '@ainyc/canonry-contracts'
 import type { MeasurementOverviewSort } from '@ainyc/canonry-contracts'
@@ -88,6 +88,7 @@ import {
   getApiV1ProjectsByNameGoogleConnectionsOptions,
   getApiV1ProjectsByNameMeasurementOverviewInfiniteOptions,
   getApiV1ProjectsByNameMeasurementPlanOptions,
+  getApiV1ProjectsByNameMeasurementPortfolioSummaryOptions,
   getApiV1ProjectsByNameScheduleOptions,
   getApiV1ProjectsByNameMeasurementReportOptions,
   getApiV1ProjectsByNameMeasurementSetupOptions,
@@ -1703,7 +1704,7 @@ function ProjectPageContent({
     const previous = lastMeasurementPlanIdentity.current
     if (measurementPlanIdentity !== null) lastMeasurementPlanIdentity.current = measurementPlanIdentity
     if (!shouldResetMeasurementView(previous, measurementPlanIdentity)) return
-    setAdvancedMeasurementView({ scope: 'all', queryClass: 'all' })
+    setAdvancedMeasurementView(DEFAULT_MEASUREMENT_VIEW)
     setHasExpandedAdvancedProperty(false)
   }, [measurementPlanIdentity, setAdvancedMeasurementView])
   const advancedMeasurementOverviewQueryInput = {
@@ -1816,6 +1817,27 @@ function ProjectPageContent({
       },
     }
   }, [advancedMeasurementOverviewPagesInconsistent, advancedMeasurementOverviewQuery.data])
+  const advancedMeasurementPortfolioSummaryQuery = useQuery({
+    ...getApiV1ProjectsByNameMeasurementPortfolioSummaryOptions({
+      client: heyClient,
+      path: { name: projectName },
+      query: {
+        queryClass: advancedMeasurementView.queryClass,
+        ...(advancedMeasurementView.scope === 'group' && advancedMeasurementView.groupKey
+          ? { groupKey: advancedMeasurementView.groupKey }
+          : {}),
+        ...(advancedMeasurementDisplayedRunId
+          ? { runId: advancedMeasurementDisplayedRunId }
+          : {}),
+      },
+    }),
+    enabled: tab === 'overview'
+      && Boolean(projectName)
+      && activeMeasurementPlanSchemaVersion === 2
+      && mergedAdvancedMeasurementOverview !== undefined,
+    staleTime: 0,
+    refetchOnMount: 'always',
+  })
   const advancedMeasurementReport = useMemo(() => {
     if (!activeMeasurementPlan) return undefined
     if (activeMeasurementPlan.plan.schemaVersion === 1) {
@@ -1860,6 +1882,11 @@ function ProjectPageContent({
       : advancedMeasurementReportQuery.isError && !hasCachedAdvancedMeasurementReport
         ? 'error' as const
         : 'ready' as const
+  const advancedMeasurementPortfolioSummaryState = advancedMeasurementPortfolioSummaryQuery.data !== undefined
+    ? 'ready' as const
+    : advancedMeasurementPortfolioSummaryQuery.isError
+      ? 'error' as const
+      : 'loading' as const
   const hasActiveVisibilitySweep = (model?.recentRuns ?? []).some(
     r => r.kind === RunKinds['answer-visibility'] && (r.status === RunStatuses.running || r.status === RunStatuses.queued),
   )
@@ -2549,12 +2576,64 @@ function ProjectPageContent({
             )}
             report={advancedMeasurementReport}
             reportState={advancedMeasurementReportState}
+            portfolioSummary={activeMeasurementPlanSchemaVersion === 2
+              ? advancedMeasurementPortfolioSummaryQuery.data
+              : undefined}
+            portfolioSummaryState={activeMeasurementPlanSchemaVersion === 2
+              ? advancedMeasurementPortfolioSummaryState
+              : undefined}
+            onRetryPortfolioSummary={() => { void advancedMeasurementPortfolioSummaryQuery.refetch() }}
+            projectTrend={activeMeasurementPlanSchemaVersion === 2 ? (
+              <VisibilityTrendSection
+                projectName={model.project.name}
+                competitorDomains={competitorDomains}
+                analyticsRevision={latestVisibilityRevision}
+              />
+            ) : undefined}
+            renderGroupLink={activeMeasurementPlanSchemaVersion === 2 && !isEmbed()
+              ? ({ id, name }) => (
+                  <Link
+                    to="/projects/$projectName"
+                    params={{ projectName }}
+                    search={(previous: Record<string, unknown>) => ({
+                      ...previous,
+                      ...measurementViewSearch({
+                        scope: 'group',
+                        groupKey: id,
+                        queryClass: advancedMeasurementView.queryClass,
+                      }),
+                    })}
+                    className="rounded-sm font-medium text-link outline-none hover:underline focus-visible:ring-2 focus-visible:ring-mono-400"
+                  >
+                    {name}
+                  </Link>
+                )
+              : undefined}
+            renderPortfolioLink={activeMeasurementPlanSchemaVersion === 2 && !isEmbed()
+              ? () => (
+                  <Link
+                    to="/projects/$projectName"
+                    params={{ projectName }}
+                    search={(previous: Record<string, unknown>) => ({
+                      ...previous,
+                      ...measurementViewSearch({ scope: 'all', queryClass: advancedMeasurementView.queryClass }),
+                    })}
+                    className="rounded-sm text-link outline-none hover:underline focus-visible:ring-2 focus-visible:ring-mono-400"
+                  >
+                    Portfolio
+                  </Link>
+                )
+              : undefined}
             onOpenSetup={!isEmbed() ? () => {
               void navigate({ to: '/projects/$projectName/portfolio', params: { projectName } })
             } : undefined}
             onRetryReport={() => {
               if (activeMeasurementPlanSchemaVersion === 2) {
-                void Promise.all([advancedMeasurementOverviewQuery.refetch(), advancedMeasurementReportQuery.refetch()])
+                void Promise.all([
+                  advancedMeasurementOverviewQuery.refetch(),
+                  advancedMeasurementReportQuery.refetch(),
+                  advancedMeasurementPortfolioSummaryQuery.refetch(),
+                ])
               }
               else void advancedMeasurementReportQuery.refetch()
             }}

--- a/apps/web/src/queries/query-invalidation.ts
+++ b/apps/web/src/queries/query-invalidation.ts
@@ -21,6 +21,7 @@ export const PROJECT_QUERY_DOMAINS = {
   discovery: 'getApiV1ProjectsByNameDiscover',
   researchRuns: 'getApiV1ProjectsByNameResearchRuns',
   technicalAeo: 'getApiV1ProjectsByNameTechnicalAeo',
+  measurement: 'getApiV1ProjectsByNameMeasurement',
   runs: 'getApiV1ProjectsByNameRuns',
 } as const
 

--- a/apps/web/src/queries/run-invalidations.ts
+++ b/apps/web/src/queries/run-invalidations.ts
@@ -42,6 +42,12 @@ export function invalidateQueriesForRunKind(
 
   switch (kind) {
     case RunKinds['answer-visibility']:
+      // Advanced Measurement snapshots are run-pinned reads. Unlike the
+      // project-wide trend, their keys do not carry `latestVisibilityRevision`,
+      // so a completed sweep must mark the measurement domain stale directly.
+      // This keeps the Overview, Portfolio pulse, and Property evidence on the
+      // same newly-completed run while the page remains mounted.
+      void invalidateProjectQueryDomain(queryClient, 'measurement')
       // No explicit `['analytics-metrics', project]` invalidation here. That
       // key's last segment is `analyticsRevision` (`VisibilityTrendSection`,
       // fed by `latestVisibilityRevision` in `use-project-dashboard.ts`).

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import type { MeasurementPortfolioSummaryResponse } from '@ainyc/canonry-api-client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -17,6 +18,29 @@ function ratio(numerator: number, denominator: number): AdvancedMeasurementMetri
 
 function unavailable(reason: string): AdvancedMeasurementMetric {
   return { numerator: null, denominator: null, reason }
+}
+
+function portfolioSummary(): MeasurementPortfolioSummaryResponse {
+  const coverage = { state: 'available' as const, value: 0.5, numerator: 1, denominator: 2 }
+  return {
+    portfolio: { groupKey: null, label: null, measurementScope: 'full' },
+    measurement: {
+      state: 'complete',
+      displayedRunId: 'run-1',
+      planRevision: 2,
+      completedAt: '2026-08-02T12:00:00.000Z',
+    },
+    queryClass: 'non-brand',
+    metrics: {
+      propertiesMentioned: { state: 'available', value: 1, numerator: 1, denominator: 2, rate: 0.5 },
+      mentionCoverage: coverage,
+      citationCoverage: coverage,
+    },
+    weakestProperties: [],
+    markets: [],
+    totalProperties: 2,
+    truncated: false,
+  }
 }
 
 function property(
@@ -118,14 +142,14 @@ function report(overrides: Partial<AdvancedMeasurementOverviewReport> = {}): Adv
     },
     overall: nonBrand,
     classScopes: { nonBrand, branded },
-    flaggedResults: [{ id: 'flag-1', property: 'Downtown Office', summary: 'One URL needs review.', tone: 'caution' }],
+    flaggedResults: [{ id: 'flag-1', property: 'Downtown Office', summary: 'One ambiguous source-to-Property match.', tone: 'caution' }],
     ...overrides,
   }
 }
 
 /**
- * The default view is All queries, which reads `report.overall`. The base
- * fixture sets `overall: nonBrand`, but a test that overrides
+ * The base fixture uses the non-brand scope for the legacy `overall` fallback,
+ * but a test that overrides
  * `classScopes.nonBrand` replaces only that half — leaving `overall` pointing
  * at the unmodified scope and the override invisible. This keeps the two in
  * step, exactly as the base fixture does.
@@ -205,7 +229,7 @@ describe('AdvancedMeasurementOverview', () => {
     expect(statusLine.textContent).not.toContain('8 of 8')
     expect(statusLine.textContent).not.toContain('slots completed')
     expect(statusLine.textContent).toContain('Aug 2, 2026')
-    expect(statusLine.textContent).toContain('1 flagged result needs review.')
+    expect(statusLine.textContent).toContain('1 ambiguous source-to-Property match.')
   })
 
   it('does not render an unavailable slot denominator as zero', () => {
@@ -241,7 +265,7 @@ describe('AdvancedMeasurementOverview', () => {
 
     expect(screen.getByRole('button', { name: 'Show details for Uptown Office' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Show details for Downtown Office' })).toBeNull()
-    expect(screen.queryByText('Flagged results (1)')).toBeNull()
+    expect(screen.queryByText('Ambiguous matches (1)')).toBeNull()
   })
 
   it('withholds stale report content while a server view changes', () => {
@@ -392,7 +416,7 @@ describe('AdvancedMeasurementOverview', () => {
     expect(screen.getByText('Rival Co.')).toBeTruthy()
     fireEvent.click(within(screen.getByLabelText('Query type')).getByRole('radio', { name: 'Branded' }))
     expect(screen.queryByText('Brand share of voice')).toBeNull()
-    expect((screen.getByText('Flagged results (1)').closest('details') as HTMLDetailsElement).open).toBe(false)
+    expect((screen.getByText('Ambiguous matches (1)').closest('details') as HTMLDetailsElement).open).toBe(false)
   })
 
   it('hides competitor share of voice when a group has no confirmed competitors', () => {
@@ -707,7 +731,7 @@ describe('status strip (defect 1)', () => {
     expect(screen.getByText('1 property is unavailable.')).toBeTruthy()
   })
 
-  it('renders the flagged-results count with correct singular/plural agreement', () => {
+  it('names ambiguous source matches with correct singular/plural agreement', () => {
     const current = report()
     renderOverview({
       report: {
@@ -715,7 +739,7 @@ describe('status strip (defect 1)', () => {
         flaggedResults: [{ id: 'flag-1', property: 'Downtown Office', summary: 'x', tone: 'caution', count: 3 }],
       },
     })
-    expect(screen.getByText('3 flagged results need review.')).toBeTruthy()
+    expect(screen.getByText('3 ambiguous source-to-Property matches.')).toBeTruthy()
   })
 
   it('falls through to metricReasons.plan_v1 when the setup needs republishing', () => {
@@ -1051,6 +1075,45 @@ describe('outcome count row', () => {
     expect(screen.queryByLabelText('Property outcomes')).toBeNull()
   })
 
+  it.each(['loading', 'error'] as const)('keeps loaded outcomes visible while the Portfolio pulse is %s', (portfolioSummaryState) => {
+    renderOverview({
+      report: withOutcomes({
+        bothSignals: 1, mentionedOnly: 1, citedOnly: 1, neither: 1, notMeasured: 1, total: 5,
+      }),
+      portfolioSummaryState,
+    })
+
+    expect(screen.getAllByLabelText('Property outcomes')).toHaveLength(1)
+  })
+
+  it('lets a ready Portfolio pulse own the outcome partition exactly once', () => {
+    renderOverview({
+      report: withOutcomes({
+        bothSignals: 1, mentionedOnly: 1, citedOnly: 1, neither: 1, notMeasured: 1, total: 5,
+      }),
+      portfolioSummaryState: 'ready',
+      portfolioSummary: portfolioSummary(),
+    })
+
+    expect(screen.getAllByLabelText('Property outcomes')).toHaveLength(1)
+  })
+
+  it('does not flash the cached Pulse while a cleared search is still applied by the parent', () => {
+    renderOverview({
+      report: withOutcomes({
+        bothSignals: 1, mentionedOnly: 1, citedOnly: 1, neither: 1, notMeasured: 1, total: 5,
+      }),
+      viewSearch: 'harbor',
+      portfolioSummaryState: 'ready',
+      portfolioSummary: portfolioSummary(),
+    })
+
+    const box = screen.getByPlaceholderText('Search properties')
+    expect(screen.queryByRole('heading', { name: 'Portfolio pulse' })).toBeNull()
+    fireEvent.change(box, { target: { value: '' } })
+    expect(screen.queryByRole('heading', { name: 'Portfolio pulse' })).toBeNull()
+  })
+
   // The parent trims the term before storing it, so a pause after a space
   // echoes back a shorter string. Writing that echo into the controlled input
   // deletes the space the user just typed, and the next word merges onto the
@@ -1163,7 +1226,7 @@ describe('sorting and status', () => {
               ...scope.aggregate,
               properties: [
                 { ...first!, status: { label: 'Complete', tone: 'positive' as const } },
-                { ...second!, status: { label: 'Review', tone: 'caution' as const } },
+                { ...second!, status: { label: 'Ambiguous match', tone: 'caution' as const } },
               ],
             },
           },
@@ -1177,6 +1240,6 @@ describe('sorting and status', () => {
     // status lives in the header, outside this table.)
     expect(within(table).queryByText('Complete')).toBeNull()
     // The exception still shows, next to the Property it belongs to.
-    expect(within(table).getByText('Review')).toBeTruthy()
+    expect(within(table).getByText('Ambiguous match')).toBeTruthy()
   })
 })

--- a/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
+++ b/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
@@ -266,7 +266,7 @@ describe('version-two measurement overview adapter', () => {
     expect(() => adaptV2MeasurementOverview({ overview, activePlan })).toThrow('All Properties or group scope')
   })
 
-  it('keeps server-wide flagged totals visible before the flagged Property page is loaded', () => {
+  it('keeps server-wide ambiguous-source totals visible before the matching Property page is loaded', () => {
     const { activePlan, overview } = fixture()
     overview.flags.total = 3
     overview.nextAction = { kind: 'review_flags', count: 3 }
@@ -280,9 +280,9 @@ describe('version-two measurement overview adapter', () => {
       />,
     )
 
-    expect(screen.getByText('3 flagged results need review.')).toBeTruthy()
-    fireEvent.click(screen.getByText('Flagged results (3)'))
-    expect(screen.getByText('Showing details for 0 of 3 flagged results')).toBeTruthy()
+    expect(screen.getByText('3 ambiguous source-to-Property matches.')).toBeTruthy()
+    fireEvent.click(screen.getByText('Ambiguous matches (3)'))
+    expect(screen.getByText('Showing details for 0 of 3 ambiguous matches')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Load more Properties' }))
     expect(onLoadMore).toHaveBeenCalledWith('page-2')
   })

--- a/apps/web/test/measurement-property-page.test.tsx
+++ b/apps/web/test/measurement-property-page.test.tsx
@@ -118,7 +118,11 @@ function overviewResponse(queryClass: 'branded' | 'non-brand', row: {
   mentionCoverage: Metric
   citationCoverage: Metric
   providers?: Array<{ provider: string; mentionCoverage: Metric; citationCoverage: Metric }>
-}, options: { measurementState?: 'complete' | 'not_measured'; nextAction?: 'none' | 'run_measurement' } = {}) {
+}, options: {
+  measurementState?: 'complete' | 'not_measured'
+  nextAction?: 'none' | 'run_measurement'
+  flags?: number
+} = {}) {
   return {
     mode: 'active-v2' as const,
     scope: { kind: 'property' as const, key: TARGET_KEY, label: 'Harbor House' },
@@ -145,12 +149,12 @@ function overviewResponse(queryClass: 'branded' | 'non-brand', row: {
         mentionCoverage: row.mentionCoverage,
         citationCoverage: row.citationCoverage,
         providers: row.providers ?? [],
-        flags: 0,
+        flags: options.flags ?? 0,
       }],
       nextCursor: null,
       totalEstimate: 1,
     },
-    flags: { total: 0 },
+    flags: { total: options.flags ?? 0 },
   }
 }
 
@@ -661,6 +665,24 @@ describe('Property page', () => {
     expect(screen.queryByText(/revision \d+/i)).toBeNull()
     expect(screen.getByLabelText('Query type').className).toContain('h-11')
   })
+
+  it('labels ambiguous source-to-Property matches consistently', async () => {
+    await renderPropertyPage({
+      branded: overviewResponse('branded', {
+        mentionCoverage: unavailable('no_population'),
+        citationCoverage: unavailable('no_population'),
+      }),
+      nonBrand: overviewResponse('non-brand', {
+        mentionCoverage: available(3, 4),
+        citationCoverage: available(2, 4),
+      }, { flags: 2 }),
+    })
+
+    expect(await screen.findByText('2 ambiguous matches')).toBeTruthy()
+    expect(screen.getByRole('button', {
+      name: /recorded as an ambiguous source-to-Property match instead of being credited to either/i,
+    })).toBeTruthy()
+  })
 })
 
 describe('Property answer evidence', () => {
@@ -1034,12 +1056,10 @@ describe('Reading the answer', () => {
   })
 })
 
-// Two queries repeated down almost every row — the production shape that
-// motivated collapsing the Queries cell into a count. A real screenshot had
-// nine rows where four carried this exact joined string and the rest carried
-// one half of it.
-const REPEATED_QUERY_A = 'best apartments in buckhead atlanta'
-const REPEATED_QUERY_B = 'luxury apartments buckhead atlanta'
+// Two fictional queries repeat down almost every row, which exercises the
+// production-shaped layout that collapses the Queries cell into a count.
+const REPEATED_QUERY_A = 'best apartments in north district'
+const REPEATED_QUERY_B = 'luxury apartments in north district'
 const REPEATED_QUERIES_TEXT = `${REPEATED_QUERY_A} · ${REPEATED_QUERY_B}`
 
 type CompetitorRowFixture = {

--- a/apps/web/test/measurement-view-url.test.ts
+++ b/apps/web/test/measurement-view-url.test.ts
@@ -26,7 +26,7 @@ test('a malformed scope degrades to all properties rather than throwing', () => 
 
 test('a malformed class degrades to the default, which is never pooled with branded', () => {
   for (const cls of ['', 'BRANDED', 'nonbrand', 'both']) {
-    expect(parseMeasurementViewSearch({ class: cls }).queryClass).toBe('all')
+    expect(parseMeasurementViewSearch({ class: cls }).queryClass).toBe('non-brand')
   }
 })
 
@@ -43,12 +43,12 @@ test('defaults are written as absent, so the common case leaves a clean URL', ()
 })
 
 test('a deliberate choice is written, and only that choice', () => {
-  // Non-brand is no longer the default, so choosing it is a deliberate choice
-  // and must survive a reload.
   expect(measurementViewSearch({ scope: 'group', groupKey: 'north', queryClass: 'non-brand' }))
-    .toEqual({ scope: 'group:north', class: 'non-brand' })
+    .toEqual({ scope: 'group:north', class: undefined })
   expect(measurementViewSearch({ scope: 'all', queryClass: 'branded' }))
     .toEqual({ scope: undefined, class: 'branded' })
+  expect(measurementViewSearch({ scope: 'all', queryClass: 'all' }))
+    .toEqual({ scope: undefined, class: 'all' })
 })
 
 test('every state survives a URL round trip', () => {
@@ -90,14 +90,13 @@ describe('shouldResetMeasurementView', () => {
   })
 })
 
-// Branded and non-brand answer different questions and are never pooled INTO a
-// single rate — but the operator arriving at the page has not yet said which he
-// is asking, and defaulting to one silently hides the other half of the basket.
-test('the default view is all queries', () => {
-  expect(DEFAULT_MEASUREMENT_VIEW.queryClass).toBe('all')
-  expect(parseMeasurementViewSearch({}).queryClass).toBe('all')
+// Branded and non-brand answer different questions. The first headline stays
+// actionable by defaulting to non-brand; pooling remains an explicit choice.
+test('the default view is non-brand and all queries remains explicit', () => {
+  expect(DEFAULT_MEASUREMENT_VIEW.queryClass).toBe('non-brand')
+  expect(parseMeasurementViewSearch({}).queryClass).toBe('non-brand')
   // Still absent from the URL, because it is the default.
   expect(measurementViewSearch(DEFAULT_MEASUREMENT_VIEW).class).toBeUndefined()
-  // And an explicit narrower choice still round-trips.
+  expect(parseMeasurementViewSearch({ class: 'all' }).queryClass).toBe('all')
   expect(parseMeasurementViewSearch({ class: 'branded' }).queryClass).toBe('branded')
 })

--- a/apps/web/test/portfolio-pulse.test.tsx
+++ b/apps/web/test/portfolio-pulse.test.tsx
@@ -1,0 +1,222 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import type { MeasurementPortfolioSummaryResponse } from '@ainyc/canonry-api-client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PortfolioPulse } from '../src/components/project/advanced-measurement/PortfolioPulse.js'
+
+afterEach(cleanup)
+
+const available = (numerator: number, denominator: number) => ({
+  state: 'available' as const,
+  value: numerator / denominator,
+  numerator,
+  denominator,
+})
+
+const count = (numerator: number, denominator: number, rate = numerator / denominator) => ({
+  state: 'available' as const,
+  value: numerator,
+  numerator,
+  denominator,
+  rate,
+})
+
+const unavailable = (reason: 'no_completed_run' | 'no_population' = 'no_completed_run') => ({
+  state: 'unavailable' as const,
+  reason,
+})
+
+function summary(overrides: Partial<MeasurementPortfolioSummaryResponse> = {}): MeasurementPortfolioSummaryResponse {
+  return {
+    portfolio: { groupKey: null, label: null, measurementScope: 'full' },
+    measurement: {
+      state: 'complete',
+      displayedRunId: 'run-1',
+      planRevision: 2,
+      completedAt: '2026-08-27T14:00:00.000Z',
+    },
+    queryClass: 'non-brand',
+    metrics: {
+      propertiesMentioned: count(178, 200),
+      mentionCoverage: available(194, 224),
+      citationCoverage: available(171, 224),
+    },
+    weakestProperties: [],
+    markets: [
+      {
+        groupKey: 'west',
+        label: 'West',
+        propertyCount: 16,
+        propertiesMentioned: count(12, 16),
+        mentionCoverage: available(14, 20),
+        citationCoverage: available(8, 20),
+      },
+      {
+        groupKey: 'east',
+        label: 'East',
+        propertyCount: 19,
+        propertiesMentioned: count(18, 19),
+        mentionCoverage: available(18, 20),
+        citationCoverage: available(16, 20),
+      },
+    ],
+    totalProperties: 200,
+    truncated: false,
+    ...overrides,
+  }
+}
+
+describe('PortfolioPulse', () => {
+  it('shows the compact portfolio metrics and keeps all five outcomes distinct', () => {
+    render(<PortfolioPulse
+      state="ready"
+      summary={summary()}
+      outcomes={{ bothSignals: 178, mentionedOnly: 16, citedOnly: 7, neither: 4, notMeasured: 13, total: 218 }}
+    />)
+
+    expect(screen.getByRole('heading', { name: 'Portfolio pulse' })).toBeTruthy()
+    const countTile = screen.getByText('Properties mentioned').closest('div')!
+    expect(within(countTile).getByText('178 of 200')).toBeTruthy()
+    expect(within(countTile).getByText('89%')).toBeTruthy()
+    expect(screen.getByText('87%')).toBeTruthy()
+    expect(screen.getByText('194 of 224 answers')).toBeTruthy()
+    expect(screen.getByText('76%')).toBeTruthy()
+    expect(screen.getByText('171 of 224 answers')).toBeTruthy()
+
+    const outcomes = screen.getByLabelText('Property outcomes')
+    expect(outcomes.textContent).toContain('Mentioned and cited178')
+    expect(outcomes.textContent).toContain('Mention only16')
+    expect(outcomes.textContent).toContain('Citation only7')
+    expect(outcomes.textContent).toContain('Neither4')
+    expect(outcomes.textContent).toContain('Not measured13')
+    expect(outcomes.textContent).not.toContain('Review')
+    expect(screen.getByRole('button', { name: 'One or both signals missing. Not the same as neither.' })).toBeTruthy()
+
+    const mentionOnlySegment = document.querySelector('[data-outcome="mention"]')!
+    const citationOnlySegment = document.querySelector('[data-outcome="citation"]')!
+    expect(mentionOnlySegment.className).toContain('--chart-series-2')
+    expect(citationOnlySegment.className).toContain('--chart-series-3')
+    expect(mentionOnlySegment.className).not.toMatch(/positive|caution|negative/)
+    expect(citationOnlySegment.className).not.toMatch(/positive|caution|negative/)
+  })
+
+  it('uses the server-supplied count rate instead of recomputing it in the UI', () => {
+    render(<PortfolioPulse state="ready" summary={summary({
+      metrics: {
+        ...summary().metrics,
+        propertiesMentioned: count(178, 200, 0.42),
+      },
+    })} />)
+
+    const countTile = screen.getByText('Properties mentioned').closest('div')!
+    expect(within(countTile).getByText('42%')).toBeTruthy()
+    expect(within(countTile).queryByText('89%')).toBeNull()
+  })
+
+  it('renders unavailable data as unavailable, never as a measured zero', () => {
+    const base = summary()
+    render(<PortfolioPulse
+      state="ready"
+      summary={summary({
+        metrics: {
+          propertiesMentioned: unavailable(),
+          mentionCoverage: unavailable('no_population'),
+          citationCoverage: unavailable(),
+        },
+        markets: [{
+          ...base.markets[0]!,
+          mentionCoverage: unavailable(),
+          citationCoverage: unavailable('no_population'),
+        }],
+      })}
+    />)
+
+    const countTile = screen.getByText('Properties mentioned').closest('div')!
+    expect(within(countTile).getByText('Not measured')).toBeTruthy()
+    expect(countTile.textContent).not.toContain('0')
+    expect(screen.getAllByText('Not measured').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('No matching queries').length).toBeGreaterThan(0)
+    expect(screen.queryByText('0%')).toBeNull()
+  })
+
+  it('preserves server order and opens a Group without summing overlapping membership', () => {
+    const onSelectGroup = vi.fn()
+    render(<PortfolioPulse state="ready" summary={summary()} onSelectGroup={onSelectGroup} />)
+
+    const table = screen.getByRole('table', { name: /Advanced measurement Groups/ })
+    const rows = within(table).getAllByRole('row').slice(1)
+    expect(rows.map(row => within(row).getAllByRole('cell')[0]?.textContent)).toEqual(['West', 'East'])
+    expect(screen.getByText('200 Properties')).toBeTruthy()
+    expect(screen.queryByText('35 Properties')).toBeNull()
+
+    fireEvent.click(within(rows[0]!).getByRole('button', { name: 'West' }))
+    expect(onSelectGroup).toHaveBeenCalledWith('west')
+  })
+
+  it('uses the same shell for one Group and returns to the portfolio', () => {
+    const onOpenPortfolio = vi.fn()
+    render(<PortfolioPulse
+      state="ready"
+      summary={summary({
+        portfolio: { groupKey: 'west', label: 'West', measurementScope: 'full' },
+        markets: [],
+        totalProperties: 16,
+      })}
+      onOpenPortfolio={onOpenPortfolio}
+    />)
+
+    expect(screen.getByRole('heading', { name: 'West' })).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: 'Groups' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Portfolio' }))
+    expect(onOpenPortfolio).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses the project trend at Portfolio scope without presenting it as Group history', () => {
+    const trend = <section aria-label="Project visibility trend">Project trend</section>
+    const view = render(<PortfolioPulse state="ready" summary={summary()} projectTrend={trend} />)
+
+    expect(screen.getByLabelText('Project visibility trend')).toBeTruthy()
+    expect(screen.getByText('Project-wide · all tracked queries')).toBeTruthy()
+
+    view.rerender(<PortfolioPulse
+      state="ready"
+      summary={summary({
+        portfolio: { groupKey: 'west', label: 'West', measurementScope: 'full' },
+        markets: [],
+        totalProperties: 16,
+      })}
+      projectTrend={trend}
+    />)
+    expect(screen.queryByLabelText('Project visibility trend')).toBeNull()
+  })
+
+  it('labels a spot check without changing its measured population', () => {
+    render(<PortfolioPulse state="ready" summary={summary({
+      portfolio: { groupKey: null, label: null, measurementScope: 'spot_check' },
+      totalProperties: 12,
+    })} />)
+
+    expect(screen.getByText('Spot check')).toBeTruthy()
+    expect(screen.getByText('12 Properties')).toBeTruthy()
+  })
+
+  it('contains loading, error, and no-Group states inside the Pulse region', () => {
+    const { unmount } = render(<PortfolioPulse state="loading" />)
+    expect(screen.getByLabelText('Loading Portfolio pulse')).toBeTruthy()
+    unmount()
+
+    const onRetry = vi.fn()
+    const errorView = render(<PortfolioPulse
+      state="error"
+      onRetry={onRetry}
+      projectTrend={<section aria-label="Project visibility trend">Project trend</section>}
+    />)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+    expect(screen.getByLabelText('Project visibility trend')).toBeTruthy()
+    errorView.unmount()
+
+    render(<PortfolioPulse state="ready" summary={summary({ markets: [] })} />)
+    expect(screen.getByText('No Groups configured.')).toBeTruthy()
+  })
+})

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -96,7 +96,7 @@ async function renderAt(
     const q = {
       scope: measurement.overviewKey?.scope ?? 'all',
       ...(measurement.overviewKey?.groupKey ? { groupKey: measurement.overviewKey.groupKey } : {}),
-      queryClass: measurement.overviewKey?.queryClass ?? 'all',
+      queryClass: measurement.overviewKey?.queryClass ?? 'non-brand',
       limit: 50,
     }
     queryClient.setQueryData(
@@ -233,12 +233,45 @@ function measurementOverviewResponse(overrides: {
         label: overrides.label ?? 'Harbor House',
         mentionCoverage: { state: 'available' as const, value: 1, numerator: 1, denominator: 1 },
         citationCoverage: { state: 'available' as const, value: 1, numerator: 1, denominator: 1 },
+        providers: [],
         flags: 0,
       }],
       nextCursor: overrides.nextCursor ?? null,
       totalEstimate: overrides.totalEstimate ?? 1,
     },
+    outcomes: { bothSignals: 1, mentionedOnly: 0, citedOnly: 0, neither: 0, notMeasured: 0, total: 1 },
     flags: { total: 0 },
+  }
+}
+
+function measurementPortfolioSummaryResponse(groupKey?: string, queryClass: 'all' | 'non-brand' | 'branded' = 'non-brand') {
+  const metric = { state: 'available' as const, value: 1, numerator: 1, denominator: 1 }
+  const countMetric = { ...metric, rate: 1 }
+  return {
+    portfolio: {
+      groupKey: groupKey ?? null,
+      label: groupKey === 'north' ? 'North' : null,
+      measurementScope: 'full' as const,
+    },
+    measurement: {
+      state: 'complete' as const,
+      displayedRunId: 'run-synthetic',
+      planRevision: 4,
+      completedAt: '2026-08-02T12:05:00.000Z',
+    },
+    queryClass,
+    metrics: { propertiesMentioned: countMetric, mentionCoverage: metric, citationCoverage: metric },
+    weakestProperties: [],
+    markets: groupKey ? [] : [{
+      groupKey: 'north',
+      label: 'North',
+      propertyCount: 1,
+      propertiesMentioned: countMetric,
+      mentionCoverage: metric,
+      citationCoverage: metric,
+    }],
+    totalProperties: groupKey ? 1 : 218,
+    truncated: false,
   }
 }
 
@@ -443,6 +476,8 @@ test('a version-two Overview uses server scope, search and pagination and defers
   let releaseSearch: (() => void) | undefined
   let failRetrySearch = true
   const searchGate = new Promise<void>(resolve => { releaseSearch = resolve })
+  const fixture = createDashboardFixture({})
+  const drawerRunId = fixture.dashboard.projects.flatMap(project => project.recentRuns)[0]!.id
   const realFetch = globalThis.fetch
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const raw = input instanceof Request ? input.url : String(input)
@@ -468,7 +503,12 @@ test('a version-two Overview uses server scope, search and pagination and defers
           failRetrySearch = false
           return jsonResponse({ code: 'INTERNAL_ERROR', message: 'Synthetic failure' }, 500)
         }
-        return jsonResponse(measurementOverviewResponse({ label: 'Recovered Search Result' }))
+        return jsonResponse(measurementOverviewResponse({
+          scope: 'group',
+          scopeKey: 'north',
+          scopeLabel: 'North',
+          label: 'Recovered Search Result',
+        }))
       }
       if (url.searchParams.get('cursor') === 'cursor-2') {
         return jsonResponse(measurementOverviewResponse({
@@ -496,14 +536,19 @@ test('a version-two Overview uses server scope, search and pagination and defers
       }
       return jsonResponse(measurementOverviewResponse({ nextCursor: 'cursor-2', totalEstimate: 2 }))
     }
+    if (url.pathname.endsWith('/measurement-portfolio-summary')) {
+      return jsonResponse(measurementPortfolioSummaryResponse(
+        url.searchParams.get('groupKey') ?? undefined,
+        (url.searchParams.get('queryClass') ?? 'non-brand') as 'all' | 'non-brand' | 'branded',
+      ))
+    }
     if (url.pathname.endsWith('/measurement-report')) return jsonResponse(measurementReportResponse(4))
     return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
   }) as typeof fetch
   onTestFinished(() => { globalThis.fetch = realFetch })
 
-  const fixture = createDashboardFixture({})
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  const router = createAppRouter(queryClient, { initialEntries: ['/projects/project_citypoint'] })
+  const router = createAppRouter(queryClient, { initialEntries: [`/projects/project_citypoint?runId=${drawerRunId}`] })
   await router.load()
   const page = render(
     <QueryClientProvider client={queryClient}>
@@ -516,28 +561,42 @@ test('a version-two Overview uses server scope, search and pagination and defers
   expect(await page.findByText('Harbor House')).toBeTruthy()
   const firstOverviewUrl = observed.find(path => path.includes('/measurement-overview?'))
   expect(firstOverviewUrl).toContain('scope=all')
-  // All queries is the default now — the operator has not yet said which lane
-  // he is asking about, and defaulting to one silently hid the other.
-  expect(firstOverviewUrl).toContain('queryClass=all')
+  expect(firstOverviewUrl).toContain('queryClass=non-brand')
   expect(firstOverviewUrl).toContain('limit=50')
   expect(observed.some(path => path.includes('/measurement-report?'))).toBe(false)
+  expect(await page.findByRole('heading', { name: 'Portfolio pulse' })).toBeTruthy()
+  expect(page.getByRole('dialog')).toBeTruthy()
+  await waitFor(() => expect(observed.some(path => path.includes('/measurement-portfolio-summary?')
+    && path.includes('queryClass=non-brand')
+    && path.includes('runId=run-synthetic'))).toBe(true))
 
   fireEvent.click(page.getByRole('button', { name: 'Show 50 more' }))
   expect(await page.findByText('Harbor Annex')).toBeTruthy()
   expect(observed.some(path => path.includes('cursor=cursor-2') && path.includes('runId=run-synthetic'))).toBe(true)
 
-  // Group is a segmented radiogroup at <=5 groups, so pick the option by label.
-  fireEvent.click(within(page.getByLabelText('Group')).getByRole('radio', { name: 'North' }))
+  // The Pulse row is a real URL-backed link, so Groups remain shareable rather
+  // than becoming local dropdown state.
+  const pulseGroups = page.getByRole('table', { name: /Advanced measurement Groups/ })
+  fireEvent.click(within(pulseGroups).getByRole('link', { name: 'North' }))
   expect(await page.findByText('North Property')).toBeTruthy()
+  expect(router.state.location.search.runId).toBe(drawerRunId)
+  expect(page.getByRole('dialog')).toBeTruthy()
   expect(observed.some(path => path.includes('scope=group') && path.includes('groupKey=north'))).toBe(true)
+  await waitFor(() => expect(observed.some(path => path.includes('/measurement-portfolio-summary?')
+    && path.includes('groupKey=north')
+    && path.includes('queryClass=non-brand')
+    && path.includes('runId=run-synthetic'))).toBe(true))
 
+  expect(page.getByRole('heading', { name: 'North' })).toBeTruthy()
   fireEvent.change(page.getByLabelText('Search properties'), { target: { value: 'harbor' } })
   await waitFor(() => expect(observed.some(path => path.includes('search=harbor'))).toBe(true))
+  await waitFor(() => expect(page.queryByRole('heading', { name: 'North' })).toBeNull())
   expect((page.getByLabelText('Search properties') as HTMLInputElement).value).toBe('harbor')
   expect(page.queryByText('North Property')).toBeNull()
   expect(page.getByLabelText('Updating Property results')).toBeTruthy()
   releaseSearch!()
   expect(await page.findByText('Harbor Search Result')).toBeTruthy()
+  expect(page.getByLabelText('Property outcomes')).toBeTruthy()
   expect(observed.some(path => path.includes('/measurement-report?'))).toBe(false)
 
   fireEvent.click(page.getByText('Harbor Search Result').closest('tr')!)
@@ -549,6 +608,13 @@ test('a version-two Overview uses server scope, search and pagination and defers
   fireEvent.click(page.getByRole('button', { name: 'Retry report' }))
   expect(await page.findByText('Recovered Search Result')).toBeTruthy()
   expect((page.getByLabelText('Search properties') as HTMLInputElement).value).toBe('retry')
+
+  fireEvent.change(page.getByLabelText('Search properties'), { target: { value: '' } })
+  const groupPulse = (await page.findByRole('heading', { name: 'North' })).closest('section')!
+  fireEvent.click(within(groupPulse).getByRole('link', { name: 'Portfolio' }))
+  expect(await page.findByRole('heading', { name: 'Portfolio pulse' })).toBeTruthy()
+  expect(router.state.location.search.runId).toBe(drawerRunId)
+  expect(page.getByRole('dialog')).toBeTruthy()
 })
 
 test('a direct Portfolio URL falls back safely in embed mode', async () => {

--- a/apps/web/test/run-invalidations.test.ts
+++ b/apps/web/test/run-invalidations.test.ts
@@ -60,6 +60,13 @@ test('invalidates the project-scoped runs list so the project page refreshes aft
   expect(predicateMatches('getApiV1ProjectsByNameRuns')).toBe(true)
 })
 
+test('invalidates Advanced Measurement snapshots after an answer-visibility run', () => {
+  invalidateQueriesForRunKind(queryClient, RunKinds['answer-visibility'], 'demo')
+  expect(predicateMatches('getApiV1ProjectsByNameMeasurementOverview')).toBe(true)
+  expect(predicateMatches('getApiV1ProjectsByNameMeasurementPortfolioSummary')).toBe(true)
+  expect(predicateMatches('getApiV1ProjectsByNameMeasurementPropertyEvidence')).toBe(true)
+})
+
 test('does not prefix-invalidate the analytics trend after an answer-visibility run', () => {
   // The trend key ends in the revision of the NEWEST completed|partial
   // non-probe sweep (`['analytics-metrics', project, window, frameKey,
@@ -179,11 +186,12 @@ test('invalidates every Site Health operation for site-audit runs', () => {
   expect(predicateMatches('getApiV1ProjectsByNameTechnicalAeoDeadLinks')).toBe(true)
 })
 
-test('does not invalidate domain-scoped operations for answer-visibility runs', () => {
+test('invalidates measurement data but not unrelated domains for answer-visibility runs', () => {
   invalidateQueriesForRunKind(queryClient, RunKinds['answer-visibility'], 'demo')
   expect(predicateMatches('getApiV1ProjectsByNameGoogleGscCoverage')).toBe(false)
   expect(predicateMatches('getApiV1ProjectsByNameBingCoverage')).toBe(false)
   expect(predicateMatches('getApiV1ProjectsByNameGaTraffic')).toBe(false)
   expect(predicateMatches('getApiV1ProjectsByNameGbpSummary')).toBe(false)
   expect(predicateMatches('getApiV1ProjectsByNameTechnicalAeo')).toBe(false)
+  expect(predicateMatches('getApiV1ProjectsByNameMeasurementOverview')).toBe(true)
 })

--- a/docs/mockups/advanced-measurement/README.md
+++ b/docs/mockups/advanced-measurement/README.md
@@ -1,0 +1,99 @@
+# Advanced Measurement: Portfolio Pulse
+
+Interactive prototype: [portfolio-scale-flows.html](./portfolio-scale-flows.html)
+
+The prototype uses one deterministic synthetic dataset with 225 Properties in
+15 Groups. All brand, domain, market, Property, count, and schedule details are
+fictional.
+It explores the selected Portfolio Pulse direction inside the existing project
+shell; it is not a second dashboard or a four-view switcher.
+
+## Product structure
+
+```text
+AI Visibility
+  Portfolio Pulse → Group overview → Property overview → answer evidence
+
+Queries
+  Tracked | Discover | Test
+
+Settings
+  Measurement setup
+  AI visibility sweep
+```
+
+Properties and Groups remain scopes inside one Project. The Project owns one
+published measurement plan, one official sweep schedule, and one project-wide
+visibility trend.
+
+## Operator flow
+
+1. Test free-form queries without changing official reporting.
+2. Save a useful test and choose **Add to measurement**.
+3. In Simple setup, track it project-wide immediately.
+4. In Advanced setup, assign Properties, inspect the exact plan change, and
+   publish a new revision.
+5. Show the query as **Awaiting first sweep** until the next full sweep. The
+   saved test never enters Portfolio Pulse or trends as official evidence.
+
+## Accuracy rules
+
+- Keep Non-brand and Branded denominators separate.
+- Show `cited answers / measured answers` with each percentage.
+- Render `Not measured` as unavailable, never as `0%`.
+- Treat Groups as independent scopes. They can overlap, so Group Property
+  counts must not be summed into a portfolio total.
+- Reuse the current project-wide trend only at Portfolio scope.
+- Do not infer Group or Property time series from project-wide analytics.
+- Compare full sweeps only when plan revision, execution identity, provider,
+  location, and scope are comparable.
+- Keep spot checks and saved tests outside official reporting.
+
+## Production boundary
+
+This change ships the Portfolio Pulse rollup on the Advanced Measurement
+Overview and reuses the current project-wide `VisibilityTrendSection`. It also
+replaces vague “Review” status copy with **Ambiguous source match** when one
+cited source matches multiple Properties.
+
+The prototype also shows the intended Query Test → Tracked handoff and schedule
+placement. Those interactions remain product direction until the browser has a
+transactional Research-result-to-plan promotion flow. Existing typed reads
+already support the shipped snapshot:
+
+| Need | Existing read |
+| --- | --- |
+| Portfolio and Group rollups | `GET /projects/:name/measurement-portfolio-summary` |
+| Paged Property results | `GET /projects/:name/measurement-overview` |
+| Comparable current-versus-previous changes | `GET /projects/:name/measurement-changes` |
+| Property investigation | Property questions, result, and evidence reads |
+| Project-wide history | `GET /projects/:name/analytics/metrics` |
+
+There is no multi-point Group or Property trend endpoint. Group and Property
+views should use a current snapshot plus a comparable one-step change until a
+bounded scoped-history read exists.
+
+## Comparable product patterns
+
+- Google Ads manager accounts use a cross-account overview, hierarchy,
+  sortable tables, search, and labels:
+  <https://support.google.com/google-ads/answer/6139225?hl=en>
+- Datadog uses synchronized search, facets with counts, and saved views:
+  <https://docs.datadoghq.com/monitors/manage/search/>
+- New Relic Workloads groups entities by business meaning and makes rollup
+  status explicit:
+  <https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/workloads/use-workloads/>
+- Grafana uses variable-driven views and bounded repeated panels:
+  <https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/>
+
+## Local preview
+
+From the repository root:
+
+```bash
+python3 -m http.server 4821
+```
+
+Then open:
+
+<http://127.0.0.1:4821/docs/mockups/advanced-measurement/portfolio-scale-flows.html#pulse>

--- a/docs/mockups/advanced-measurement/portfolio-scale-flows.html
+++ b/docs/mockups/advanced-measurement/portfolio-scale-flows.html
@@ -1,0 +1,1724 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Advanced Measurement, Portfolio Pulse</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: oklch(0.145 0.008 286);
+      --bg-elevated: oklch(0.19 0.009 286);
+      --surface: oklch(0.21 0.009 286 / 0.56);
+      --surface-subtle: oklch(0.21 0.009 286 / 0.3);
+      --surface-hover: oklch(0.27 0.012 286 / 0.52);
+      --surface-active: oklch(0.3 0.014 286 / 0.65);
+      --border: oklch(0.31 0.012 286 / 0.62);
+      --border-subtle: oklch(0.28 0.01 286 / 0.44);
+      --border-strong: oklch(0.45 0.014 286);
+      --text: oklch(0.97 0.004 286);
+      --heading: oklch(0.93 0.005 286);
+      --strong: oklch(0.86 0.006 286);
+      --secondary: oklch(0.72 0.011 286);
+      --muted: oklch(0.62 0.012 286);
+      --faint: oklch(0.54 0.011 286);
+      --accent: oklch(0.78 0.115 178);
+      --accent-soft: oklch(0.3 0.055 178 / 0.62);
+      --positive: oklch(0.76 0.13 156);
+      --positive-soft: oklch(0.27 0.05 156 / 0.65);
+      --caution: oklch(0.79 0.12 78);
+      --caution-soft: oklch(0.3 0.05 78 / 0.62);
+      --negative: oklch(0.72 0.16 25);
+      --negative-soft: oklch(0.29 0.06 25 / 0.65);
+      --info: oklch(0.76 0.105 235);
+      --info-soft: oklch(0.28 0.05 235 / 0.62);
+      --mono: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+      --sans: "Geist", Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --shadow: 0 18px 60px oklch(0.08 0.01 286 / 0.34);
+    }
+
+    * { box-sizing: border-box; }
+    html { min-width: 320px; background: var(--bg); }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+      font-size: 14px;
+      line-height: 1.45;
+      -webkit-font-smoothing: antialiased;
+    }
+    button, input, select { font: inherit; }
+    button, select { cursor: pointer; }
+    button:disabled, select:disabled { cursor: not-allowed; opacity: 0.48; }
+    button:focus-visible, input:focus-visible, select:focus-visible, summary:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+    a { color: var(--accent); }
+    [hidden] { display: none !important; }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .prototype-bar {
+      position: sticky;
+      top: 0;
+      z-index: 30;
+      display: grid;
+      grid-template-columns: minmax(280px, 1fr) auto;
+      align-items: stretch;
+      min-height: 62px;
+      border-bottom: 1px solid var(--border);
+      background: oklch(0.17 0.01 286 / 0.97);
+      box-shadow: 0 8px 28px oklch(0.08 0.01 286 / 0.16);
+    }
+    .prototype-title {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      min-width: 0;
+      padding: 9px 18px;
+      border-right: 1px solid var(--border-subtle);
+    }
+    .eyebrow {
+      color: var(--muted);
+      font-family: var(--mono);
+      font-size: 10px;
+      font-weight: 650;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .prototype-title strong {
+      overflow: hidden;
+      color: var(--heading);
+      font-size: 14px;
+      font-weight: 630;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .dataset-note {
+      display: flex;
+      align-items: center;
+      padding: 0 18px;
+      color: var(--secondary);
+      font-family: var(--mono);
+      font-size: 11px;
+      white-space: nowrap;
+    }
+
+    .app-shell { min-height: calc(100vh - 62px); }
+    .sidebar {
+      position: sticky;
+      top: 62px;
+      align-self: start;
+      height: calc(100vh - 62px);
+      overflow-y: auto;
+      border-right: 1px solid var(--border-subtle);
+      background: oklch(0.16 0.008 286);
+      padding: 20px 14px;
+    }
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      padding: 0 8px 18px;
+      color: var(--heading);
+      font-weight: 720;
+      letter-spacing: -0.02em;
+    }
+    .brand-mark {
+      display: grid;
+      width: 26px;
+      height: 26px;
+      place-items: center;
+      border: 1px solid var(--border-strong);
+      border-radius: 6px;
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 12px;
+    }
+    .project-switcher {
+      width: 100%;
+      min-height: 42px;
+      margin-bottom: 20px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--surface);
+      color: var(--heading);
+      padding: 8px 10px;
+      text-align: left;
+    }
+    .project-switcher small { display: block; color: var(--muted); font-size: 11px; }
+    .side-label {
+      margin: 18px 8px 6px;
+      color: var(--faint);
+      font-size: 10px;
+      font-weight: 650;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .side-nav { display: grid; gap: 2px; }
+    .side-nav a {
+      display: flex;
+      align-items: center;
+      min-height: 36px;
+      border-radius: 5px;
+      color: var(--secondary);
+      padding: 7px 9px;
+      text-decoration: none;
+    }
+    .side-nav a:hover { background: var(--surface-hover); color: var(--heading); }
+    .side-nav a.active { background: var(--surface-active); color: var(--text); font-weight: 580; }
+
+    .main { min-width: 0; }
+    .project-frame {
+      width: min(100%, 1500px);
+      margin: 0 auto;
+      padding: 24px clamp(20px, 3.2vw, 48px) 0;
+    }
+    .project-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 28px;
+      padding-bottom: 20px;
+    }
+    .project-identity h1 {
+      margin: 0;
+      color: var(--heading);
+      font-size: 25px;
+      font-weight: 680;
+      letter-spacing: -0.03em;
+      line-height: 1.1;
+    }
+    .project-identity p { margin: 6px 0 0; color: var(--secondary); font-size: 13px; }
+    .tag-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 11px; }
+    .tag {
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--muted);
+      padding: 2px 6px;
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.02em;
+    }
+    .project-header-right { display: grid; justify-items: end; gap: 9px; text-align: right; }
+    .project-period { margin: 0; color: var(--muted); font-size: 12px; }
+    .project-header-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: 9px 12px; }
+    .schedule-summary {
+      border: 0;
+      background: transparent;
+      color: var(--secondary);
+      padding: 5px 0;
+      font-size: 12px;
+      text-decoration: underline;
+      text-decoration-color: transparent;
+      text-underline-offset: 3px;
+    }
+    .schedule-summary:hover { color: var(--accent); text-decoration-color: currentColor; }
+    .project-subnav {
+      display: flex;
+      align-items: stretch;
+      gap: 2px;
+      overflow-x: auto;
+      border-bottom: 1px solid var(--border);
+      scrollbar-width: thin;
+    }
+    .project-subnav button {
+      position: relative;
+      min-height: 43px;
+      flex: 0 0 auto;
+      border: 0;
+      background: transparent;
+      color: var(--muted);
+      padding: 8px 11px;
+      font-size: 12px;
+      white-space: nowrap;
+    }
+    .project-subnav button:hover { color: var(--heading); }
+    .project-subnav button.active { color: var(--text); font-weight: 620; }
+    .project-subnav button.active::after {
+      position: absolute;
+      right: 8px;
+      bottom: -1px;
+      left: 8px;
+      height: 2px;
+      background: var(--accent);
+      content: "";
+    }
+    .project-subnav .subnav-spacer { flex: 1 1 auto; min-width: 18px; }
+    .content {
+      width: min(100%, 1500px);
+      margin: 0 auto;
+      padding: 24px clamp(20px, 3.2vw, 48px) 72px;
+    }
+    .breadcrumb { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; color: var(--muted); font-size: 12px; }
+    .breadcrumb button {
+      border: 0;
+      background: transparent;
+      color: var(--secondary);
+      padding: 0;
+      text-decoration: underline;
+      text-decoration-color: transparent;
+      text-underline-offset: 3px;
+    }
+    .breadcrumb button:hover { color: var(--accent); text-decoration-color: currentColor; }
+    .breadcrumb-separator { color: var(--faint); }
+    .page-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 22px;
+      margin-top: 12px;
+      padding-bottom: 18px;
+      border-bottom: 1px solid var(--border);
+    }
+    .page-head h1 {
+      margin: 0;
+      color: var(--heading);
+      font-size: 23px;
+      font-weight: 660;
+      letter-spacing: -0.025em;
+      line-height: 1.18;
+    }
+    .page-head p { max-width: 68ch; margin: 7px 0 0; color: var(--secondary); }
+    .head-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+    .button {
+      display: inline-flex;
+      min-height: 36px;
+      align-items: center;
+      justify-content: center;
+      gap: 7px;
+      border: 1px solid var(--border-strong);
+      border-radius: 6px;
+      background: var(--surface);
+      color: var(--heading);
+      padding: 7px 12px;
+      font-weight: 570;
+      line-height: 1;
+    }
+    .button:hover { background: var(--surface-hover); }
+    .button.primary { border-color: oklch(0.79 0.02 286); background: var(--text); color: var(--bg); }
+    .button.primary:hover { background: var(--strong); }
+    .button.ghost { border-color: transparent; background: transparent; color: var(--secondary); }
+    .button.ghost:hover { background: var(--surface-hover); color: var(--heading); }
+    .button.small { min-height: 30px; padding: 5px 9px; font-size: 12px; }
+    .button.icon { width: 32px; min-height: 32px; padding: 0; }
+
+    .status-line {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 9px 14px;
+      min-height: 43px;
+      border-bottom: 1px solid var(--border);
+      color: var(--secondary);
+      font-size: 13px;
+    }
+    .status-line .spacer { flex: 1; }
+    .badge {
+      display: inline-flex;
+      min-height: 22px;
+      align-items: center;
+      border: 1px solid var(--border-strong);
+      border-radius: 999px;
+      padding: 2px 8px;
+      color: var(--strong);
+      font-size: 11px;
+      font-weight: 650;
+      white-space: nowrap;
+    }
+    .badge.positive { border-color: oklch(0.5 0.09 156); background: var(--positive-soft); color: var(--positive); }
+    .badge.caution { border-color: oklch(0.5 0.08 78); background: var(--caution-soft); color: var(--caution); }
+    .badge.negative { border-color: oklch(0.5 0.1 25); background: var(--negative-soft); color: var(--negative); }
+    .badge.info { border-color: oklch(0.5 0.08 235); background: var(--info-soft); color: var(--info); }
+
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: end;
+      gap: 12px 18px;
+      padding: 16px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .field { display: grid; gap: 5px; min-width: 140px; }
+    .field.grow { flex: 1; min-width: 220px; }
+    .field label, .field-label { color: var(--strong); font-size: 12px; font-weight: 620; }
+    .control {
+      width: 100%;
+      min-height: 36px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--surface);
+      color: var(--text);
+      padding: 7px 10px;
+    }
+    input.control::placeholder { color: var(--faint); }
+    .segment {
+      display: inline-flex;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--surface-subtle);
+    }
+    .segment button {
+      min-height: 34px;
+      border: 0;
+      border-right: 1px solid var(--border);
+      background: transparent;
+      color: var(--secondary);
+      padding: 6px 11px;
+    }
+    .segment button:last-child { border-right: 0; }
+    .segment button:hover { background: var(--surface-hover); color: var(--heading); }
+    .segment button[aria-pressed="true"] { background: var(--surface-active); color: var(--text); font-weight: 610; }
+
+    .section { margin-top: 24px; }
+    .section-head {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 8px 18px;
+      margin-bottom: 10px;
+    }
+    .section-head h2 { margin: 0; color: var(--heading); font-size: 16px; font-weight: 640; }
+    .section-head p { margin: 0; color: var(--secondary); font-size: 13px; }
+    .section-note { max-width: 75ch; margin: 10px 0 0; color: var(--muted); font-size: 12px; }
+
+    .metrics-strip {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(130px, 1fr));
+      border-block: 1px solid var(--border);
+    }
+    .metrics-strip.three { grid-template-columns: repeat(3, minmax(150px, 1fr)); }
+    .pulse-metrics .metric-summary dd { font-size: 24px; }
+    .metric-summary { min-width: 0; padding: 15px 18px; border-right: 1px solid var(--border-subtle); }
+    .metric-summary:first-child { padding-left: 0; }
+    .metric-summary:last-child { border-right: 0; }
+    .metric-summary dt { color: var(--secondary); font-size: 12px; }
+    .metric-summary dd { margin: 5px 0 0; color: var(--heading); font-family: var(--mono); font-size: 17px; font-weight: 640; font-variant-numeric: tabular-nums; }
+    .metric-summary small { display: block; margin-top: 3px; color: var(--muted); font-family: var(--sans); font-size: 11px; }
+
+    .outcomes {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 7px 24px;
+      margin-top: 11px;
+    }
+    .outcome { display: inline-flex; align-items: baseline; gap: 6px; padding: 0; }
+    .outcome strong { color: var(--heading); font-family: var(--mono); font-size: 14px; font-variant-numeric: tabular-nums; }
+    .outcome span { color: var(--secondary); font-size: 12px; }
+    .outcome.neither strong { color: var(--negative); }
+    .outcome.unavailable strong { color: var(--faint); }
+    .distribution {
+      display: flex;
+      height: 7px;
+      overflow: hidden;
+      border-radius: 2px;
+      background: var(--surface-active);
+    }
+    .distribution span { min-width: 2px; }
+    .distribution .both { background: var(--positive); }
+    .distribution .mention-only { background: var(--accent); }
+    .distribution .cite-only { background: var(--info); }
+    .distribution .neither { background: var(--negative); }
+    .distribution .unavailable { background: var(--border-strong); }
+
+    .scope-trend {
+      margin-top: 24px;
+      border-block: 1px solid var(--border);
+      padding: 18px 0 12px;
+    }
+    .trend-head {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px 24px;
+    }
+    .trend-head h2 { margin: 0; color: var(--heading); font-size: 16px; font-weight: 640; }
+    .trend-head p { margin: 3px 0 0; color: var(--muted); font-size: 12px; }
+    .trend-latest { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; }
+    .trend-key { display: inline-flex; align-items: center; gap: 6px; color: var(--secondary); font-size: 12px; }
+    .trend-key::before { width: 8px; height: 8px; border-radius: 999px; background: var(--accent); content: ""; }
+    .trend-key.cited::before { background: var(--positive); }
+    .trend-key strong { color: var(--heading); font-family: var(--mono); font-size: 13px; }
+    .trend-chart { width: 100%; height: 245px; margin-top: 12px; overflow: hidden; }
+    .trend-chart svg { display: block; width: 100%; height: 100%; }
+    .trend-grid { stroke: var(--border-subtle); stroke-width: 1; vector-effect: non-scaling-stroke; }
+    .trend-axis-label { fill: var(--faint); font-family: var(--mono); font-size: 10px; }
+    .trend-line { fill: none; stroke-linecap: round; stroke-linejoin: round; stroke-width: 2.25; vector-effect: non-scaling-stroke; }
+    .trend-line.mention { stroke: var(--accent); }
+    .trend-line.citation { stroke: var(--positive); }
+    .trend-dot { stroke: var(--bg); stroke-width: 2; vector-effect: non-scaling-stroke; }
+    .trend-dot.mention { fill: var(--accent); }
+    .trend-dot.citation { fill: var(--positive); }
+    .trend-date-row { display: none; }
+    .trend-controls { display: flex; flex-wrap: wrap; align-items: end; justify-content: space-between; gap: 12px; margin-top: 15px; }
+    .trend-control-group { display: flex; flex-wrap: wrap; gap: 10px; }
+    .trend-readout { display: flex; align-items: baseline; gap: 9px; }
+    .trend-readout strong { color: var(--heading); font-family: var(--mono); font-size: 25px; font-variant-numeric: tabular-nums; }
+    .trend-readout span { color: var(--positive); font-family: var(--mono); font-size: 12px; }
+    .trend-legend-list { display: flex; flex-wrap: wrap; gap: 10px 22px; margin: 13px 0 0; padding: 0; list-style: none; }
+    .trend-legend-item { display: inline-grid; grid-template-columns: 8px auto auto; align-items: center; gap: 7px; color: var(--secondary); font-size: 12px; }
+    .trend-legend-item::before { width: 7px; height: 7px; border-radius: 50%; background: var(--series-color); content: ""; }
+    .trend-legend-item strong { color: var(--heading); font-family: var(--mono); font-size: 12px; }
+    .scope-change { margin-top: 24px; border-block: 1px solid var(--border); padding: 18px 0; }
+    .change-grid { display: grid; grid-template-columns: repeat(3, minmax(150px, 1fr)); margin-top: 13px; }
+    .change-item { padding: 0 18px; border-right: 1px solid var(--border-subtle); }
+    .change-item:first-child { padding-left: 0; }
+    .change-item:last-child { border-right: 0; }
+    .change-item span { display: block; color: var(--muted); font-size: 11px; }
+    .change-item strong { display: block; margin-top: 4px; color: var(--heading); font-family: var(--mono); font-size: 16px; }
+
+    .workspace-tabs { display: inline-flex; margin-top: 18px; border-bottom: 1px solid var(--border); }
+    .workspace-tabs button { border: 0; border-bottom: 2px solid transparent; background: transparent; color: var(--muted); padding: 8px 13px; }
+    .workspace-tabs button:hover { color: var(--heading); }
+    .workspace-tabs button.active { border-bottom-color: var(--accent); color: var(--text); font-weight: 620; }
+    .query-toolbar { display: flex; flex-wrap: wrap; align-items: end; gap: 10px 16px; padding: 16px 0; }
+    .query-toolbar .grow { flex: 1; min-width: 260px; }
+    .query-composer {
+      margin: 0 0 18px;
+      border-block: 1px solid var(--border);
+      background: var(--surface-subtle);
+      padding: 16px;
+    }
+    .query-composer-grid { display: grid; grid-template-columns: minmax(280px, 1.25fr) minmax(180px, .75fr) minmax(180px, .75fr); gap: 12px; }
+    textarea.control { min-height: 92px; resize: vertical; }
+    .query-notice { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; border-block: 1px solid var(--border); padding: 11px 0; color: var(--secondary); font-size: 12px; }
+    .query-notice strong { color: var(--heading); }
+    .test-layout { display: grid; grid-template-columns: minmax(340px, .85fr) minmax(420px, 1.15fr); gap: 22px; margin-top: 18px; }
+    .test-pane + .test-pane { border-left: 1px solid var(--border); padding-left: 22px; }
+    .test-pane h2, .settings-section h2 { margin: 0; color: var(--heading); font-size: 16px; }
+    .test-pane > p { margin: 5px 0 0; color: var(--muted); font-size: 12px; }
+    .form-stack { display: grid; gap: 12px; margin-top: 16px; }
+    .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+    .test-batches { display: grid; gap: 2px; margin-top: 14px; }
+    .test-batch { display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 12px; border: 0; border-bottom: 1px solid var(--border-subtle); background: transparent; color: var(--secondary); padding: 10px 4px; text-align: left; }
+    .test-batch:hover, .test-batch.active { background: var(--surface-hover); color: var(--heading); }
+    .test-result { margin-top: 22px; padding-top: 18px; border-top: 1px solid var(--border); }
+    .settings-section { padding: 22px 0; border-top: 1px solid var(--border); }
+    .settings-section:first-of-type { margin-top: 20px; }
+    .settings-row { display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; gap: 18px; margin-top: 14px; }
+    .settings-facts { display: grid; gap: 5px; color: var(--secondary); font-size: 12px; }
+    .settings-facts strong { color: var(--heading); font-size: 14px; }
+    .settings-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+    .schedule-editor { max-width: 760px; margin-top: 16px; border-top: 1px solid var(--border-subtle); padding-top: 16px; }
+    .promotion-panel { margin-top: 22px; border-top: 1px solid var(--border); padding-top: 18px; }
+    .promotion-panel .section-head { align-items: flex-start; }
+    .promotion-panel .section-head h2 { margin: 3px 0 0; color: var(--heading); font-size: 18px; }
+    .promotion-panel .section-head p { max-width: 70ch; margin: 5px 0 0; color: var(--secondary); }
+    .promotion-steps {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      margin: 16px 0 0;
+      padding: 0;
+      border-bottom: 1px solid var(--border);
+      list-style: none;
+    }
+    .promotion-step {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      min-height: 48px;
+      color: var(--faint);
+      padding: 9px 12px;
+      font-size: 12px;
+    }
+    .promotion-step:first-child { padding-left: 0; }
+    .promotion-step-number {
+      display: inline-grid;
+      width: 23px;
+      height: 23px;
+      flex: 0 0 auto;
+      place-items: center;
+      border: 1px solid var(--border);
+      border-radius: 50%;
+      color: var(--muted);
+      font-family: var(--mono);
+      font-size: 10px;
+    }
+    .promotion-step.current { color: var(--heading); font-weight: 620; }
+    .promotion-step.current .promotion-step-number { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
+    .promotion-step.complete { color: var(--secondary); }
+    .promotion-step.complete .promotion-step-number { border-color: oklch(0.5 0.09 156); background: var(--positive-soft); color: var(--positive); }
+    .promotion-body { max-width: 980px; padding-top: 18px; }
+    .promotion-body h3 { margin: 0; color: var(--heading); font-size: 16px; }
+    .promotion-body > p { max-width: 70ch; margin: 6px 0 0; color: var(--secondary); }
+    .promotion-origin { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px; margin-top: 17px; color: var(--muted); font-size: 12px; }
+    .promotion-fields { display: grid; grid-template-columns: minmax(280px, 1.4fr) minmax(180px, .6fr); gap: 14px; margin-top: 18px; }
+    .promotion-query {
+      border-block: 1px solid var(--border);
+      padding: 14px 0;
+      color: var(--heading);
+      font-size: 15px;
+      font-weight: 610;
+      line-height: 1.5;
+    }
+    .assignment-preview { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
+    .assignment-preview span { border: 1px solid var(--border); border-radius: 4px; color: var(--secondary); padding: 3px 7px; font-size: 11px; }
+    .promotion-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 10px; margin-top: 22px; border-top: 1px solid var(--border); padding-top: 16px; }
+    .promotion-actions-group { display: flex; flex-wrap: wrap; gap: 8px; }
+    .review-list { margin: 20px 0 0; border-block: 1px solid var(--border); }
+    .review-row { display: grid; grid-template-columns: 170px minmax(0, 1fr); gap: 18px; padding: 12px 0; border-bottom: 1px solid var(--border-subtle); }
+    .review-row:last-child { border-bottom: 0; }
+    .review-row dt { color: var(--muted); font-size: 12px; }
+    .review-row dd { margin: 0; color: var(--strong); }
+    .review-impact { display: flex; flex-wrap: wrap; gap: 8px 24px; margin-top: 15px; color: var(--secondary); font-size: 12px; }
+    .review-impact strong { color: var(--heading); font-family: var(--mono); }
+    .scope-table-actions { width: 1%; text-align: right; }
+    .portfolio-groups table { min-width: 720px; }
+    .scope-table table { min-width: 760px; }
+    .scope-link { display: inline-flex; min-height: 30px; align-items: center; border: 0; background: transparent; color: var(--accent); padding: 3px 4px; font-weight: 620; }
+    .scope-link:hover { text-decoration: underline; text-underline-offset: 3px; }
+    .scope-meta { color: var(--secondary); font-size: 12px; }
+    .question-signal { display: inline-flex; align-items: center; gap: 6px; color: var(--secondary); font-size: 12px; white-space: nowrap; }
+    .signal-dot { width: 7px; height: 7px; border-radius: 999px; background: var(--border-strong); }
+    .signal-dot.yes { background: var(--positive); }
+    .signal-dot.no { background: var(--negative); }
+
+    .table-wrap { overflow: auto; border: 1px solid var(--border); border-radius: 7px; }
+    table { width: 100%; border-collapse: collapse; }
+    caption { text-align: left; }
+    th, td { padding: 10px 12px; border-bottom: 1px solid var(--border-subtle); text-align: left; vertical-align: middle; }
+    thead th {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      background: oklch(0.185 0.009 286 / 0.98);
+      color: var(--muted);
+      font-size: 10px;
+      font-weight: 680;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    tbody tr:last-child td { border-bottom: 0; }
+    tbody tr.data-row:hover td { background: var(--surface-hover); }
+    tbody tr.selected td { background: var(--accent-soft); }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    .property-name { color: var(--heading); font-weight: 610; }
+    .subline { margin-top: 2px; color: var(--faint); font-size: 11px; font-weight: 450; }
+    .metric-cell { min-width: 116px; }
+    .metric-value { display: block; color: var(--heading); font-family: var(--mono); font-weight: 620; font-variant-numeric: tabular-nums; }
+    .metric-fraction { display: block; margin-top: 1px; color: var(--muted); font-size: 11px; font-variant-numeric: tabular-nums; }
+    .not-measured { color: var(--secondary); font-size: 12px; }
+    .delta { font-family: var(--mono); font-size: 12px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+    .delta.up { color: var(--positive); }
+    .delta.down { color: var(--negative); }
+    .delta.flat { color: var(--muted); }
+    .text-button { border: 0; background: transparent; color: var(--heading); padding: 0; text-align: left; }
+    .text-button:hover { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; }
+    .expand-button { display: inline-grid; width: 28px; height: 28px; place-items: center; border: 0; border-radius: 5px; background: transparent; color: var(--secondary); }
+    .expand-button:hover { background: var(--surface-hover); color: var(--heading); }
+    .expanded-row td { background: var(--surface-subtle); padding: 0; }
+    .expanded-content { padding: 12px 16px 16px 48px; }
+    .mini-table { max-width: 960px; }
+    .mini-table th, .mini-table td { padding: 7px 10px; }
+    .table-footer {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-top: 10px;
+      color: var(--secondary);
+      font-size: 12px;
+    }
+
+    .explorer-grid {
+      display: grid;
+      grid-template-columns: 200px minmax(430px, 1fr) 300px;
+      min-height: 620px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 7px;
+      background: var(--surface-subtle);
+    }
+    .explorer-tree, .inspector { min-width: 0; padding: 14px; background: oklch(0.17 0.008 286 / 0.64); }
+    .explorer-tree { border-right: 1px solid var(--border); }
+    .inspector { border-left: 1px solid var(--border); }
+    .panel-title { margin: 0 0 10px; color: var(--heading); font-size: 12px; font-weight: 660; letter-spacing: 0.04em; text-transform: uppercase; }
+    .tree-list { display: grid; gap: 2px; margin-top: 10px; }
+    .tree-item {
+      display: flex;
+      width: 100%;
+      min-height: 33px;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      border: 0;
+      border-radius: 5px;
+      background: transparent;
+      color: var(--secondary);
+      padding: 6px 8px;
+      text-align: left;
+    }
+    .tree-item:hover { background: var(--surface-hover); color: var(--heading); }
+    .tree-item.active { background: var(--surface-active); color: var(--text); font-weight: 610; }
+    .tree-item span:last-child { color: var(--faint); font-family: var(--mono); font-size: 11px; }
+    .explorer-results { min-width: 0; background: var(--bg); }
+    .explorer-toolbar { display: flex; flex-wrap: wrap; gap: 10px; padding: 12px; border-bottom: 1px solid var(--border); }
+    .explorer-table { max-height: 556px; overflow: auto; }
+    .explorer-table table { min-width: 760px; }
+    .inspector h3 { margin: 0; color: var(--heading); font-size: 17px; font-weight: 640; }
+    .inspector .market { margin: 3px 0 14px; color: var(--secondary); font-size: 12px; }
+    .inspector-section { padding: 14px 0; border-top: 1px solid var(--border-subtle); }
+    .inspector-section h4 { margin: 0 0 9px; color: var(--strong); font-size: 12px; font-weight: 630; }
+    .inspector-metrics { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .inspector-metric span { display: block; color: var(--muted); font-size: 11px; }
+    .inspector-metric strong { display: block; margin-top: 3px; color: var(--heading); font-family: var(--mono); font-size: 15px; }
+    .engine-list, .evidence-list { display: grid; gap: 7px; }
+    .engine-row { display: grid; grid-template-columns: 1fr auto auto; gap: 10px; color: var(--secondary); font-size: 12px; }
+    .engine-row span:not(:first-child) { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+    .evidence-item { padding: 9px 0; border-top: 1px solid var(--border-subtle); }
+    .evidence-item:first-child { border-top: 0; padding-top: 0; }
+    .evidence-item strong { display: block; color: var(--strong); font-size: 12px; }
+    .evidence-item span { display: block; margin-top: 3px; color: var(--muted); font-size: 11px; }
+
+    .queue-grid {
+      display: grid;
+      grid-template-columns: 190px minmax(460px, 1fr) 300px;
+      min-height: 620px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 7px;
+    }
+    .queue-nav { padding: 14px; border-right: 1px solid var(--border); background: var(--surface-subtle); }
+    .queue-nav-list { display: grid; gap: 3px; }
+    .queue-view {
+      display: flex;
+      width: 100%;
+      min-height: 39px;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      border: 0;
+      border-radius: 5px;
+      background: transparent;
+      color: var(--secondary);
+      padding: 8px 9px;
+      text-align: left;
+    }
+    .queue-view:hover { background: var(--surface-hover); color: var(--heading); }
+    .queue-view.active { background: var(--surface-active); color: var(--text); font-weight: 610; }
+    .queue-view span:last-child { color: var(--faint); font-family: var(--mono); font-size: 11px; }
+    .queue-results { min-width: 0; background: var(--bg); }
+    .queue-results .table-wrap { max-height: 570px; border: 0; border-radius: 0; }
+    .queue-results table { min-width: 780px; }
+    .queue-detail { min-width: 0; padding: 16px; border-left: 1px solid var(--border); background: var(--surface-subtle); }
+    .queue-detail h3 { margin: 0; color: var(--heading); font-size: 17px; }
+    .queue-detail .property-context { margin: 4px 0 16px; color: var(--secondary); font-size: 12px; }
+    .fact-list { margin: 0; }
+    .fact-list > div { display: grid; grid-template-columns: 112px 1fr; gap: 10px; padding: 9px 0; border-top: 1px solid var(--border-subtle); }
+    .fact-list dt { color: var(--muted); font-size: 12px; }
+    .fact-list dd { margin: 0; color: var(--strong); font-size: 12px; }
+    .quote {
+      margin: 12px 0 0;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--surface);
+      padding: 11px 12px;
+      color: var(--secondary);
+      font-size: 12px;
+    }
+    .queue-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+
+    .compare-picker {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: end;
+      gap: 10px 14px;
+      padding: 15px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .selection-summary { margin-left: auto; color: var(--secondary); font-size: 12px; }
+    .comparison-table table { min-width: 900px; }
+    .comparison-table th:first-child, .comparison-table td:first-child { position: sticky; left: 0; z-index: 1; background: var(--bg-elevated); }
+    .comparison-table thead th:first-child { z-index: 3; }
+    .scope-cell { min-width: 190px; }
+    .scope-cell .remove { float: right; margin-left: 8px; }
+    .remove {
+      display: inline-grid;
+      width: 25px;
+      height: 25px;
+      place-items: center;
+      border: 0;
+      border-radius: 4px;
+      background: transparent;
+      color: var(--muted);
+    }
+    .remove:hover { background: var(--surface-hover); color: var(--heading); }
+    .heat { min-width: 112px; }
+    .heat-track { height: 4px; margin-top: 5px; overflow: hidden; border-radius: 2px; background: var(--surface-active); }
+    .heat-track span { display: block; height: 100%; background: var(--accent); }
+    .matrix table { min-width: 780px; }
+    .matrix-cell { min-width: 125px; }
+    .matrix-cell strong { display: block; color: var(--heading); font-family: var(--mono); font-size: 12px; }
+    .matrix-cell span { display: block; color: var(--muted); font-size: 10px; }
+
+    .prototype-footnote {
+      margin-top: 24px;
+      border-top: 1px solid var(--border);
+      padding-top: 14px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .prototype-footnote summary { cursor: pointer; color: var(--secondary); font-weight: 620; }
+    .prototype-footnote ul { max-width: 76ch; margin: 10px 0 0; padding-left: 18px; }
+    .prototype-footnote li + li { margin-top: 5px; }
+    .toast {
+      position: fixed;
+      right: 20px;
+      bottom: 20px;
+      z-index: 50;
+      max-width: 360px;
+      border: 1px solid var(--border-strong);
+      border-radius: 7px;
+      background: var(--bg-elevated);
+      box-shadow: var(--shadow);
+      color: var(--strong);
+      padding: 11px 14px;
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(8px);
+      transition: opacity 180ms ease-out, transform 180ms ease-out;
+    }
+    .toast.visible { opacity: 1; transform: translateY(0); }
+
+    @media (max-width: 1220px) {
+      .prototype-bar { grid-template-columns: minmax(280px, 1fr) auto; }
+      .explorer-grid, .queue-grid { grid-template-columns: 205px minmax(500px, 1fr); }
+      .inspector, .queue-detail { grid-column: 1 / -1; border-top: 1px solid var(--border); border-left: 0; }
+      .inspector { display: grid; grid-template-columns: minmax(220px, 0.8fr) repeat(2, minmax(220px, 1fr)); gap: 0 24px; }
+      .inspector > .inspector-section { border-top: 0; }
+    }
+    @media (max-width: 940px) {
+      .prototype-bar { position: static; grid-template-columns: 1fr; }
+      .prototype-title { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+      .dataset-note { min-height: 38px; padding-block: 8px; }
+      .app-shell { display: block; }
+      .sidebar { display: none; }
+      .project-header { display: block; }
+      .project-header-right { justify-items: start; margin-top: 18px; text-align: left; }
+      .project-header-actions { justify-content: flex-start; }
+      .content { padding-inline: 18px; }
+      .project-frame { padding-inline: 18px; }
+      .metrics-strip { grid-template-columns: repeat(2, 1fr); }
+      .metrics-strip.three { grid-template-columns: repeat(2, 1fr); }
+      .metric-summary:nth-child(2) { border-right: 0; }
+      .metric-summary:nth-child(-n+2) { border-bottom: 1px solid var(--border-subtle); }
+      .metric-summary:nth-child(3) { padding-left: 0; }
+      .explorer-grid, .queue-grid { display: block; }
+      .explorer-tree, .queue-nav { border-right: 0; border-bottom: 1px solid var(--border); }
+      .tree-list, .queue-nav-list { grid-template-columns: repeat(2, minmax(140px, 1fr)); }
+      .inspector { display: block; border-top: 1px solid var(--border); }
+      .test-layout { grid-template-columns: 1fr; }
+      .test-pane + .test-pane { border-top: 1px solid var(--border); border-left: 0; padding-top: 20px; padding-left: 0; }
+      .query-composer-grid { grid-template-columns: 1fr 1fr; }
+      .query-composer-grid .field:first-child { grid-column: 1 / -1; }
+      .promotion-fields { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 620px) {
+      .page-head { display: block; }
+      .head-actions { justify-content: flex-start; margin-top: 14px; }
+      .metrics-strip { display: block; }
+      .metrics-strip.three { display: block; }
+      .metric-summary { border-right: 0; border-bottom: 1px solid var(--border-subtle); padding-left: 0; }
+      .metric-summary:last-child { border-bottom: 0; }
+      .outcomes { display: grid; grid-template-columns: repeat(2, minmax(110px, 1fr)); }
+      .tree-list, .queue-nav-list { grid-template-columns: 1fr; }
+      .selection-summary { width: 100%; margin-left: 0; }
+      .trend-chart { height: 190px; }
+      .trend-chart svg { height: 165px; }
+      .trend-axis-label { display: none; }
+      .trend-date-row { display: flex; align-items: center; justify-content: space-between; margin: 3px 8px 0; color: var(--faint); font-family: var(--mono); font-size: 10px; }
+      .change-grid, .query-composer-grid, .form-grid { display: block; }
+      .change-item { border-right: 0; border-bottom: 1px solid var(--border-subtle); padding: 10px 0; }
+      .change-item:last-child { border-bottom: 0; }
+      .query-composer-grid .field, .form-grid .field { margin-top: 10px; }
+      .promotion-steps { grid-template-columns: 1fr; }
+      .promotion-step { min-height: 38px; padding-left: 0; }
+      .review-row { grid-template-columns: 1fr; gap: 4px; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; }
+    }
+  </style>
+</head>
+<body>
+  <header class="prototype-bar">
+    <div class="prototype-title">
+      <span class="eyebrow">Selected direction</span>
+      <strong>Advanced Measurement · Portfolio Pulse</strong>
+    </div>
+    <div class="dataset-note">225 Properties · 15 Groups · synthetic</div>
+  </header>
+
+  <div class="app-shell">
+    <main class="main">
+      <div class="project-frame">
+        <header class="project-header">
+          <div class="project-identity">
+            <h1>Northstar Demo</h1>
+            <p>northstar.example · 225-property synthetic portfolio</p>
+            <div class="tag-row"><span class="tag">US</span><span class="tag">EN</span><span class="tag">PROPERTY PORTFOLIO</span></div>
+          </div>
+          <div class="project-header-right">
+            <p class="project-period">Last 30 days</p>
+            <div class="project-header-actions">
+              <button type="button" class="schedule-summary" data-project-section="settings">Next AI sweep · Wednesday at 9:00 AM UTC</button>
+              <button type="button" class="button" data-run-sweep>Run AI sweep</button>
+            </div>
+          </div>
+        </header>
+        <nav class="project-subnav" aria-label="Project sections">
+          <button type="button" data-project-section="visibility">AI Visibility</button>
+          <button type="button" data-toast="Search Engines remains unchanged in the current project UI.">Search Engines</button>
+          <button type="button" data-toast="Activity remains traffic and conversion activity, not AI sweep history.">Activity</button>
+          <button type="button" data-toast="Site Health remains unchanged in the current project UI.">Site Health</button>
+          <button type="button" data-toast="Conversions remains unchanged in the current project UI.">Conversions</button>
+          <button type="button" data-toast="Local Presence remains unchanged in the current project UI.">Local Presence</button>
+          <button type="button" data-project-section="queries">Queries</button>
+          <span class="subnav-spacer" aria-hidden="true"></span>
+          <button type="button" data-toast="Report and Change History live under More in the current UI.">More</button>
+          <button type="button" data-project-section="settings">Settings</button>
+        </nav>
+      </div>
+      <div id="flow-root" class="content" role="region" aria-label="Portfolio Pulse prototype" aria-live="polite"></div>
+    </main>
+  </div>
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+  <script>
+    const groupDefinitions = [
+      { key: 'metro-alpha', label: 'Metro Alpha', count: 15 },
+      { key: 'metro-bravo', label: 'Metro Bravo', count: 15 },
+      { key: 'metro-charlie', label: 'Metro Charlie', count: 15 },
+      { key: 'metro-delta', label: 'Metro Delta', count: 15 },
+      { key: 'metro-echo', label: 'Metro Echo', count: 15 },
+      { key: 'metro-foxtrot', label: 'Metro Foxtrot', count: 15 },
+      { key: 'metro-golf', label: 'Metro Golf', count: 15 },
+      { key: 'metro-hotel', label: 'Metro Hotel', count: 15 },
+      { key: 'metro-india', label: 'Metro India', count: 15 },
+      { key: 'metro-juliet', label: 'Metro Juliet', count: 15 },
+      { key: 'metro-kilo', label: 'Metro Kilo', count: 15 },
+      { key: 'metro-lima', label: 'Metro Lima', count: 15 },
+      { key: 'metro-mike', label: 'Metro Mike', count: 15 },
+      { key: 'metro-november', label: 'Metro November', count: 15 },
+      { key: 'metro-oscar', label: 'Metro Oscar', count: 15 },
+    ]
+    const nameStems = [
+      'Arden', 'Avery', 'Beacon', 'Briar', 'Crescent', 'District', 'Emerson', 'Foundry',
+      'Harbor', 'Juniper', 'Kendall', 'Landmark', 'Mason', 'Northline', 'Orchard', 'Preserve',
+      'Quarry', 'Ridge', 'Station', 'Terrace', 'Union', 'Vantage', 'Wren', 'Yards',
+    ]
+    const providers = ['OpenAI', 'Gemini', 'Perplexity']
+    const recommendedNames = ['Blue Oak Demo', 'Harborstone Demo', 'Pine & Peak Demo', 'Signal Demo', 'Summit Grove Demo', 'Willowline Demo']
+
+    function routeFromHash() {
+      const parts = location.hash.slice(1).split('/').filter(Boolean)
+      if (parts[0] === 'queries') {
+        const queryView = ['tracked', 'discover', 'test'].includes(parts[1]) ? parts[1] : 'tracked'
+        return { section: 'queries', queryView, pulseGroup: null, pulseProperty: null }
+      }
+      if (parts[0] === 'settings') return { section: 'settings', queryView: 'tracked', pulseGroup: null, pulseProperty: null }
+      if (parts[1] === 'group' && parts[2]) return { section: 'visibility', queryView: 'tracked', pulseGroup: parts[2], pulseProperty: null }
+      if (parts[1] === 'property' && parts[2]) return { section: 'visibility', queryView: 'tracked', pulseGroup: null, pulseProperty: parts[2] }
+      return { section: 'visibility', queryView: 'tracked', pulseGroup: null, pulseProperty: null }
+    }
+    const initialRoute = routeFromHash()
+    const state = {
+      section: initialRoute.section,
+      queryView: initialRoute.queryView,
+      queryClass: 'nonBrand',
+      pulseGroup: initialRoute.pulseGroup,
+      pulseProperty: initialRoute.pulseProperty,
+      trendMetric: 'mentioned',
+      trendMode: 'byEngine',
+      queryComposer: false,
+      researchComplete: true,
+      promotionStep: 0,
+      promotionQuery: '',
+      publishedQuery: '',
+      scheduleEditing: false,
+    }
+
+    function clamp(value, min, max) { return Math.max(min, Math.min(max, value)) }
+    function percent(numerator, denominator) { return denominator > 0 ? Math.round((numerator / denominator) * 100) : null }
+    function escapeHtml(value) {
+      return String(value).replace(/[&<>"']/g, character => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;',
+      })[character])
+    }
+    function slug(value) { return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') }
+    function allocate(total, count) {
+      const base = Math.floor(total / count)
+      const remainder = total % count
+      return Array.from({ length: count }, (_, index) => base + (index < remainder ? 1 : 0))
+    }
+    function propertyName(group, localIndex, globalIndex) {
+      const stem = nameStems[(globalIndex * 5 + localIndex) % nameStems.length]
+      const pattern = globalIndex % 3
+      if (pattern === 0) return `Northstar Demo ${stem}`
+      if (pattern === 1) return `The ${stem} at ${group.label}`
+      return `${stem} ${group.label}`
+    }
+    function makeMetrics(index, groupIndex, kind) {
+      const isNonBrand = kind === 'nonBrand'
+      const unavailable = isNonBrand ? index % 17 === 0 : index % 7 === 0
+      const measured = unavailable ? 0 : isNonBrand
+        ? 8 + ((index * 5 + groupIndex * 3) % 17)
+        : 4 + ((index * 3 + groupIndex) % 8)
+      let mentioned = measured === 0 ? 0 : Math.round(measured * ((isNonBrand ? 31 : 69) + ((index * 11 + groupIndex * 7) % (isNonBrand ? 48 : 26))) / 100)
+      let cited = measured === 0 ? 0 : Math.round(measured * ((isNonBrand ? 8 : 43) + ((index * 13 + groupIndex * 5) % (isNonBrand ? 55 : 43))) / 100)
+      if (isNonBrand && measured > 0 && index % 13 === 0) cited = 0
+      if (isNonBrand && measured > 0 && index % 31 === 0) mentioned = 0
+      if (isNonBrand && measured > 0 && index % 47 === 0) { mentioned = 0; cited = 0 }
+      if (!isNonBrand && measured > 0 && index % 29 === 0) cited = 0
+      mentioned = clamp(mentioned, 0, measured)
+      cited = clamp(cited, 0, measured)
+      const intendedDelta = ((index * 7 + groupIndex * 3 + (isNonBrand ? 0 : 4)) % 17) - 8
+      const previousCited = measured === 0 ? 0 : clamp(cited - Math.round(measured * intendedDelta / 100), 0, measured)
+      const previousMentioned = measured === 0 ? 0 : clamp(mentioned - Math.round(measured * (intendedDelta / 2) / 100), 0, measured)
+      const measuredSplit = allocate(measured, providers.length)
+      const mentionedSplit = allocate(mentioned, providers.length)
+      const citedSplit = allocate(cited, providers.length)
+      return {
+        measured,
+        mentioned,
+        cited,
+        previousMentioned,
+        previousCited,
+        delta: measured > 0 ? percent(cited, measured) - percent(previousCited, measured) : null,
+        providers: providers.map((provider, providerIndex) => ({
+          provider,
+          measured: measuredSplit[providerIndex],
+          mentioned: mentionedSplit[providerIndex],
+          cited: citedSplit[providerIndex],
+        })),
+      }
+    }
+
+    const properties = []
+    let globalPropertyIndex = 0
+    groupDefinitions.forEach((group, groupIndex) => {
+      for (let localIndex = 0; localIndex < group.count; localIndex += 1) {
+        const name = propertyName(group, localIndex, globalPropertyIndex)
+        const nonBrand = makeMetrics(globalPropertyIndex, groupIndex, 'nonBrand')
+        const branded = makeMetrics(globalPropertyIndex, groupIndex, 'branded')
+        const evidenceIncomplete = nonBrand.measured > 0 && globalPropertyIndex % 37 === 0
+        const stale = globalPropertyIndex % 41 === 0
+        const crossProperty = globalPropertyIndex % 29 === 0
+        let issue = null
+        if (nonBrand.measured === 0) issue = 'not-measured'
+        else if (evidenceIncomplete) issue = 'incomplete'
+        else if (nonBrand.delta <= -5) issue = 'regressed'
+        else if (percent(nonBrand.cited, nonBrand.measured) < 20) issue = 'weak'
+        else if (crossProperty) issue = 'cross-property'
+        else if (stale) issue = 'stale'
+        properties.push({
+          id: `property-${globalPropertyIndex + 1}`,
+          name,
+          groupKey: group.key,
+          groupLabel: group.label,
+          nonBrand,
+          branded,
+          issue,
+          stale,
+          evidenceIncomplete,
+          crossProperty,
+          urls: [`https://portfolio.example/properties/${slug(name)}/`],
+          queries: [
+            `best apartments in ${group.label}`,
+            `luxury apartments near ${group.label}`,
+            `${name} reviews`,
+          ],
+          recommended: [
+            recommendedNames[(globalPropertyIndex + groupIndex) % recommendedNames.length],
+            recommendedNames[(globalPropertyIndex + groupIndex + 2) % recommendedNames.length],
+          ],
+        })
+        globalPropertyIndex += 1
+      }
+    })
+
+    function metricFor(property, classKey) { return property[classKey] }
+    function median(values) {
+      if (values.length === 0) return null
+      const sorted = [...values].sort((a, b) => a - b)
+      const middle = Math.floor(sorted.length / 2)
+      return sorted.length % 2 ? sorted[middle] : Math.round((sorted[middle - 1] + sorted[middle]) / 2)
+    }
+    function aggregate(rows, classKey) {
+      const metrics = rows.map(property => metricFor(property, classKey))
+      const measuredRows = metrics.filter(metric => metric.measured > 0)
+      const measured = metrics.reduce((sum, metric) => sum + metric.measured, 0)
+      const mentioned = metrics.reduce((sum, metric) => sum + metric.mentioned, 0)
+      const cited = metrics.reduce((sum, metric) => sum + metric.cited, 0)
+      const previousCited = metrics.reduce((sum, metric) => sum + metric.previousCited, 0)
+      const previousMentioned = metrics.reduce((sum, metric) => sum + metric.previousMentioned, 0)
+      const outcomes = { both: 0, mentionOnly: 0, citeOnly: 0, neither: 0, unavailable: 0 }
+      metrics.forEach(metric => {
+        if (metric.measured === 0) outcomes.unavailable += 1
+        else if (metric.mentioned > 0 && metric.cited > 0) outcomes.both += 1
+        else if (metric.mentioned > 0) outcomes.mentionOnly += 1
+        else if (metric.cited > 0) outcomes.citeOnly += 1
+        else outcomes.neither += 1
+      })
+      const providerTotals = providers.map((provider, providerIndex) => ({
+        provider,
+        measured: metrics.reduce((sum, metric) => sum + metric.providers[providerIndex].measured, 0),
+        mentioned: metrics.reduce((sum, metric) => sum + metric.providers[providerIndex].mentioned, 0),
+        cited: metrics.reduce((sum, metric) => sum + metric.providers[providerIndex].cited, 0),
+      }))
+      return {
+        propertyCount: rows.length,
+        measuredPropertyCount: measuredRows.length,
+        propertiesMentioned: measuredRows.filter(metric => metric.mentioned > 0).length,
+        propertiesCited: measuredRows.filter(metric => metric.cited > 0).length,
+        measured,
+        mentioned,
+        cited,
+        previousMentioned,
+        previousCited,
+        mentionCoverage: percent(mentioned, measured),
+        citationCoverage: percent(cited, measured),
+        previousCitationCoverage: percent(previousCited, measured),
+        previousMentionCoverage: percent(previousMentioned, measured),
+        delta: measured > 0 ? percent(cited, measured) - percent(previousCited, measured) : null,
+        medianCitation: median(measuredRows.map(metric => percent(metric.cited, metric.measured))),
+        outcomes,
+        providers: providerTotals,
+      }
+    }
+    function groupRows(groupKey) { return properties.filter(property => property.groupKey === groupKey) }
+    function groupSummaries(classKey) {
+      return groupDefinitions.map(group => ({ ...group, rows: groupRows(group.key), aggregate: aggregate(groupRows(group.key), classKey) }))
+    }
+    function formatMetric(numerator, denominator, label = '') {
+      const value = percent(numerator, denominator)
+      if (value === null) return `<span class="not-measured" title="No matching measured answers">Not measured</span>`
+      return `<span class="metric-value">${value}%</span><span class="metric-fraction">${numerator.toLocaleString()} of ${denominator.toLocaleString()}${label ? ` ${escapeHtml(label)}` : ''}</span>`
+    }
+    function pulseStatusFor(property, metric) {
+      if (metric.measured === 0) return ['Not measured', 'caution']
+      if (property.evidenceIncomplete) return ['Evidence incomplete', 'caution']
+      if (property.crossProperty) return ['Ambiguous source', 'caution']
+      return ['Measured', 'positive']
+    }
+    function badge(label, tone) { return `<span class="badge ${tone}">${escapeHtml(label)}</span>` }
+    function queryClassControl(value, owner) {
+      return `<div class="field"><span class="field-label">Query type</span><div class="segment" role="group" aria-label="Query type">
+        <button type="button" data-query-class="nonBrand" data-owner="${owner}" aria-pressed="${value === 'nonBrand'}">Non-brand</button>
+        <button type="button" data-query-class="branded" data-owner="${owner}" aria-pressed="${value === 'branded'}">Branded</button>
+      </div></div>`
+    }
+    function outcomesHtml(outcomes) {
+      const total = Object.values(outcomes).reduce((sum, value) => sum + value, 0) || 1
+      return `<div class="distribution" aria-label="Property outcome distribution">
+          <span class="both" style="width:${outcomes.both / total * 100}%" title="${outcomes.both} mentioned and cited"></span>
+          <span class="mention-only" style="width:${outcomes.mentionOnly / total * 100}%" title="${outcomes.mentionOnly} mentioned only"></span>
+          <span class="cite-only" style="width:${outcomes.citeOnly / total * 100}%" title="${outcomes.citeOnly} cited only"></span>
+          <span class="neither" style="width:${outcomes.neither / total * 100}%" title="${outcomes.neither} neither signal"></span>
+          ${outcomes.unavailable > 0 ? `<span class="unavailable" style="width:${outcomes.unavailable / total * 100}%" title="${outcomes.unavailable} not measured"></span>` : ''}
+        </div>
+        <div class="outcomes">
+          <div class="outcome" title="Mentioned and cited"><strong>${outcomes.both}</strong><span>Both</span></div>
+          <div class="outcome"><strong>${outcomes.mentionOnly}</strong><span>Mention only</span></div>
+          <div class="outcome"><strong>${outcomes.citeOnly}</strong><span>Citation only</span></div>
+          <div class="outcome neither"><strong>${outcomes.neither}</strong><span>Neither</span></div>
+          ${outcomes.unavailable > 0 ? `<div class="outcome unavailable"><strong>${outcomes.unavailable}</strong><span>Not measured</span></div>` : ''}
+        </div>`
+    }
+
+    function pulseScopeHeader({ title, context, measuredLabel, group = null, property = null }) {
+      const portfolioCrumb = group || property
+        ? '<button type="button" data-pulse-back="portfolio">Portfolio</button>'
+        : '<span>Portfolio</span>'
+      const groupCrumb = group
+        ? `${property ? `<button type="button" data-pulse-back="group" data-group-key="${group.key}">${escapeHtml(group.label)}</button>` : `<span>${escapeHtml(group.label)}</span>`}`
+        : ''
+      return `<div class="breadcrumb"><span>Northstar Demo</span><span class="breadcrumb-separator">/</span>${portfolioCrumb}${groupCrumb ? `<span class="breadcrumb-separator">/</span>${groupCrumb}` : ''}${property ? `<span class="breadcrumb-separator">/</span><span>${escapeHtml(property.name)}</span>` : ''}</div>
+        <div class="page-head">
+          <div><h1>${escapeHtml(title)}</h1>${context ? `<p>${escapeHtml(context)}</p>` : ''}</div>
+          <div class="head-actions">
+            ${group || property ? `<button type="button" class="button" data-spot-check="${property ? 'Property' : 'Group'}">Spot check ${property ? 'Property' : 'Group'}</button>` : ''}
+            <button type="button" class="button" data-open-query-view="test">Test queries</button>
+            <button type="button" class="button ghost" data-project-section="settings">Measurement setup</button>
+          </div>
+        </div>
+        <div class="status-line"><span class="badge positive">Complete</span><span>Latest full sweep · 2 days ago</span><span>${escapeHtml(measuredLabel)}</span><span class="spacer"></span><button type="button" class="scope-link" data-open-query-view="tracked">36 tracked queries</button></div>`
+    }
+
+    function projectQueryTrendHtml(rows, classKey) {
+      const summary = aggregate(rows, classKey)
+      if (summary.measured === 0) {
+        return `<section class="scope-trend" aria-labelledby="project-trend-title"><div class="trend-head"><div><h2 id="project-trend-title">Visibility over time</h2><p>Run a full AI sweep to start the project trend.</p></div></div></section>`
+      }
+      const metricLabels = { mentioned: 'Mentioned', cited: 'Cited', mentionShare: 'Mention share' }
+      const metric = state.trendMetric
+      const mentionShare = Math.round(((summary.propertiesMentioned + Math.max(0, summary.propertyCount - summary.propertiesMentioned) * .2) / summary.propertyCount) * 100)
+      const current = metric === 'cited' ? summary.citationCoverage : metric === 'mentionShare' ? mentionShare : summary.mentionCoverage
+      const previous = metric === 'cited' ? summary.previousCitationCoverage : metric === 'mentionShare' ? mentionShare - 2 : summary.previousMentionCoverage
+      const now = current ?? 0
+      const delta = previous === null || previous === undefined ? null : now - previous
+      const dates = ['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Week 5', 'Week 6', 'Week 7', 'Week 8']
+      const offsets = [-7, -5, -6, -3, -4, -2, delta === null ? -1 : -delta, 0]
+      const engines = [
+        { label: 'OpenAI', color: 'var(--accent)', shift: 4 },
+        { label: 'Gemini', color: 'var(--positive)', shift: 0 },
+        { label: 'Perplexity', color: 'var(--info)', shift: -3 },
+      ]
+      const visibleSeries = state.trendMode === 'overall' || metric === 'mentionShare'
+        ? [{ label: 'All engines', color: 'var(--accent)', shift: 0 }]
+        : engines
+      const x = index => 52 + index * 100
+      const y = value => 16 + (100 - value) * 1.72
+      const grid = [100, 75, 50, 25, 0].map(value => `<line class="trend-grid" x1="52" y1="${y(value)}" x2="752" y2="${y(value)}"></line><text class="trend-axis-label" x="42" y="${y(value) + 3}" text-anchor="end">${value}%</text>`).join('')
+      const dateLabels = [0, 2, 4, 7].map(index => `<text class="trend-axis-label" x="${x(index)}" y="216" text-anchor="middle">${dates[index]}</text>`).join('')
+      const lines = visibleSeries.map((series, seriesIndex) => {
+        const values = dates.map((_, index) => clamp(Math.round(now + series.shift + offsets[index] + ((seriesIndex + index) % 3) - 1), 0, 100))
+        values[values.length - 1] = clamp(now + series.shift, 0, 100)
+        const points = values.map((value, index) => `${x(index)},${y(value)}`).join(' ')
+        return `<polyline class="trend-line" style="stroke:${series.color}" points="${points}"></polyline><circle class="trend-dot" style="fill:${series.color}" cx="752" cy="${y(values[values.length - 1])}" r="4"></circle>`
+      }).join('')
+      return `<section class="scope-trend" aria-labelledby="project-trend-title">
+        <div class="trend-head"><div><h2 id="project-trend-title">Visibility over time</h2><p>Project queries · all tracked queries · full sweeps only</p></div><button type="button" class="scope-link" data-toast="Change History compares full project sweeps and query coverage changes.">View history&nbsp;→</button></div>
+        <div class="trend-controls">
+          <div class="trend-control-group">
+            <div class="segment" role="group" aria-label="Trend metric">${Object.entries(metricLabels).map(([key, label]) => `<button type="button" data-trend-metric="${key}" aria-pressed="${metric === key}">${label}</button>`).join('')}</div>
+            ${metric !== 'mentionShare' ? `<div class="segment" role="group" aria-label="Trend series"><button type="button" data-trend-mode="byEngine" aria-pressed="${state.trendMode === 'byEngine'}">By engine</button><button type="button" data-trend-mode="overall" aria-pressed="${state.trendMode === 'overall'}">All engines</button></div>` : ''}
+            <div class="segment" role="group" aria-label="Trend window"><button type="button" data-toast="7-day trend window">7d</button><button type="button" data-toast="30-day trend window">30d</button><button type="button" data-toast="90-day trend window">90d</button><button type="button" aria-pressed="true">All</button></div>
+          </div>
+          <div class="trend-readout"><strong>${now}%</strong>${delta === null ? '' : `<span>${delta >= 0 ? '+' : ''}${delta.toFixed(1)} pts</span>`}</div>
+        </div>
+        <ul class="trend-legend-list" aria-label="Trend series">${visibleSeries.map(series => `<li class="trend-legend-item" style="--series-color:${series.color}"><span>${series.label}</span><strong>${clamp(now + series.shift, 0, 100)}%</strong></li>`).join('')}</ul>
+        <div class="trend-chart" role="img" aria-label="${metricLabels[metric]} trend for all tracked project queries across eight full sweeps">
+          <svg viewBox="0 0 800 228" preserveAspectRatio="none" aria-hidden="true">${grid}${lines}${dateLabels}</svg>
+          <div class="trend-date-row" aria-hidden="true"><span>Week 1</span><span>Week 3</span><span>Week 5</span><span>Week 8</span></div>
+        </div>
+      </section>`
+    }
+
+    function measurementChangeHtml(rows, classKey, label) {
+      const summary = aggregate(rows, classKey)
+      const mentionDelta = summary.previousMentionCoverage === null || summary.mentionCoverage === null
+        ? null
+        : summary.mentionCoverage - summary.previousMentionCoverage
+      const citationDelta = summary.previousCitationCoverage === null || summary.citationCoverage === null
+        ? null
+        : summary.citationCoverage - summary.previousCitationCoverage
+      const changedProperties = rows.filter(property => {
+        const metric = metricFor(property, classKey)
+        return metric.delta !== null && metric.delta !== 0
+      }).length
+      const signed = value => value === null ? 'N/A' : `${value > 0 ? '+' : ''}${value} pp`
+      return `<section class="scope-change" aria-labelledby="scope-change-title">
+        <div class="trend-head"><div><h2 id="scope-change-title">Since last full sweep</h2><p>${escapeHtml(label)} · comparable plan and engine scope</p></div><button type="button" class="scope-link" data-toast="This uses the existing current-versus-previous measurement change read.">View changes&nbsp;→</button></div>
+        <div class="change-grid">
+          <div class="change-item"><span>Mention coverage</span><strong>${signed(mentionDelta)}</strong></div>
+          <div class="change-item"><span>Citation coverage</span><strong>${signed(citationDelta)}</strong></div>
+          <div class="change-item"><span>Properties changed</span><strong>${changedProperties} of ${rows.length}</strong></div>
+        </div>
+      </section>`
+    }
+
+    function renderPulsePortfolio() {
+      const summaries = groupSummaries(state.queryClass)
+      const portfolio = aggregate(properties, state.queryClass)
+      return `${pulseScopeHeader({ title: 'Portfolio pulse', context: '', measuredLabel: `${portfolio.measuredPropertyCount} of ${portfolio.propertyCount} Properties measured` })}
+        <div class="toolbar">${queryClassControl(state.queryClass, 'pulse')}</div>
+        <section class="section" aria-labelledby="portfolio-summary-title">
+          <div class="section-head"><h2 id="portfolio-summary-title">Portfolio</h2><p>${portfolio.propertyCount} Properties</p></div>
+          <dl class="metrics-strip three pulse-metrics">
+            <div class="metric-summary"><dt>Properties mentioned</dt><dd>${portfolio.propertiesMentioned} of ${portfolio.propertyCount}</dd><small>${percent(portfolio.propertiesMentioned, portfolio.propertyCount)}%</small></div>
+            <div class="metric-summary"><dt>Mentioned answers</dt><dd>${portfolio.mentionCoverage ?? 'N/A'}%</dd><small>${portfolio.mentioned.toLocaleString()} of ${portfolio.measured.toLocaleString()} answers</small></div>
+            <div class="metric-summary"><dt>Cited answers</dt><dd>${portfolio.citationCoverage ?? 'N/A'}%</dd><small>${portfolio.cited.toLocaleString()} of ${portfolio.measured.toLocaleString()} answers</small></div>
+          </dl>
+          <div class="section-head" style="margin-top:16px"><h2>Outcomes</h2><p>${portfolio.propertyCount} Properties</p></div>
+          ${outcomesHtml(portfolio.outcomes)}
+        </section>
+        ${projectQueryTrendHtml(properties, state.queryClass)}
+        <section class="section" aria-labelledby="group-rollup-title">
+          <div class="section-head"><h2 id="group-rollup-title">Groups</h2><p>${groupDefinitions.length}</p></div>
+          <div class="table-wrap portfolio-groups"><table><caption class="sr-only">Advanced Measurement Group rollup, weakest mention coverage first</caption>
+            <thead><tr><th>Group</th><th>Properties</th><th>Mention</th><th>Citation</th></tr></thead><tbody>
+              ${[...summaries].sort((a, b) => (a.aggregate.mentionCoverage ?? 101) - (b.aggregate.mentionCoverage ?? 101)).map(group => `<tr class="data-row">
+                <td><button type="button" class="text-button property-name" data-open-pulse-group="${group.key}">${escapeHtml(group.label)}</button></td>
+                <td>${group.aggregate.propertyCount}</td>
+                <td class="metric-cell">${formatMetric(group.aggregate.mentioned, group.aggregate.measured)}</td>
+                <td class="metric-cell">${formatMetric(group.aggregate.cited, group.aggregate.measured)}</td>
+              </tr>`).join('')}
+            </tbody></table></div>
+        </section>`
+    }
+
+    function renderPulseGroup(group) {
+      const rows = groupRows(group.key)
+      const summary = aggregate(rows, state.queryClass)
+      const ranked = [...rows].sort((a, b) => (percent(metricFor(a, state.queryClass).cited, metricFor(a, state.queryClass).measured) ?? 101) - (percent(metricFor(b, state.queryClass).cited, metricFor(b, state.queryClass).measured) ?? 101))
+      return `${pulseScopeHeader({ title: group.label, context: `Group · ${rows.length} Properties`, measuredLabel: `${summary.measuredPropertyCount} of ${rows.length} Properties measured`, group })}
+        <div class="toolbar">${queryClassControl(state.queryClass, 'pulse')}</div>
+        <section class="section" aria-labelledby="group-summary-title"><div class="section-head"><h2 id="group-summary-title">Group pulse</h2><p>${summary.propertyCount} Properties</p></div>
+          <dl class="metrics-strip three pulse-metrics">
+            <div class="metric-summary"><dt>Properties mentioned</dt><dd>${summary.propertiesMentioned} of ${summary.propertyCount}</dd><small>${percent(summary.propertiesMentioned, summary.propertyCount)}%</small></div>
+            <div class="metric-summary"><dt>Mentioned answers</dt><dd>${summary.mentionCoverage ?? 'N/A'}%</dd><small>${summary.mentioned} of ${summary.measured} answers</small></div>
+            <div class="metric-summary"><dt>Cited answers</dt><dd>${summary.citationCoverage ?? 'N/A'}%</dd><small>${summary.cited} of ${summary.measured} answers</small></div>
+          </dl>
+          <div class="section-head" style="margin-top:16px"><h2>Outcomes</h2><p>${summary.propertyCount} Properties</p></div>
+          ${outcomesHtml(summary.outcomes)}
+        </section>
+        ${measurementChangeHtml(rows, state.queryClass, `${group.label} Group`)}
+        <section class="section" aria-labelledby="group-properties-title"><div class="section-head"><h2 id="group-properties-title">Properties</h2><p>Lowest citation first</p></div>
+          <div class="table-wrap scope-table"><table><caption class="sr-only">${escapeHtml(group.label)} Properties</caption><thead><tr><th>Property</th><th>Mention</th><th>Citation</th><th>Status</th></tr></thead><tbody>
+            ${ranked.map(property => {
+              const metric = metricFor(property, state.queryClass)
+              const [status, tone] = pulseStatusFor(property, metric)
+              return `<tr class="data-row"><td><button type="button" class="text-button property-name" data-open-pulse-property="${property.id}">${escapeHtml(property.name)}</button><div class="subline">1 URL · ${property.queries.length} query patterns</div></td><td>${formatMetric(metric.mentioned, metric.measured)}</td><td>${formatMetric(metric.cited, metric.measured)}</td><td>${property.issue ? badge(status, tone) : '<span class="subline">Measured</span>'}</td></tr>`
+            }).join('')}
+          </tbody></table></div>
+        </section>`
+    }
+
+    function renderPulseProperty(property) {
+      const group = groupDefinitions.find(candidate => candidate.key === property.groupKey)
+      const metric = metricFor(property, state.queryClass)
+      const summary = aggregate([property], state.queryClass)
+      const [status, tone] = pulseStatusFor(property, metric)
+      const propertyIndex = properties.findIndex(candidate => candidate.id === property.id)
+      const alternativeSources = ['marketplace-a.example', 'marketplace-b.example', 'marketplace-c.example']
+      return `${pulseScopeHeader({ title: property.name, context: `Property · ${property.groupLabel} · 1 URL`, measuredLabel: metric.measured ? `${metric.measured} answers measured` : 'Not measured', group, property })}
+        <div class="toolbar">${queryClassControl(state.queryClass, 'pulse')}<span style="align-self:center">${badge(status, tone)}</span></div>
+        <section class="section" aria-labelledby="property-summary-title"><div class="section-head"><h2 id="property-summary-title">Current sweep</h2></div>
+          <dl class="metrics-strip three pulse-metrics">
+            <div class="metric-summary"><dt>Mentioned answers</dt><dd>${summary.mentionCoverage ?? 'N/A'}%</dd><small>${metric.mentioned} of ${metric.measured} answers</small></div>
+            <div class="metric-summary"><dt>Cited answers</dt><dd>${summary.citationCoverage ?? 'N/A'}%</dd><small>${metric.cited} of ${metric.measured} answers</small></div>
+            <div class="metric-summary"><dt>Answers measured</dt><dd>${metric.measured || 'N/A'}</dd><small>${state.queryClass === 'nonBrand' ? 'Non-brand' : 'Branded'}</small></div>
+          </dl>
+        </section>
+        ${measurementChangeHtml([property], state.queryClass, property.name)}
+        <section class="section" aria-labelledby="property-engines-title"><div class="section-head"><h2 id="property-engines-title">Answer engines</h2></div>
+          <div class="table-wrap"><table><caption class="sr-only">${escapeHtml(property.name)} answer engine results</caption><thead><tr><th>Engine</th><th>Answers</th><th>Mention</th><th>Citation</th></tr></thead><tbody>
+            ${metric.providers.map(provider => `<tr><td class="property-name">${provider.provider}</td><td>${provider.measured}</td><td>${formatMetric(provider.mentioned, provider.measured)}</td><td>${formatMetric(provider.cited, provider.measured)}</td></tr>`).join('')}
+          </tbody></table></div>
+        </section>
+        <section class="section" aria-labelledby="property-answers-title"><div class="section-head"><h2 id="property-answers-title">Latest answers</h2><p>Open a row for stored answer and source evidence</p></div>
+          <div class="table-wrap scope-table"><table><caption class="sr-only">${escapeHtml(property.name)} latest answer evidence</caption><thead><tr><th>Question</th><th>Engine</th><th>Mention</th><th>Citation</th><th>Top source</th><th><span class="sr-only">Open</span></th></tr></thead><tbody>
+            ${property.queries.map((query, index) => {
+              const wasMeasured = metric.measured > 0
+              const cited = wasMeasured && (index === 0 || metric.cited > index + 1)
+              const mentioned = wasMeasured && (index !== 0 ? metric.mentioned > index : propertyIndex % 2 === 0)
+              const mentionCell = wasMeasured ? `<span class="question-signal"><span class="signal-dot ${mentioned ? 'yes' : 'no'}"></span>${mentioned ? 'Yes' : 'No'}</span>` : '<span class="not-measured">Not measured</span>'
+              const citationCell = wasMeasured ? `<span class="question-signal"><span class="signal-dot ${cited ? 'yes' : 'no'}"></span>${cited ? 'Yes' : 'No'}</span>` : '<span class="not-measured">Not measured</span>'
+              const source = wasMeasured ? (cited ? 'northstar.example' : alternativeSources[index]) : '—'
+              return `<tr class="data-row"><td class="property-name">${escapeHtml(query)}</td><td>${providers[index]}</td><td>${mentionCell}</td><td>${citationCell}</td><td>${escapeHtml(source)}</td><td class="scope-table-actions"><button type="button" class="scope-link" data-toast="A production build would open the stored answer and source evidence.">Evidence&nbsp;→</button></td></tr>`
+            }).join('')}
+          </tbody></table></div>
+        </section>`
+    }
+
+    function renderPulse() {
+      const property = state.pulseProperty ? properties.find(candidate => candidate.id === state.pulseProperty) : null
+      if (property) return renderPulseProperty(property)
+      const group = state.pulseGroup ? groupDefinitions.find(candidate => candidate.key === state.pulseGroup) : null
+      if (group) return renderPulseGroup(group)
+      return renderPulsePortfolio()
+    }
+
+    function queryWorkspaceHeader(title, description = '') {
+      const tabs = [
+        { key: 'tracked', label: 'Tracked' },
+        { key: 'discover', label: 'Discover' },
+        { key: 'test', label: 'Test' },
+      ]
+      return `<div class="breadcrumb"><span>Northstar Demo</span><span class="breadcrumb-separator">/</span><span>Queries</span></div>
+        <div class="page-head"><div><h1>${escapeHtml(title)}</h1>${description ? `<p>${escapeHtml(description)}</p>` : ''}</div></div>
+        <nav class="workspace-tabs" aria-label="Query workflows">${tabs.map(tab => `<button type="button" class="${state.queryView === tab.key ? 'active' : ''}" data-query-view="${tab.key}" aria-current="${state.queryView === tab.key ? 'page' : 'false'}">${tab.label}</button>`).join('')}</nav>`
+    }
+
+    function trackedQueryRows() {
+      const unique = [...new Set(properties.flatMap(property => property.queries))]
+      const rows = unique.slice(0, 12).map((query, index) => ({
+        query,
+        classLabel: index % 4 === 0 ? 'Branded' : 'Non-brand',
+        assigned: index % 5 === 0 ? properties.length : 8 + ((index * 17) % 74),
+        mentioned: 38 + ((index * 11) % 42),
+        cited: 18 + ((index * 7) % 31),
+        lastMeasured: index === 10 ? 'Not measured' : '2 days ago',
+      }))
+      if (state.publishedQuery) {
+        rows.unshift({ query: state.publishedQuery, classLabel: 'Non-brand', assigned: 15, mentioned: null, cited: null, lastMeasured: 'Awaiting first sweep' })
+        rows.length = 12
+      }
+      return rows
+    }
+
+    function trackedQueryRowHtml(row) {
+      const measured = typeof row.mentioned === 'number' && typeof row.cited === 'number' && row.lastMeasured === '2 days ago'
+      const measuredCell = value => measured ? `<span class="metric-value">${value}%</span>` : '<span class="not-measured">Not measured</span>'
+      const lastMeasured = row.lastMeasured === 'Awaiting first sweep' ? badge('Awaiting first sweep', 'caution') : row.lastMeasured
+      return `<tr class="data-row"><td class="property-name">${escapeHtml(row.query)}</td><td>${row.classLabel}</td><td>${row.assigned} of ${properties.length}</td><td>${lastMeasured}</td><td>${measuredCell(row.mentioned)}</td><td>${measuredCell(row.cited)}</td><td class="scope-table-actions"><button type="button" class="scope-link" data-toast="Assignment editing opens the Advanced Measurement draft, preserving the published plan.">Assignments&nbsp;→</button></td></tr>`
+    }
+
+    function promotionStepsHtml(step) {
+      const steps = ['Assign', 'Confirm']
+      return `<ol class="promotion-steps" aria-label="Add query to measurement progress">${steps.map((label, index) => {
+        const stepNumber = index + 1
+        const stateClass = stepNumber < step ? 'complete' : stepNumber === step ? 'current' : ''
+        return `<li class="promotion-step ${stateClass}" ${stepNumber === step ? 'aria-current="step"' : ''}><span class="promotion-step-number">${stepNumber < step ? '✓' : stepNumber}</span><span>${label}</span></li>`
+      }).join('')}</ol>`
+    }
+
+    function renderPromotionPanel() {
+      if (!state.promotionStep) return ''
+      const query = state.promotionQuery || 'What are the best luxury apartments in Metro Golf?'
+      const step = state.promotionStep
+      const source = state.queryView === 'discover' ? 'Discovery candidate' : 'Saved test'
+      const sourceDetail = state.queryView === 'discover' ? 'Portfolio discovery · sample candidates' : 'OpenAI · Metro Golf · sample run'
+      if (step === 1) {
+        return `<section class="promotion-panel" aria-labelledby="promotion-title">
+          <div class="section-head"><div><span class="eyebrow">Measurement draft</span><h2 id="promotion-title" tabindex="-1">Add to measurement</h2><p>Choose the published scope without leaving this workspace.</p></div><button type="button" class="button small ghost" data-promotion-cancel>Cancel</button></div>
+          ${promotionStepsHtml(step)}
+          <div class="promotion-body">
+            <h3>Assign query</h3>
+            <p>Choose how the query enters the portfolio measurement.</p>
+            <div class="promotion-origin"><span class="badge info">${source}</span><span>${sourceDetail}</span><span class="badge positive">No duplicate found</span></div>
+            <div class="promotion-query">${escapeHtml(query)}</div>
+            <div class="promotion-fields">
+              <div class="field"><label for="promotion-class">Query type</label><select id="promotion-class" class="control"><option>Non-brand</option><option>Branded</option></select></div>
+              <div class="field"><label for="promotion-scope">Use a Group to select Properties</label><select id="promotion-scope" class="control"><option>Metro Golf · 15 Properties</option><option>All 225 Properties</option><option>Specific Properties…</option></select></div>
+            </div>
+            <div class="assignment-preview" aria-label="Selected Property preview"><span>Northstar Demo Station</span><span>The Arden at Metro Golf</span><span>Emerson Metro Golf</span><span>+12 Properties</span></div>
+            <p class="section-note">The published plan stores 15 Property assignments, not a live Group reference. If the normalized query already exists, this step updates its assignments instead of creating a duplicate.</p>
+            <div class="promotion-actions"><button type="button" class="button ghost" data-promotion-cancel>Discard draft</button><button type="button" class="button primary" data-promotion-next>Continue to confirmation</button></div>
+          </div>
+        </section>`
+      }
+      return `<section class="promotion-panel" aria-labelledby="promotion-title">
+          <div class="section-head"><div><span class="eyebrow">Measurement draft</span><h2 id="promotion-title" tabindex="-1">Add to measurement</h2><p>Review the exact plan change before publishing.</p></div><button type="button" class="button small ghost" data-promotion-cancel>Cancel</button></div>
+          ${promotionStepsHtml(step)}
+          <div class="promotion-body">
+            <h3>Confirm measurement change</h3>
+            <p>The current published revision remains live until this change is published.</p>
+            <dl class="review-list">
+              <div class="review-row"><dt>Query</dt><dd class="property-name">${escapeHtml(query)}</dd></div>
+              <div class="review-row"><dt>Query type</dt><dd>Non-brand</dd></div>
+              <div class="review-row"><dt>Assigned Properties</dt><dd>Metro Golf selection · 15 Properties</dd></div>
+              <div class="review-row"><dt>First official measurement</dt><dd>Next full AI sweep · Wednesday at 9:00 AM UTC</dd></div>
+            </dl>
+            <div class="review-impact"><span><strong>1</strong> query added</span><span><strong>15</strong> Property assignments</span><span><strong>0</strong> runs started</span></div>
+            <p class="section-note">Publishing changes the long-term plan. It does not count the saved test as official evidence or start a sweep.</p>
+            <div class="promotion-actions"><button type="button" class="button ghost" data-promotion-back>Back</button><button type="button" class="button primary" data-promotion-publish>Publish new revision</button></div>
+          </div>
+        </section>`
+    }
+
+    function renderTrackedQueries() {
+      const rows = trackedQueryRows()
+      return `${queryWorkspaceHeader('Tracked queries', 'The published query basket and its Property assignments.')}
+        <div class="query-toolbar">
+          <div class="field grow"><label for="tracked-search">Search queries</label><input id="tracked-search" class="control" type="search" placeholder="Query text"></div>
+          <div class="field"><label for="tracked-class">Query type</label><select id="tracked-class" class="control"><option>All</option><option>Non-brand</option><option>Branded</option></select></div>
+          <button type="button" class="button" data-toggle-query-composer>${state.queryComposer ? 'Cancel' : '+ Add query'}</button>
+        </div>
+        ${state.queryComposer ? `<section class="query-composer" aria-labelledby="query-composer-title">
+          <div class="section-head"><div><h2 id="query-composer-title">Add to measurement</h2><p>New queries stay in draft until assigned and published.</p></div></div>
+          <div class="query-composer-grid">
+            <div class="field"><label for="new-tracked-query">Queries</label><textarea id="new-tracked-query" class="control" placeholder="One query per line">best luxury apartments near metro golf</textarea></div>
+            <div class="field"><label for="new-query-class">Query type</label><select id="new-query-class" class="control"><option>Non-brand</option><option>Branded</option></select></div>
+            <div class="field"><label for="new-query-scope">Assign to</label><select id="new-query-scope" class="control"><option>Choose Properties…</option><option>All 225 Properties</option><option>Metro Golf · 15 Properties</option><option>Specific Properties…</option></select></div>
+          </div>
+          <div class="head-actions" style="margin-top:14px"><button type="button" class="button ghost" data-toggle-query-composer>Cancel</button><button type="button" class="button primary" data-toast="Added to the measurement draft. Publish the draft before the next full sweep.">Add to draft</button></div>
+        </section>` : ''}
+        <div class="table-wrap"><table><caption class="sr-only">Tracked project queries</caption><thead><tr><th>Query</th><th>Type</th><th>Assigned Properties</th><th>Last measured</th><th>Mention</th><th>Citation</th><th><span class="sr-only">Actions</span></th></tr></thead><tbody>
+          ${rows.map(trackedQueryRowHtml).join('')}
+        </tbody></table></div>
+        <div class="table-footer"><span>Showing 12 of ${state.publishedQuery ? 37 : 36} tracked queries</span><button type="button" class="button small" data-toast="The production list uses server paging.">Show more</button></div>`
+    }
+
+    function renderDiscoverQueries() {
+      const candidates = [
+        ['best apartments near major employers', 'Cited opportunity', '18 Properties'],
+        ['luxury apartments with short commutes', 'Aspirational', '32 Properties'],
+        ['pet friendly apartments with dog parks', 'Cited opportunity', '71 Properties'],
+        ['apartments with flexible lease terms', 'Coverage gap', '44 Properties'],
+      ]
+      return `${queryWorkspaceHeader('Discover queries', 'Find candidate demand, then choose what enters measurement.')}
+        <div class="test-layout">
+          <section class="test-pane"><h2>New discovery</h2><p>Describe the renter and market you want to cover.</p>
+            <div class="form-stack"><div class="field"><label for="discovery-icp">Audience and intent</label><textarea id="discovery-icp" class="control">Prospective renters comparing professionally managed apartments across a synthetic national portfolio.</textarea></div><div><button type="button" class="button" data-toast="A discovery session would start without changing the tracked query basket.">Find candidates</button></div></div>
+          </section>
+          <section class="test-pane"><h2>Latest candidates</h2><p>Sample discovery · 63 candidates found</p>
+            <div class="table-wrap" style="margin-top:14px"><table><thead><tr><th>Candidate</th><th>Signal</th><th>Suggested scope</th><th></th></tr></thead><tbody>${candidates.map(candidate => `<tr><td class="property-name">${candidate[0]}</td><td>${candidate[1]}</td><td>${candidate[2]}</td><td><button type="button" class="scope-link" data-add-to-measurement data-promotion-query="${escapeHtml(candidate[0])}">Add&nbsp;→</button></td></tr>`).join('')}</tbody></table></div>
+          </section>
+        </div>
+        ${renderPromotionPanel()}`
+    }
+
+    function renderTestQueries() {
+      const testQueries = [
+        'What are the best luxury apartments in Metro Golf?',
+        'Which Metro Golf apartments have coworking spaces?',
+        'Where can I find pet-friendly apartments near central Metro Golf?',
+      ]
+      return `${queryWorkspaceHeader('Test queries', 'Run saved checks without changing the official measurement.')}
+        <div class="query-notice"><span class="badge info">Test</span><strong>Saved separately</strong><span>Does not change tracked queries, Portfolio Pulse, trends, or the AI sweep schedule.</span></div>
+        <div class="test-layout">
+          <section class="test-pane"><h2>New test</h2><p>Use arbitrary prompts with one API model and location.</p>
+            <div class="form-stack">
+              <div class="field"><label for="test-query-text">Queries</label><textarea id="test-query-text" class="control">${testQueries.join('\n')}</textarea></div>
+              <div class="form-grid"><div class="field"><label for="test-provider">API provider</label><select id="test-provider" class="control"><option>Project default</option><option>OpenAI</option><option>Gemini</option></select></div><div class="field"><label for="test-location">Location</label><select id="test-location" class="control"><option>Metro Golf</option><option>Project default</option><option>No location</option></select></div></div>
+              <div><button type="button" class="button primary" data-run-research>Run 3 test queries</button></div>
+            </div>
+            <div class="settings-section" style="margin-top:20px"><h2>Spot check published measurement</h2><p class="section-note">Run assigned questions for one Group or Property. The probe stays out of official reporting.</p><div class="form-grid" style="margin-top:12px"><div class="field"><label for="spot-check-scope">Scope</label><select id="spot-check-scope" class="control"><option>Metro Golf Group</option><option>Northstar Demo Station</option><option>All published queries</option></select></div><div class="field" style="align-self:end"><button type="button" class="button" data-spot-check="Selected scope">Run spot check</button></div></div></div>
+          </section>
+          <section class="test-pane"><h2>Saved tests</h2><p>Standalone answer and source evidence.</p><div class="test-batches">
+            <button type="button" class="test-batch active"><span>3 Metro Golf queries</span><span>OpenAI</span><span class="badge positive">Complete</span></button>
+            <button type="button" class="test-batch"><span>5 apartment comparison queries</span><span>Gemini</span><span class="badge positive">Complete</span></button>
+            <button type="button" class="test-batch"><span>2 brand recall queries</span><span>OpenAI</span><span class="badge caution">Partial</span></button>
+          </div></section>
+        </div>
+        ${state.researchComplete ? `<section class="test-result" aria-labelledby="test-results-title"><div class="section-head"><div><h2 id="test-results-title">Test results</h2><p>OpenAI · Metro Golf · sample run</p></div></div><div class="table-wrap"><table><thead><tr><th>Query</th><th>Mention</th><th>Citation</th><th>Sources</th><th></th></tr></thead><tbody>${testQueries.map((query, index) => `<tr><td class="property-name">${escapeHtml(query)}</td><td>${index === 1 ? badge('Not mentioned', '') : badge('Mentioned', 'positive')}</td><td>${index === 0 ? badge('Cited', 'positive') : badge('Not cited', '')}</td><td>${index === 0 ? 'northstar.example · marketplace-a.example' : index === 1 ? 'marketplace-a.example · marketplace-b.example' : 'marketplace-c.example'}</td><td><button type="button" class="scope-link" data-add-to-measurement data-promotion-query="${escapeHtml(query)}">Add to measurement&nbsp;→</button></td></tr>`).join('')}</tbody></table></div></section>` : ''}
+        ${renderPromotionPanel()}`
+    }
+
+    function renderQueries() {
+      if (state.queryView === 'discover') return renderDiscoverQueries()
+      if (state.queryView === 'test') return renderTestQueries()
+      return renderTrackedQueries()
+    }
+
+    function renderSettings() {
+      return `<div class="breadcrumb"><span>Northstar Demo</span><span class="breadcrumb-separator">/</span><span>Settings</span></div>
+        <div class="page-head"><div><h1>Settings</h1><p>Project configuration and automation.</p></div></div>
+        <section class="settings-section" aria-labelledby="measurement-settings-title"><div class="section-head"><div><span class="eyebrow">Advanced measurement</span><h2 id="measurement-settings-title">Measurement setup</h2></div><button type="button" class="button" data-toast="The setup draft opens with the current revision still published.">Edit measurement</button></div><div class="settings-row"><div class="settings-facts"><strong>Published · current revision</strong><span>225 Properties · 15 Groups · 36 tracked queries</span><span>Last published 5 days ago</span></div></div></section>
+        <section class="settings-section" aria-labelledby="schedule-settings-title"><div class="section-head"><div><span class="eyebrow">Automation</span><h2 id="schedule-settings-title">AI visibility sweep</h2></div>${state.scheduleEditing ? '' : '<button type="button" class="button" data-edit-schedule>Edit schedule</button>'}</div>
+          ${state.scheduleEditing ? `<div class="schedule-editor"><div class="form-grid"><div class="field"><label for="schedule-frequency">Frequency</label><select id="schedule-frequency" class="control"><option>Every Wednesday</option><option>Every day</option><option>Every Monday</option><option>Every Friday</option></select></div><div class="field"><label for="schedule-time">Time</label><select id="schedule-time" class="control"><option>9:00 AM</option><option>1:00 PM</option><option>6:00 PM</option></select></div><div class="field"><label for="schedule-timezone">Timezone</label><select id="schedule-timezone" class="control"><option>UTC</option><option>America/New_York</option><option>America/Chicago</option></select></div></div><div class="head-actions" style="margin-top:14px;justify-content:flex-start"><button type="button" class="button ghost" data-cancel-schedule>Cancel</button><button type="button" class="button primary" data-save-schedule>Save schedule</button></div></div>` : `<div class="settings-row"><div class="settings-facts"><strong>Every Wednesday at 9:00 AM · UTC</strong><span>Next run · this Wednesday at 9:00 AM</span><span>Last run · previous Wednesday at 9:03 AM</span></div><div class="settings-actions"><span class="badge positive">Active</span><button type="button" class="button small" data-toast="The project-wide AI sweep schedule would be paused.">Pause</button><button type="button" class="button small ghost" data-toast="The project-wide AI sweep schedule would be removed.">Remove</button></div></div>`}
+        </section>
+        <p class="section-note">One schedule runs the full published plan. Groups and Properties inherit its official results; they do not have separate schedules.</p>`
+    }
+
+    function render() {
+      const root = document.getElementById('flow-root')
+      root.innerHTML = state.section === 'queries'
+        ? renderQueries()
+        : state.section === 'settings'
+          ? renderSettings()
+          : renderPulse()
+      root.setAttribute('aria-label', state.section === 'queries' ? 'Query workspace prototype' : state.section === 'settings' ? 'Project settings prototype' : 'Portfolio Pulse prototype')
+      document.querySelectorAll('.project-subnav [data-project-section]').forEach(button => {
+        button.classList.toggle('active', button.dataset.projectSection === state.section)
+        if (button.dataset.projectSection === state.section) button.setAttribute('aria-current', 'page')
+        else button.removeAttribute('aria-current')
+      })
+    }
+
+    function clearPromotion() {
+      state.promotionStep = 0
+      state.promotionQuery = ''
+    }
+
+    function focusPromotionPanel() {
+      document.getElementById('promotion-title')?.focus()
+    }
+
+    function focusQueryWorkspace() {
+      document.querySelector(`[data-query-view="${state.queryView}"]`)?.focus()
+    }
+
+    let toastTimer = null
+    function showToast(message) {
+      const toast = document.getElementById('toast')
+      toast.textContent = message
+      toast.classList.add('visible')
+      window.clearTimeout(toastTimer)
+      toastTimer = window.setTimeout(() => toast.classList.remove('visible'), 2600)
+    }
+
+    document.addEventListener('click', event => {
+      const target = event.target.closest('button, a')
+      if (!target) return
+      if (target.dataset.toast) {
+        event.preventDefault()
+        showToast(target.dataset.toast)
+        return
+      }
+      if (target.dataset.projectSection) {
+        state.section = target.dataset.projectSection
+        if (state.section !== 'queries') clearPromotion()
+        if (state.section === 'visibility') history.pushState(null, '', '#pulse')
+        else if (state.section === 'queries') history.pushState(null, '', `#queries/${state.queryView}`)
+        else history.pushState(null, '', '#settings')
+        render()
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+        return
+      }
+      if (target.dataset.openQueryView) {
+        state.section = 'queries'
+        clearPromotion()
+        state.queryView = target.dataset.openQueryView
+        history.pushState(null, '', `#queries/${state.queryView}`)
+        render()
+        focusQueryWorkspace()
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+        return
+      }
+      if (target.dataset.queryView) {
+        clearPromotion()
+        state.queryView = target.dataset.queryView
+        history.pushState(null, '', `#queries/${state.queryView}`)
+        render()
+        focusQueryWorkspace()
+        return
+      }
+      if (target.dataset.trendMetric) {
+        state.trendMetric = target.dataset.trendMetric
+        if (state.trendMetric === 'mentionShare') state.trendMode = 'overall'
+        render()
+        return
+      }
+      if (target.dataset.trendMode) {
+        state.trendMode = target.dataset.trendMode
+        render()
+        return
+      }
+      if (target.dataset.toggleQueryComposer !== undefined) {
+        state.queryComposer = !state.queryComposer
+        render()
+        return
+      }
+      if (target.dataset.runResearch !== undefined) {
+        state.researchComplete = true
+        render()
+        showToast('Test complete. Saved separately from official measurement.')
+        return
+      }
+      if (target.dataset.addToMeasurement !== undefined) {
+        state.section = 'queries'
+        state.queryComposer = false
+        state.promotionQuery = target.dataset.promotionQuery || 'What are the best luxury apartments in Metro Golf?'
+        state.promotionStep = 1
+        render()
+        focusPromotionPanel()
+        return
+      }
+      if (target.dataset.promotionNext !== undefined) {
+        state.promotionStep = 2
+        render()
+        focusPromotionPanel()
+        return
+      }
+      if (target.dataset.promotionBack !== undefined) {
+        state.promotionStep = 1
+        render()
+        focusPromotionPanel()
+        return
+      }
+      if (target.dataset.promotionPublish !== undefined) {
+        state.publishedQuery = state.promotionQuery
+        clearPromotion()
+        state.queryView = 'tracked'
+        history.pushState(null, '', '#queries/tracked')
+        render()
+        focusQueryWorkspace()
+        showToast('Published new revision. The query is awaiting its first sweep.')
+        return
+      }
+      if (target.dataset.promotionCancel !== undefined) {
+        clearPromotion()
+        render()
+        focusQueryWorkspace()
+        return
+      }
+      if (target.dataset.spotCheck) {
+        showToast(`${target.dataset.spotCheck} probe queued. It will not affect Portfolio Pulse or trends.`)
+        return
+      }
+      if (target.dataset.runSweep !== undefined) {
+        showToast('Full project AI sweep queued for the published measurement plan.')
+        return
+      }
+      if (target.dataset.editSchedule !== undefined) {
+        state.scheduleEditing = true
+        render()
+        return
+      }
+      if (target.dataset.cancelSchedule !== undefined) {
+        state.scheduleEditing = false
+        render()
+        return
+      }
+      if (target.dataset.saveSchedule !== undefined) {
+        state.scheduleEditing = false
+        render()
+        showToast('Project-wide AI sweep schedule saved.')
+        return
+      }
+      if (target.dataset.queryClass) {
+        state.queryClass = target.dataset.queryClass
+        render()
+        return
+      }
+      if (target.dataset.openPulseGroup) {
+        state.section = 'visibility'
+        state.pulseGroup = target.dataset.openPulseGroup
+        state.pulseProperty = null
+        history.pushState(null, '', `#pulse/group/${state.pulseGroup}`)
+        render()
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+        return
+      }
+      if (target.dataset.openPulseProperty) {
+        state.section = 'visibility'
+        state.pulseGroup = null
+        state.pulseProperty = target.dataset.openPulseProperty
+        history.pushState(null, '', `#pulse/property/${state.pulseProperty}`)
+        render()
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+        return
+      }
+      if (target.dataset.pulseBack) {
+        state.section = 'visibility'
+        if (target.dataset.pulseBack === 'group') {
+          state.pulseGroup = target.dataset.groupKey
+          state.pulseProperty = null
+          history.pushState(null, '', `#pulse/group/${state.pulseGroup}`)
+        } else {
+          state.pulseGroup = null
+          state.pulseProperty = null
+          history.pushState(null, '', '#pulse')
+        }
+        render()
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+        return
+      }
+    })
+
+    function syncRouteFromLocation() {
+      const next = routeFromHash()
+      clearPromotion()
+      state.section = next.section
+      state.queryView = next.queryView
+      state.pulseGroup = next.pulseGroup
+      state.pulseProperty = next.pulseProperty
+      render()
+    }
+    window.addEventListener('hashchange', syncRouteFromLocation)
+    window.addEventListener('popstate', syncRouteFromLocation)
+
+    render()
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.179.0",
+  "version": "4.179.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -4941,6 +4941,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -4950,6 +4951,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -4966,6 +4968,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -4975,6 +4978,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -4991,6 +4995,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5000,6 +5005,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5020,6 +5026,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5029,6 +5036,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5045,6 +5053,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5054,6 +5063,7 @@ export type MeasurementChangesResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5298,6 +5308,7 @@ export type MeasurementOverviewResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5307,6 +5318,7 @@ export type MeasurementOverviewResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5316,6 +5328,7 @@ export type MeasurementOverviewResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5325,6 +5338,7 @@ export type MeasurementOverviewResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5337,6 +5351,7 @@ export type MeasurementOverviewResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5351,6 +5366,7 @@ export type MeasurementOverviewResponse = {
                 value: number;
                 numerator?: number;
                 denominator?: number;
+                rate?: number;
             } | {
                 state: 'unavailable';
                 reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5360,6 +5376,7 @@ export type MeasurementOverviewResponse = {
                 value: number;
                 numerator?: number;
                 denominator?: number;
+                rate?: number;
             } | {
                 state: 'unavailable';
                 reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5371,6 +5388,7 @@ export type MeasurementOverviewResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5380,6 +5398,7 @@ export type MeasurementOverviewResponse = {
                     value: number;
                     numerator?: number;
                     denominator?: number;
+                    rate?: number;
                 } | {
                     state: 'unavailable';
                     reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5435,6 +5454,7 @@ export type MeasurementPortfolioSummaryResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5444,6 +5464,7 @@ export type MeasurementPortfolioSummaryResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5453,6 +5474,7 @@ export type MeasurementPortfolioSummaryResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5466,6 +5488,7 @@ export type MeasurementPortfolioSummaryResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5475,6 +5498,7 @@ export type MeasurementPortfolioSummaryResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5496,6 +5520,7 @@ export type MeasurementPortfolioSummaryResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5505,6 +5530,7 @@ export type MeasurementPortfolioSummaryResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';
@@ -5514,6 +5540,7 @@ export type MeasurementPortfolioSummaryResponse = {
             value: number;
             numerator?: number;
             denominator?: number;
+            rate?: number;
         } | {
             state: 'unavailable';
             reason: 'no_completed_run' | 'plan_v1' | 'no_population' | 'evidence_incomplete' | 'not_applicable';

--- a/packages/api-routes/src/measurement-overview.ts
+++ b/packages/api-routes/src/measurement-overview.ts
@@ -229,7 +229,13 @@ function providerRows(property: MeasurementOverviewPropertyRow): MeasurementProp
 /** A count metric reads out as the numerator, with the eligible population beside it. */
 function countMetric(rate: MeasurementRate): MetricValue {
   if (rate.numerator === null) return unavailable(metricReason(rate.reason))
-  return { state: 'available', value: rate.numerator, numerator: rate.numerator, denominator: rate.denominator }
+  return {
+    state: 'available',
+    value: rate.numerator,
+    numerator: rate.numerator,
+    denominator: rate.denominator,
+    ...(rate.rate === null ? {} : { rate: rate.rate }),
+  }
 }
 
 function normalizedText(value: string): string {

--- a/packages/api-routes/src/measurement-portfolio-reads.ts
+++ b/packages/api-routes/src/measurement-portfolio-reads.ts
@@ -156,7 +156,13 @@ function coverageMetric(rate: MeasurementRate): MetricValue {
 
 function countMetric(rate: MeasurementRate): MetricValue {
   if (rate.numerator === null) return unavailable(metricReason(rate.reason))
-  return { state: 'available', value: rate.numerator, numerator: rate.numerator, denominator: rate.denominator }
+  return {
+    state: 'available',
+    value: rate.numerator,
+    numerator: rate.numerator,
+    denominator: rate.denominator,
+    ...(rate.rate === null ? {} : { rate: rate.rate }),
+  }
 }
 
 /** The materializer reads through its explicit DB argument; the report kernel never does. */

--- a/packages/api-routes/test/measurement-portfolio-reads.test.ts
+++ b/packages/api-routes/test/measurement-portfolio-reads.test.ts
@@ -295,6 +295,8 @@ describe('measurement portfolio reads', () => {
     if (harborOnly.propertiesMentioned.state === 'available' && regional.propertiesMentioned.state === 'available') {
       expect(harborOnly.propertiesMentioned.denominator).toBe(1)
       expect(regional.propertiesMentioned.denominator).toBe(2)
+      expect(harborOnly.propertiesMentioned.rate).toBe(harborOnly.propertiesMentioned.numerator / harborOnly.propertiesMentioned.denominator)
+      expect(regional.propertiesMentioned.rate).toBe(regional.propertiesMentioned.numerator / regional.propertiesMentioned.denominator)
     }
 
     // Same computation as the group-scoped read, so the dashboard and the CLI

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.179.0",
+  "version": "4.179.1",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/measurement-plan.ts
+++ b/packages/canonry/src/commands/measurement-plan.ts
@@ -457,7 +457,7 @@ function printMeasurementProperty(response: MeasurementOverviewResponse): void {
   lines.push('')
   lines.push(`Mentioned  ${metricText(row ? row.mentionCoverage : response.metrics.mentionCoverage)}`)
   lines.push(`Cited      ${metricText(row ? row.citationCoverage : response.metrics.citationCoverage)}`)
-  if (row && row.flags > 0) lines.push(`Flagged    ${row.flags} ${row.flags === 1 ? 'result needs' : 'results need'} review`)
+  if (row && row.flags > 0) lines.push(`Ambiguous  ${row.flags} source-to-Property ${row.flags === 1 ? 'match' : 'matches'}`)
 
   if (row && row.providers.length > 0) {
     lines.push('')

--- a/packages/canonry/test/measurement-plan-commands.test.ts
+++ b/packages/canonry/test/measurement-plan-commands.test.ts
@@ -595,6 +595,28 @@ describe('measurement-plan CLI commands', () => {
     expect(output).not.toMatch(/\d+%/)
   })
 
+  it('labels ambiguous source-to-Property matches consistently', async () => {
+    getMeasurementOverview.mockResolvedValueOnce({
+      ...OVERVIEW,
+      properties: {
+        ...OVERVIEW.properties,
+        items: [{ ...OVERVIEW.properties.items[0], flags: 2 }],
+      },
+      flags: { total: 2 },
+    })
+    const logged: string[] = []
+    const log = vi.spyOn(console, 'log').mockImplementation(line => { logged.push(String(line)) })
+
+    await command('measurement-plan property').run({
+      positionals: ['acme'], values: { 'target-key': 'harbor-view' }, format: 'text', dryRun: false,
+    })
+
+    log.mockRestore()
+    const output = logged.join('\n')
+    expect(output).toContain('Ambiguous  2 source-to-Property matches')
+    expect(output).not.toContain('Flagged')
+  })
+
   it('rejects a question class outside the published vocabulary', () => {
     expect(() => command('measurement-plan property').run({
       positionals: ['acme'], values: { 'target-key': 'harbor-view', 'query-class': 'brand' }, format: 'json', dryRun: false,

--- a/packages/contracts/src/measurement-plan-v2.ts
+++ b/packages/contracts/src/measurement-plan-v2.ts
@@ -360,6 +360,8 @@ export const measurementMetricValueSchema = z.discriminatedUnion('state', [
     value: z.number(),
     numerator: z.number().int().nonnegative().optional(),
     denominator: z.number().int().positive().optional(),
+    /** Server-computed ratio for count metrics whose `value` remains the count. */
+    rate: z.number().min(0).max(1).optional(),
   }).strict(),
   z.object({
     state: z.literal('unavailable'),

--- a/packages/contracts/test/measurement-plan-v2.test.ts
+++ b/packages/contracts/test/measurement-plan-v2.test.ts
@@ -187,6 +187,13 @@ describe('measurement metric value', () => {
     expect(measurementMetricValueSchema.parse({ state: 'available', value: 0.5, numerator: 3, denominator: 6 }))
       .toEqual({ state: 'available', value: 0.5, numerator: 3, denominator: 6 })
   })
+
+  it('carries a bounded server-computed rate beside a count value', () => {
+    expect(measurementMetricValueSchema.parse({ state: 'available', value: 3, numerator: 3, denominator: 6, rate: 0.5 }))
+      .toEqual({ state: 'available', value: 3, numerator: 3, denominator: 6, rate: 0.5 })
+    expect(measurementMetricValueSchema.safeParse({ state: 'available', value: 3, rate: -0.1 }).success).toBe(false)
+    expect(measurementMetricValueSchema.safeParse({ state: 'available', value: 3, rate: 1.1 }).success).toBe(false)
+  })
 })
 
 describe('measurement overview response', () => {

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.179.0",
+  "version": "4.179.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.179.0",
+  "version": "4.179.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.179.0",
+  "version": "4.179.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/test/advanced-measurement-mockup.test.ts
+++ b/test/advanced-measurement-mockup.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const mockupPath = resolve(import.meta.dirname, '../docs/mockups/advanced-measurement/portfolio-scale-flows.html')
+const require = createRequire(import.meta.url)
+const { JSDOM } = require('jsdom') as {
+  JSDOM: new (html: string, options: {
+    url: string
+    runScripts: 'dangerously'
+    beforeParse: (window: Window) => void
+  }) => { window: Window }
+}
+
+function openMockup() {
+  return new JSDOM(readFileSync(mockupPath, 'utf8'), {
+    url: 'https://mockup.test/#queries/test',
+    runScripts: 'dangerously',
+    beforeParse(window) {
+      window.scrollTo = () => undefined
+    },
+  })
+}
+
+function click(document: Document, selector: string) {
+  const element = document.querySelector<HTMLButtonElement>(selector)
+  if (!element) throw new Error(`Missing ${selector}`)
+  element.click()
+}
+
+describe('advanced measurement query mockup', () => {
+  it('keeps Test evidence in context and clears an uncommitted promotion when the workspace changes', () => {
+    const dom = openMockup()
+    const { document, location } = dom.window
+
+    try {
+      click(document, '[data-add-to-measurement]')
+
+      expect(location.hash).toBe('#queries/test')
+      expect(document.querySelector('.page-head h1')?.textContent).toBe('Test queries')
+      expect(document.querySelector('#test-results-title')).not.toBeNull()
+      expect(document.querySelector('.promotion-panel')).not.toBeNull()
+
+      click(document, '[data-promotion-next]')
+      expect(document.querySelector('.promotion-body h3')?.textContent).toBe('Confirm measurement change')
+      expect(document.activeElement?.id).toBe('promotion-title')
+      expect(document.querySelector('[data-query-view="test"]')?.getAttribute('aria-current')).toBe('page')
+
+      click(document, '[data-query-view="test"]')
+      expect(location.hash).toBe('#queries/test')
+      expect(document.querySelector('#test-results-title')).not.toBeNull()
+      expect(document.querySelector('.promotion-panel')).toBeNull()
+
+      click(document, '[data-query-view="tracked"]')
+
+      expect(location.hash).toBe('#queries/tracked')
+      expect(document.querySelector('.page-head h1')?.textContent).toBe('Tracked queries')
+      expect(document.querySelector('caption')?.textContent).toBe('Tracked project queries')
+      expect(document.querySelector('.promotion-panel')).toBeNull()
+      expect(document.querySelector('[data-query-view="tracked"]')?.getAttribute('aria-current')).toBe('page')
+      expect(document.activeElement).toBe(document.querySelector('[data-query-view="tracked"]'))
+    } finally {
+      dom.window.close()
+    }
+  })
+
+  it('publishes directly to the visible tracked table with an awaiting-first-sweep row', () => {
+    const dom = openMockup()
+    const { document, location } = dom.window
+
+    try {
+      click(document, '[data-add-to-measurement]')
+      click(document, '[data-promotion-next]')
+      click(document, '[data-promotion-publish]')
+
+      const firstTrackedRow = document.querySelector('tbody tr')
+      const expectedQuery = 'What are the best luxury apartments in Metro Golf?'
+
+      expect(location.hash).toBe('#queries/tracked')
+      expect(document.querySelector('.page-head h1')?.textContent).toBe('Tracked queries')
+      expect(document.querySelector('.promotion-panel')).toBeNull()
+      expect(firstTrackedRow?.textContent).toContain(expectedQuery)
+      expect(firstTrackedRow?.textContent).toContain('15 of 225')
+      expect(firstTrackedRow?.textContent).toContain('Awaiting first sweep')
+      expect(firstTrackedRow?.textContent?.match(/Not measured/g)).toHaveLength(2)
+      expect(document.querySelector('.table-footer')?.textContent).toContain('Showing 12 of 37 tracked queries')
+      expect(document.activeElement).toBe(document.querySelector('[data-query-view="tracked"]'))
+    } finally {
+      dom.window.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- add the production Portfolio Pulse with Group drill-down, five-state outcomes, and Portfolio-level trend reuse
- default the headline to non-brand, render API-provided rates, and keep loaded outcomes visible when the Pulse summary is unavailable
- preserve independent signal semantics, the not-measured explanation, and existing URL state during drill-down
- keep Test and Discover query tables visible while assignment is previewed; show the promoted query in Tracked only after publish
- include only a wholly fictional portfolio in the interactive design artifact
- bump the release boundary to 4.179.1

Validation: rebased onto main `ccd7affe` (4.179.0). Full-stack `pnpm verify` passed at #1069: generated-client drift, plugin parity, typecheck, lint, and 9,531 tests. No new matches in the known-client added-line scan. Browser visual recheck pending; newer query-workspace usability changes are a separate follow-up.