### PR TITLE
feat: unify query workflows

### DIFF
--- a/apps/web/src/components/project/DiscoverySection.tsx
+++ b/apps/web/src/components/project/DiscoverySection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
 import { CheckCircle2, Play, RefreshCw } from 'lucide-react'
 import type { DiscoveryBucket, DiscoverySessionDto } from '@ainyc/canonry-contracts'
 
@@ -14,8 +15,12 @@ import {
   getApiV1ProjectsByNameDiscoverSessionsByIdOptions,
   getApiV1ProjectsByNameDiscoverSessionsByIdPromoteOptions,
   getApiV1ProjectsByNameDiscoverSessionsOptions,
+  getApiV1ProjectsByNameQueriesOptions,
+  getApiV1ProjectsByNameQueriesQueryKey,
   getApiV1ProjectsQueryKey,
   getApiV1RunsQueryKey,
+  deleteApiV1ProjectsByNameQueriesMutation,
+  postApiV1ProjectsByNameQueriesMutation,
 } from '@ainyc/canonry-api-client/react-query'
 import { addToast } from '../../lib/toast-store.js'
 import { invalidateProjectQueryDomain } from '../../queries/query-invalidation.js'
@@ -24,44 +29,209 @@ import { WriteButton } from '../shared/AccessControls.js'
 import { Card } from '../ui/card.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
 import { ResearchQueriesSection } from './ResearchQueriesSection.js'
+import { useAccount } from '../../contexts/account-context.js'
+import { assertCanWrite } from '../../lib/write-guard.js'
+
+type QueryWorkspace = 'tracked' | 'discover' | 'test'
 
 const ACTIVE_DISCOVERY_STATUSES = new Set<DiscoverySessionDto['status']>(['queued', 'seeding', 'probing'])
 
-export function DiscoverySection({ projectName }: { projectName: string }) {
-  const [workflow, setWorkflow] = useState<'find' | 'research'>('find')
+export function DiscoverySection({
+  projectName,
+  workspace = 'discover',
+}: {
+  projectName: string
+  workspace?: QueryWorkspace
+}) {
+  const tabs: ReadonlyArray<{ id: QueryWorkspace; label: string }> = [
+    { id: 'tracked', label: 'Tracked' },
+    { id: 'discover', label: 'Discover' },
+    { id: 'test', label: 'Test' },
+  ]
 
   return (
     <section className="page-section-divider">
       <div className="section-head section-head-inline">
         <div>
-          <p className="eyebrow eyebrow-soft">Query discovery</p>
-          <h2>Discover or research queries</h2>
+          <p className="eyebrow eyebrow-soft">Project workspace</p>
+          <h2>Queries</h2>
         </div>
       </div>
-      <div className="inline-flex rounded-md border border-default bg-surface p-1" role="tablist" aria-label="Query discovery workflow">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={workflow === 'find'}
-          className={`rounded px-3 py-1.5 text-sm font-medium transition-colors ${workflow === 'find' ? 'bg-bg-elevated text-heading shadow-sm' : 'text-muted hover:text-strong'}`}
-          onClick={() => setWorkflow('find')}
-        >
-          Find queries
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={workflow === 'research'}
-          className={`rounded px-3 py-1.5 text-sm font-medium transition-colors ${workflow === 'research' ? 'bg-bg-elevated text-heading shadow-sm' : 'text-muted hover:text-strong'}`}
-          onClick={() => setWorkflow('research')}
-        >
-          Research queries
-        </button>
-      </div>
+      <nav className="mt-4 flex gap-5 border-b border-default" aria-label="Queries workspace">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.id}
+            to="/projects/$projectName/discovery"
+            params={{ projectName }}
+            search={(previous: Record<string, unknown>) => ({
+              ...previous,
+              queries: tab.id === 'discover' ? undefined : tab.id,
+            })}
+            aria-current={workspace === tab.id ? 'page' : undefined}
+            className={`-mb-px border-b-2 px-0.5 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-500/60 ${workspace === tab.id ? 'border-mono-200 text-heading' : 'border-transparent text-secondary hover:border-mono-600 hover:text-heading'}`}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
       <div className="mt-4">
-        {workflow === 'find' ? <FindQueriesSection projectName={projectName} /> : <ResearchQueriesSection projectName={projectName} />}
+        {workspace === 'tracked' ? <TrackedQueriesSection projectName={projectName} /> : null}
+        {workspace === 'discover' ? <FindQueriesSection projectName={projectName} /> : null}
+        {workspace === 'test' ? <ResearchQueriesSection projectName={projectName} /> : null}
       </div>
     </section>
+  )
+}
+
+function TrackedQueriesSection({ projectName }: { projectName: string }) {
+  const account = useAccount()
+  const queryClient = useQueryClient()
+  const [newQueryText, setNewQueryText] = useState('')
+  const [removingQuery, setRemovingQuery] = useState<string | null>(null)
+  const trackedQueriesQuery = useQuery({
+    ...getApiV1ProjectsByNameQueriesOptions({ client: heyClient, path: { name: projectName } }),
+    staleTime: 0,
+    refetchOnMount: 'always',
+  })
+  const queryKey = getApiV1ProjectsByNameQueriesQueryKey({ client: heyClient, path: { name: projectName } })
+
+  const invalidateTrackedState = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey }),
+      queryClient.invalidateQueries({ queryKey: getApiV1ProjectsQueryKey({ client: heyClient }) }),
+      invalidateProjectQueryDomain(queryClient, 'measurement'),
+      queryClient.invalidateQueries({
+        predicate: (query) => Array.isArray(query.queryKey)
+          && (query.queryKey[0] === 'projects' || query.queryKey[0] === 'project-dashboard-full')
+          && query.queryKey.length > 1,
+      }),
+    ])
+  }
+
+  const addMutation = useMutation({
+    ...postApiV1ProjectsByNameQueriesMutation(),
+    onMutate: () => assertCanWrite(account),
+    onSuccess: async () => {
+      setNewQueryText('')
+      await invalidateTrackedState()
+    },
+    onError: (error) => {
+      addToast({
+        title: 'Could not add queries',
+        detail: error instanceof Error ? error.message : 'Try again after checking the query text.',
+        tone: 'negative',
+        dedupeKey: 'queries:add',
+        dedupeMode: 'replace',
+      })
+    },
+  })
+  const removeMutation = useMutation({
+    ...deleteApiV1ProjectsByNameQueriesMutation(),
+    onMutate: () => assertCanWrite(account),
+    onSuccess: async () => {
+      setRemovingQuery(null)
+      await invalidateTrackedState()
+    },
+    onError: (error) => {
+      setRemovingQuery(null)
+      addToast({
+        title: 'Could not remove query',
+        detail: error instanceof Error ? error.message : 'Try again after checking the query.',
+        tone: 'negative',
+        dedupeKey: 'queries:remove',
+        dedupeMode: 'replace',
+      })
+    },
+  })
+
+  const pendingQueries = newQueryText.split('\n').map(item => item.trim()).filter(Boolean)
+  const canEdit = account.canWrite && !isEmbed()
+
+  function addQueries() {
+    if (!canEdit || pendingQueries.length === 0 || addMutation.isPending) return
+    addMutation.mutate({ client: heyClient, path: { name: projectName }, body: { queries: pendingQueries } })
+  }
+
+  function removeQuery(query: string) {
+    if (!canEdit || removeMutation.isPending) return
+    setRemovingQuery(query)
+    removeMutation.mutate({ client: heyClient, path: { name: projectName }, body: { queries: [query] } })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="section-head section-head-inline">
+        <div>
+          <p className="eyebrow eyebrow-soft">Official measurement</p>
+          <h3>Tracked queries</h3>
+          <p className="mt-1 max-w-3xl text-sm leading-6 text-secondary">These queries are included in future AI visibility sweeps.</p>
+        </div>
+        {trackedQueriesQuery.isFetching ? <ToneBadge tone="neutral">Loading</ToneBadge> : null}
+      </div>
+
+      {trackedQueriesQuery.isError ? (
+        <div role="alert" className="border-y border-negative-800/40 bg-negative-950/20 py-3 text-sm text-negative">
+          <p>Could not load tracked queries.</p>
+          <Button className="mt-3" type="button" size="sm" variant="outline" onClick={() => { void trackedQueriesQuery.refetch() }}>Retry</Button>
+        </div>
+      ) : trackedQueriesQuery.isLoading ? (
+        <div role="status" className="space-y-2" aria-live="polite">
+          <span className="sr-only">Loading tracked queries</span>
+          <div className="h-10 animate-pulse rounded-md bg-surface-subtle" aria-hidden="true" />
+          <div className="h-10 animate-pulse rounded-md bg-surface-subtle" aria-hidden="true" />
+        </div>
+      ) : (trackedQueriesQuery.data?.length ?? 0) === 0 ? (
+        <p className="border-y border-default py-4 text-sm text-secondary">No tracked queries yet. Add queries here, or promote a completed Test query.</p>
+      ) : (
+        <div className="overflow-x-auto border-y border-default">
+          <table className="evidence-table min-w-[560px]">
+            <thead><tr><th>Query</th>{canEdit ? <th className="w-28 text-right">Action</th> : null}</tr></thead>
+            <tbody>
+              {trackedQueriesQuery.data?.map((item) => (
+                <tr key={item.id}>
+                  <td className="text-sm text-strong">{item.query}</td>
+                  {canEdit ? (
+                    <td className="text-right">
+                      <WriteButton
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        aria-label={`${removingQuery === item.query ? 'Removing' : 'Remove'} ${item.query}`}
+                        disabled={removeMutation.isPending}
+                        onClick={() => removeQuery(item.query)}
+                      >
+                        {removingQuery === item.query ? 'Removing…' : 'Remove'}
+                      </WriteButton>
+                    </td>
+                  ) : null}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {canEdit ? (
+        <div className="border-t border-default pt-4">
+          <label className="block" htmlFor="tracked-query-input">
+            <span className="text-sm font-medium text-secondary">Add queries</span>
+            <textarea
+              id="tracked-query-input"
+              className="mt-1 min-h-28 w-full resize-y rounded border border-strong bg-transparent px-3 py-2 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
+              placeholder="One query per line"
+              value={newQueryText}
+              onChange={(event) => setNewQueryText(event.target.value)}
+            />
+          </label>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-secondary">{pendingQueries.length} {pendingQueries.length === 1 ? 'query' : 'queries'} to add</p>
+            <WriteButton type="button" size="sm" disabled={pendingQueries.length === 0 || addMutation.isPending} onClick={addQueries}>
+              {addMutation.isPending ? 'Adding…' : 'Add queries'}
+            </WriteButton>
+          </div>
+        </div>
+      ) : !isEmbed() ? <p className="text-sm text-secondary">View only. Your account cannot change tracked queries.</p> : null}
+    </div>
   )
 }
 

--- a/apps/web/src/components/project/ResearchQueriesSection.tsx
+++ b/apps/web/src/components/project/ResearchQueriesSection.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
 import { ExternalLink, Play } from 'lucide-react'
 import {
   ResearchQueryStatuses,
   ResearchRunStatuses,
+  type ResearchPromotionCommitResult,
+  type ResearchPromotionPreviewResponse,
   type ResearchRunDetailDto,
   type ResearchRunQueryDto,
   type ResearchRunStatus,
@@ -11,18 +14,30 @@ import {
 
 import { heyClient, isEmbed } from '../../api.js'
 import {
+  getApiV1ProjectsByNameMeasurementPlanOptions,
+  getApiV1ProjectsByNameMeasurementPlanQueryKey,
+  getApiV1ProjectsByNameMeasurementSetupOptions,
+  getApiV1ProjectsByNameMeasurementSetupQueryKey,
   getApiV1ProjectsByNameOptions,
+  getApiV1ProjectsByNameQueriesQueryKey,
   getApiV1ProjectsByNameResearchRunsByRunIdOptions,
   getApiV1ProjectsByNameResearchRunsOptions,
+  getApiV1ProjectsQueryKey,
   getApiV1SettingsOptions,
+  postApiV1ProjectsByNameResearchRunsByRunIdQueriesByQueryIdPromotionMutation,
+  postApiV1ProjectsByNameResearchRunsByRunIdQueriesByQueryIdPromotionPreviewMutation,
   postApiV1ProjectsByNameResearchRunsMutation,
 } from '@ainyc/canonry-api-client/react-query'
+import type { MeasurementPlanResponse, MeasurementSetupResponse } from '@ainyc/canonry-api-client'
 import { addToast } from '../../lib/toast-store.js'
 import { invalidateProjectQueryDomain } from '../../queries/query-invalidation.js'
 import { safeExternalUrl } from '../../lib/safe-url.js'
 import { WriteButton } from '../shared/AccessControls.js'
+import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
+import { useAccount } from '../../contexts/account-context.js'
+import { assertCanWrite } from '../../lib/write-guard.js'
 
 const ACTIVE_RESEARCH_STATUSES = new Set<ResearchRunStatus>([
   ResearchRunStatuses.queued,
@@ -30,6 +45,7 @@ const ACTIVE_RESEARCH_STATUSES = new Set<ResearchRunStatus>([
 ])
 
 export function ResearchQueriesSection({ projectName }: { projectName: string }) {
+  const account = useAccount()
   const queryClient = useQueryClient()
   const [queryText, setQueryText] = useState('')
   const [provider, setProvider] = useState('')
@@ -44,6 +60,18 @@ export function ResearchQueriesSection({ projectName }: { projectName: string })
   const settingsQuery = useQuery({
     ...getApiV1SettingsOptions({ client: heyClient }),
     staleTime: 60_000,
+  })
+  // This section only mounts on Queries → Test. Keep the active setup and v2
+  // plan reads here so the rest of the project never pays for audience data.
+  const measurementSetupQuery = useQuery({
+    ...getApiV1ProjectsByNameMeasurementSetupOptions({ client: heyClient, path: { name: projectName } }),
+    enabled: !isEmbed() && Boolean(projectName),
+    staleTime: 0,
+  })
+  const activeMeasurementPlanQuery = useQuery({
+    ...getApiV1ProjectsByNameMeasurementPlanOptions({ client: heyClient, path: { name: projectName } }),
+    enabled: !isEmbed() && Boolean(projectName),
+    staleTime: 0,
   })
   const runsQuery = useQuery({
     ...getApiV1ProjectsByNameResearchRunsOptions({
@@ -255,12 +283,51 @@ export function ResearchQueriesSection({ projectName }: { projectName: string })
         </Card>
       </div>
 
-      <ResearchRunDetail detail={detail} isLoading={detailQuery.isFetching} />
+      <ResearchRunDetail
+        projectName={projectName}
+        detail={detail}
+        isLoading={detailQuery.isFetching}
+        setup={measurementSetupQuery.data}
+        activePlan={activeMeasurementPlanQuery.data}
+        setupPending={measurementSetupQuery.isPending}
+        setupError={measurementSetupQuery.isError}
+        onRetrySetup={() => { void measurementSetupQuery.refetch() }}
+        planPending={activeMeasurementPlanQuery.isPending}
+        planError={activeMeasurementPlanQuery.isError}
+        onRetryPlan={() => { void activeMeasurementPlanQuery.refetch() }}
+        canPromote={!isEmbed() && account.canWrite}
+      />
     </div>
   )
 }
 
-function ResearchRunDetail({ detail, isLoading }: { detail: ResearchRunDetailDto | null; isLoading: boolean }) {
+function ResearchRunDetail({
+  projectName,
+  detail,
+  isLoading,
+  setup,
+  activePlan,
+  setupPending,
+  setupError,
+  onRetrySetup,
+  planPending,
+  planError,
+  onRetryPlan,
+  canPromote,
+}: {
+  projectName: string
+  detail: ResearchRunDetailDto | null
+  isLoading: boolean
+  setup: MeasurementSetupResponse | undefined
+  activePlan: MeasurementPlanResponse | undefined
+  setupPending: boolean
+  setupError: boolean
+  onRetrySetup: () => void
+  planPending: boolean
+  planError: boolean
+  onRetryPlan: () => void
+  canPromote: boolean
+}) {
   const [selectedQueryId, setSelectedQueryId] = useState<string | null>(null)
 
   useEffect(() => {
@@ -297,14 +364,56 @@ function ResearchRunDetail({ detail, isLoading }: { detail: ResearchRunDetailDto
               </tbody>
             </table>
           </div>
-          <ResearchAnswer query={selected} isLoading={isLoading} />
+          <ResearchAnswer
+            projectName={projectName}
+            runId={detail.id}
+            query={selected}
+            isLoading={isLoading}
+            setup={setup}
+            activePlan={activePlan}
+            setupPending={setupPending}
+            setupError={setupError}
+            onRetrySetup={onRetrySetup}
+            planPending={planPending}
+            planError={planError}
+            onRetryPlan={onRetryPlan}
+            canPromote={canPromote}
+          />
         </div>
       )}
     </Card>
   )
 }
 
-function ResearchAnswer({ query, isLoading }: { query: ResearchRunQueryDto | null; isLoading: boolean }) {
+function ResearchAnswer({
+  projectName,
+  runId,
+  query,
+  isLoading,
+  setup,
+  activePlan,
+  setupPending,
+  setupError,
+  onRetrySetup,
+  planPending,
+  planError,
+  onRetryPlan,
+  canPromote,
+}: {
+  projectName: string
+  runId: string
+  query: ResearchRunQueryDto | null
+  isLoading: boolean
+  setup: MeasurementSetupResponse | undefined
+  activePlan: MeasurementPlanResponse | undefined
+  setupPending: boolean
+  setupError: boolean
+  onRetrySetup: () => void
+  planPending: boolean
+  planError: boolean
+  onRetryPlan: () => void
+  canPromote: boolean
+}) {
   if (!query) return <p className="text-sm text-muted">{isLoading ? 'Loading saved answers…' : 'Select a query to inspect its answer.'}</p>
   return (
     <div className="space-y-4 border-t border-default pt-4 xl:border-t-0 xl:border-l xl:pl-4 xl:pt-0">
@@ -316,8 +425,9 @@ function ResearchAnswer({ query, isLoading }: { query: ResearchRunQueryDto | nul
         <div className="rounded-md border border-negative-800/40 bg-negative-950/20 px-3 py-2 text-sm text-negative">{query.error}</div>
       ) : query.answerText ? (
         <div>
-          <p className="text-[10px] uppercase tracking-wide text-muted">Answer</p>
+          <p className="text-[10px] uppercase tracking-wide text-muted">Saved test evidence</p>
           <p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-secondary">{query.answerText}</p>
+          <p className="mt-2 text-sm leading-6 text-secondary">This saved answer is test evidence. It is not an official measurement.</p>
         </div>
       ) : (
         <p className="text-sm text-muted">{query.status === ResearchQueryStatuses.failed ? 'This query did not return an answer.' : 'The answer will appear here when this query finishes.'}</p>
@@ -354,8 +464,314 @@ function ResearchAnswer({ query, isLoading }: { query: ResearchRunQueryDto | nul
           </ul>
         </div>
       )}
+      {canPromote && query.status === ResearchQueryStatuses.completed ? (
+        <ResearchPromotionPanel
+          key={`${runId}:${query.id}`}
+          projectName={projectName}
+          runId={runId}
+          query={query}
+          setup={setup}
+          activePlan={activePlan}
+          setupPending={setupPending}
+          setupError={setupError}
+          onRetrySetup={onRetrySetup}
+          planPending={planPending}
+          planError={planError}
+          onRetryPlan={onRetryPlan}
+        />
+      ) : null}
     </div>
   )
+}
+
+type PromotionRequest = {
+  queryClass?: 'branded' | 'non-brand'
+  targetKeys?: string[]
+  groupKeys?: string[]
+}
+
+function ResearchPromotionPanel({
+  projectName,
+  runId,
+  query,
+  setup,
+  activePlan,
+  setupPending,
+  setupError,
+  onRetrySetup,
+  planPending,
+  planError,
+  onRetryPlan,
+}: {
+  projectName: string
+  runId: string
+  query: ResearchRunQueryDto
+  setup: MeasurementSetupResponse | undefined
+  activePlan: MeasurementPlanResponse | undefined
+  setupPending: boolean
+  setupError: boolean
+  onRetrySetup: () => void
+  planPending: boolean
+  planError: boolean
+  onRetryPlan: () => void
+}) {
+  const account = useAccount()
+  const queryClient = useQueryClient()
+  const [queryClass, setQueryClass] = useState<'non-brand' | 'branded'>('non-brand')
+  const [targetKeys, setTargetKeys] = useState<string[]>([])
+  const [groupKeys, setGroupKeys] = useState<string[]>([])
+  const [preview, setPreview] = useState<ResearchPromotionPreviewResponse | null>(null)
+  const [success, setSuccess] = useState<ResearchPromotionCommitResult | null>(null)
+  const [promotionError, setPromotionError] = useState<string | null>(null)
+  const [idempotencyKey, setIdempotencyKey] = useState<string | null>(null)
+
+  const activePlanValue = activePlan?.active?.plan
+  const activeV2Plan = activePlanValue?.schemaVersion === 2 ? activePlanValue : null
+  const isAdvanced = setup?.mode === 'active-v2'
+  const setupResolved = setup !== undefined
+  const request: PromotionRequest = isAdvanced
+    ? {
+        queryClass,
+        ...(targetKeys.length > 0 ? { targetKeys } : {}),
+        ...(groupKeys.length > 0 ? { groupKeys } : {}),
+      }
+    : {}
+  const hasAudience = targetKeys.length > 0 || groupKeys.length > 0
+  const canPreview = setupResolved && !setupPending && !setupError
+    && (!isAdvanced || (Boolean(activeV2Plan) && !planPending && !planError && hasAudience))
+  const canConfirmTracking = preview?.mode === 'simple'
+    ? preview.trackedQuery.state === 'new'
+    : preview?.mode === 'advanced'
+      ? preview.assignments.added > 0
+      : false
+
+  const previewMutation = useMutation({
+    ...postApiV1ProjectsByNameResearchRunsByRunIdQueriesByQueryIdPromotionPreviewMutation(),
+    onMutate: () => assertCanWrite(account),
+    onSuccess: (result) => {
+      setPreview(result)
+      setSuccess(null)
+      setPromotionError(null)
+      setIdempotencyKey(result.mode === 'refused' ? null : createPromotionIdempotencyKey())
+    },
+    onError: (error) => {
+      setPreview(null)
+      setPromotionError(error instanceof Error ? error.message : 'Could not preview this tracking change.')
+    },
+  })
+  const commitMutation = useMutation({
+    ...postApiV1ProjectsByNameResearchRunsByRunIdQueriesByQueryIdPromotionMutation(),
+    onMutate: () => assertCanWrite(account),
+    onSuccess: async (result) => {
+      setSuccess(result)
+      setPromotionError(null)
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: getApiV1ProjectsByNameQueriesQueryKey({ client: heyClient, path: { name: projectName } }),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: getApiV1ProjectsQueryKey({ client: heyClient }),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: getApiV1ProjectsByNameMeasurementPlanQueryKey({ client: heyClient, path: { name: projectName } }),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: getApiV1ProjectsByNameMeasurementSetupQueryKey({ client: heyClient, path: { name: projectName } }),
+        }),
+        invalidateProjectQueryDomain(queryClient, 'measurement'),
+        invalidateProjectQueryDomain(queryClient, 'researchRuns'),
+        queryClient.invalidateQueries({
+          predicate: (cached) => Array.isArray(cached.queryKey)
+            && (cached.queryKey[0] === 'projects' || cached.queryKey[0] === 'project-dashboard-full')
+            && cached.queryKey.length > 1,
+        }),
+      ])
+    },
+    onError: (error) => {
+      setPromotionError(error instanceof Error ? error.message : 'The tracking change could not be confirmed. Preview it again if the project changed.')
+    },
+  })
+
+  function resetPreview() {
+    setPreview(null)
+    setSuccess(null)
+    setPromotionError(null)
+    setIdempotencyKey(null)
+  }
+
+  function toggleSelection(keys: string[], key: string, setKeys: (next: string[]) => void) {
+    resetPreview()
+    setKeys(keys.includes(key) ? keys.filter(item => item !== key) : [...keys, key])
+  }
+
+  function previewAssignment() {
+    if (!canPreview || previewMutation.isPending) return
+    previewMutation.mutate({
+      client: heyClient,
+      path: { name: projectName, runId, queryId: query.id },
+      body: request,
+    })
+  }
+
+  function confirmTracking() {
+    if (!preview || preview.mode === 'refused' || !canConfirmTracking || commitMutation.isPending) return
+    const nextIdempotencyKey = idempotencyKey ?? createPromotionIdempotencyKey()
+    if (!idempotencyKey) setIdempotencyKey(nextIdempotencyKey)
+    commitMutation.mutate({
+      client: heyClient,
+      path: { name: projectName, runId, queryId: query.id },
+      headers: { 'Idempotency-Key': nextIdempotencyKey },
+      body: { previewChecksum: preview.previewChecksum, request },
+    })
+  }
+
+  return (
+    <section className="border-t border-default pt-4" aria-labelledby={`track-test-query-${query.id}`}>
+      <div className="section-head">
+        <div>
+          <p className="eyebrow eyebrow-soft">Track this test query</p>
+          <h4 id={`track-test-query-${query.id}`} className="text-sm font-semibold text-heading">Add it to official measurement</h4>
+          <p className="mt-1 max-w-xl text-sm leading-6 text-secondary">The saved answer remains test evidence. Tracking starts with a future AI visibility sweep.</p>
+        </div>
+      </div>
+
+      {!setupResolved || setupPending || setupError ? (
+        <div role={setupError ? 'alert' : 'status'} className="mt-3 border-y border-default py-3 text-sm text-secondary">
+          {setupError ? (
+            <>
+              <p>Could not load tracking setup.</p>
+              <Button className="mt-3" type="button" size="sm" variant="outline" onClick={onRetrySetup}>Retry setup</Button>
+            </>
+          ) : <p>Loading tracking setup.</p>}
+        </div>
+      ) : isAdvanced ? (
+        activeV2Plan ? (
+          <div className="mt-3 space-y-3">
+            <label className="block" htmlFor={`tracking-class-${query.id}`}>
+              <span className="text-sm font-medium text-secondary">Query class</span>
+              <select
+                id={`tracking-class-${query.id}`}
+                className="mt-1 w-full rounded border border-strong bg-transparent px-3 py-2 text-sm text-strong focus:border-mono-500 focus:outline-none"
+                value={queryClass}
+                onChange={(event) => {
+                  resetPreview()
+                  setQueryClass(event.target.value as 'non-brand' | 'branded')
+                }}
+              >
+                <option value="non-brand">Non-brand</option>
+                <option value="branded">Branded</option>
+              </select>
+            </label>
+            {activeV2Plan.groups.length > 0 ? (
+              <fieldset className="border-t border-default pt-3">
+                <legend className="text-sm font-medium text-secondary">Groups</legend>
+                <div className="mt-2 space-y-2">
+                  {activeV2Plan.groups.map((group) => (
+                    <label key={group.stableKey} className="flex items-start gap-2 text-sm text-secondary">
+                      <input
+                        type="checkbox"
+                        className="mt-1 size-4 accent-current"
+                        checked={groupKeys.includes(group.stableKey)}
+                        onChange={() => toggleSelection(groupKeys, group.stableKey, setGroupKeys)}
+                      />
+                      <span>{group.label} <span className="text-muted">({group.targetKeys.length} Properties)</span></span>
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+            ) : null}
+            <fieldset className="border-t border-default pt-3">
+              <legend className="text-sm font-medium text-secondary">Properties</legend>
+              <div className="mt-2 max-h-44 space-y-2 overflow-y-auto pr-1">
+                {activeV2Plan.targets.map((target) => (
+                  <label key={target.stableKey} className="flex items-start gap-2 text-sm text-secondary">
+                    <input
+                      type="checkbox"
+                      className="mt-1 size-4 accent-current"
+                      checked={targetKeys.includes(target.stableKey)}
+                      onChange={() => toggleSelection(targetKeys, target.stableKey, setTargetKeys)}
+                    />
+                    <span>{target.label}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+        ) : planError ? (
+          <div role="alert" className="mt-3 border-y border-default py-3 text-sm text-secondary">
+            <p>Could not load the published Portfolio setup.</p>
+            <Button className="mt-3" type="button" size="sm" variant="outline" onClick={onRetryPlan}>Retry Portfolio setup</Button>
+          </div>
+        ) : <p role="status" className="mt-3 text-sm text-secondary">Loading the published Portfolio setup before assignment can be previewed.</p>
+      ) : null}
+
+      {promotionError ? <p role="alert" className="mt-3 text-sm leading-6 text-negative">{promotionError}</p> : null}
+      {preview?.mode === 'refused' ? (
+        <div role="alert" className="mt-3 border-y border-caution-800/40 bg-caution-950/20 py-3 text-sm text-caution">
+          <p>{preview.refusal.message}</p>
+          {preview.refusal.reason === 'active-v1' || preview.refusal.reason === 'draft-only' || preview.refusal.reason === 'draft-exists' ? (
+            <Link
+              to="/projects/$projectName/portfolio"
+              params={{ projectName }}
+              search={(previous: Record<string, unknown>) => preserveRunDrawerSearch(previous)}
+              className="mt-2 inline-block font-medium text-link hover:underline focus:outline-none focus:underline"
+            >
+              Open Portfolio setup
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+      {preview?.mode === 'simple' ? (
+        <div className="mt-3 border-y border-default py-3 text-sm text-secondary">
+          <p>Track this query in the project basket. No test answer or source becomes official measurement.</p>
+        </div>
+      ) : null}
+      {preview?.mode === 'advanced' ? (
+        <div className="mt-3 border-y border-default py-3">
+          <dl className="grid gap-x-4 gap-y-2 text-sm sm:grid-cols-2">
+            <div><dt className="text-secondary">Query class</dt><dd className="mt-0.5 font-medium text-heading">{preview.selection.queryClass === 'branded' ? 'Branded' : 'Non-brand'}</dd></div>
+            <div><dt className="text-secondary">Resolved Properties</dt><dd className="mt-0.5 font-medium text-heading">{preview.audience.targetKeys.length}</dd></div>
+            <div><dt className="text-secondary">Assignments</dt><dd className="mt-0.5 font-medium text-heading">{preview.assignments.added} added, {preview.assignments.alreadyPresent} already tracked</dd></div>
+            <div><dt className="text-secondary">Provider calls</dt><dd className="mt-0.5 font-medium text-heading">{preview.execution.addedProviderCalls} added, {preview.execution.fullRunProviderCalls} in the full sweep</dd></div>
+          </dl>
+        </div>
+      ) : null}
+
+      {preview && preview.mode !== 'refused' && !canConfirmTracking ? (
+        <p className="mt-3 text-sm text-secondary">Already tracked; no change to confirm.</p>
+      ) : null}
+
+      {success ? (
+        <div role="status" className="mt-3 border-y border-positive-800/40 bg-positive-950/20 py-3 text-sm text-positive">
+          <p>Tracked, awaiting first sweep.</p>
+          {success.publishedRevision !== null ? <p className="mt-1 text-secondary">Published revision {success.publishedRevision} will be measured by the next AI visibility sweep.</p> : null}
+        </div>
+      ) : null}
+      {!success ? (
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <WriteButton type="button" size="sm" variant="outline" disabled={!canPreview || previewMutation.isPending || commitMutation.isPending} onClick={previewAssignment}>
+            {previewMutation.isPending ? 'Previewing…' : 'Preview assignment'}
+          </WriteButton>
+          {preview && preview.mode !== 'refused' ? (
+            <WriteButton type="button" size="sm" disabled={!canConfirmTracking || commitMutation.isPending} onClick={confirmTracking}>
+              {commitMutation.isPending ? 'Confirming…' : 'Confirm tracking'}
+            </WriteButton>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+function createPromotionIdempotencyKey(): string {
+  const random = typeof globalThis.crypto.randomUUID === 'function'
+    ? globalThis.crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  return `research-promotion-${random}`
+}
+
+function preserveRunDrawerSearch(previous: Record<string, unknown>) {
+  return typeof previous.runId === 'string' ? { runId: previous.runId } : {}
 }
 
 function normalizeResearchQueries(value: string): string[] {

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -54,8 +54,6 @@ import { NotificationsSection } from '../components/project/NotificationsSection
 import {
   fetchTimeline,
   deleteProject as apiDeleteProject,
-  appendQueries as apiAppendQueries,
-  removeQueries as apiRemoveQueries,
   appendCompetitors as apiAppendCompetitors,
   removeCompetitorById as apiRemoveCompetitorById,
   updateProject as apiUpdateProject,
@@ -1474,6 +1472,10 @@ export function ProjectPage(props: { tab: ProjectPageTab }) {
 
 type ProjectTabItem = { key: ProjectPageTab; label: string; href: string }
 
+function preserveRunDrawerSearch(previous: Record<string, unknown>) {
+  return typeof previous.runId === 'string' ? { runId: previous.runId } : {}
+}
+
 /**
  * Trailing overflow ("More") menu for low-frequency project sections (Report).
  * A standard disclosure: button toggles a `role="menu"`, closes on outside
@@ -1521,6 +1523,7 @@ function ProjectSubnavMore({ items, activeTab }: { items: ProjectTabItem[]; acti
             <Link
               key={item.key}
               to={item.href}
+              search={preserveRunDrawerSearch}
               role="menuitem"
               className={`project-subnav-menu-item ${item.key === activeTab ? 'project-subnav-menu-item-active' : ''}`}
               aria-current={item.key === activeTab ? 'page' : undefined}
@@ -1567,6 +1570,7 @@ function ProjectPageContent({
   const appendQueries = useAppendQueries()
   const projectSearchParams = useSearch({ strict: false }) as {
     manageQueries?: boolean
+    queries?: 'tracked' | 'discover' | 'test'
     runId?: string
     siteHealthRunId?: string
     scope?: string
@@ -1580,10 +1584,6 @@ function ProjectPageContent({
       search: (previous: Record<string, unknown>) => ({ ...previous, siteHealthRunId: undefined }),
     })
   }, [navigate])
-  const [managingQueries, setManagingQueries] = useState(manageQueriesRequested)
-  const [newQueryText, setNewQueryText] = useState('')
-  const [querySaving, setQuerySaving] = useState(false)
-  const [removingQuery, setRemovingQuery] = useState<string | null>(null)
   const [addingCompetitor, setAddingCompetitor] = useState(false)
   const [newCompetitorDomain, setNewCompetitorDomain] = useState('')
   const [competitorSaving, setCompetitorSaving] = useState(false)
@@ -1625,6 +1625,22 @@ function ProjectPageContent({
   const visibilityEvidence = model?.visibilityEvidence ?? []
   const projectName = model?.project.name ?? ''
   const projectLabel = model?.project.displayName || model?.project.name || projectName
+  // `manageQueries` was an overview-local drawer state. Preserve old links by
+  // translating it once into the stable Queries URL, retaining a run drawer or
+  // any other valid project search state while clearing the legacy flag.
+  useEffect(() => {
+    if (!manageQueriesRequested || !projectName) return
+    void navigate({
+      to: '/projects/$projectName/discovery',
+      params: { projectName },
+      search: (previous: Record<string, unknown>) => ({
+        ...previous,
+        manageQueries: undefined,
+        queries: 'tracked' as const,
+      }),
+      replace: true,
+    })
+  }, [manageQueriesRequested, navigate, projectName])
   const triggerRunMutation = useTriggerRun()
   const portfolioQueriesQuery = useQuery({
     ...getApiV1ProjectsByNameQueriesOptions({ client: heyClient, path: { name: projectName } }),
@@ -1902,15 +1918,6 @@ function ProjectPageContent({
   )
   const locationLabelsInEvidence = useMemo(() => new Set(visibilityEvidence.map(e => e.location ?? '')), [visibilityEvidence])
   const hasNullLocationEvidence = locationLabelsInEvidence.has('')
-  // The authoritative tracked-query set — every query the project tracks,
-  // including ones added but not yet run (build-dashboard seeds a "pending"
-  // evidence row for those). This is the same source as the "N queries tracked"
-  // header count, so the manage list and the count never diverge. Sorted for a
-  // stable order in the manage panel.
-  const trackedQueries = useMemo(
-    () => [...new Set(visibilityEvidence.map(e => e.query))].sort((a, b) => a.localeCompare(b)),
-    [visibilityEvidence],
-  )
   const distinctLocationsForCompare = useMemo(() => {
     // "Compare" needs ≥2 locations with selectable data. Prefer evidence-backed
     // locations, but fall back to configured locations so a fresh project that
@@ -2024,37 +2031,6 @@ function ProjectPageContent({
     }
   }
 
-  async function handleAddQueries() {
-    const queries = newQueryText.split('\n').map(k => k.trim()).filter(Boolean)
-    if (queries.length === 0) return
-    setQuerySaving(true)
-    try {
-      await apiAppendQueries(projectName, queries)
-      void refetch()
-      setNewQueryText('')
-    } finally {
-      setQuerySaving(false)
-    }
-  }
-
-  async function handleRemoveQuery(query: string) {
-    setRemovingQuery(query)
-    try {
-      await apiRemoveQueries(projectName, [query])
-      void refetch()
-    } catch (err) {
-      addToast({
-        title: 'Could not remove query',
-        detail: err instanceof Error ? err.message : `Failed to remove "${query}"`,
-        tone: 'negative',
-        dedupeKey: 'query:remove',
-        dedupeMode: 'replace',
-      })
-    } finally {
-      setRemovingQuery(null)
-    }
-  }
-
   async function handleAddCompetitor() {
     const domain = newCompetitorDomain.trim()
     if (!domain) return
@@ -2141,7 +2117,7 @@ function ProjectPageContent({
     { key: 'technical-aeo', label: 'Site Health', href: `${projectTabBase}/technical-aeo` },
     { key: 'conversions', label: 'Conversions', href: `${projectTabBase}/conversions` },
     { key: 'local', label: 'Local Presence', href: `${projectTabBase}/local` },
-    { key: 'discovery', label: 'Query Discovery', href: `${projectTabBase}/discovery` },
+    { key: 'discovery', label: 'Queries', href: `${projectTabBase}/discovery` },
     { key: 'backlinks', label: 'Backlinks', href: `${projectTabBase}/backlinks` },
   ]
   const projectOverflowTabItemsAll: ProjectTabItem[] = [
@@ -2225,6 +2201,7 @@ function ProjectPageContent({
             <Link
               key={item.key}
               to={item.href}
+              search={preserveRunDrawerSearch}
               className={`project-subnav-link ${item.key === tab ? 'project-subnav-link-active' : ''}`}
               aria-current={item.key === tab ? 'page' : undefined}
             >
@@ -2238,6 +2215,7 @@ function ProjectPageContent({
             <Link
               key={projectSettingsTab.key}
               to={projectSettingsTab.href}
+              search={preserveRunDrawerSearch}
               className={`project-subnav-link ${tab === 'settings' ? 'project-subnav-link-active' : ''}`}
               aria-current={tab === 'settings' ? 'page' : undefined}
             >
@@ -2272,13 +2250,14 @@ function ProjectPageContent({
             return refreshed.data ?? []
           }}
           onManageProjectQueries={() => {
-            // Local state does not survive this navigation: it remounts the page
-            // and resets, which left the operator on Overview with the manager
-            // shut. The URL carries the intent instead.
             void navigate({
-              to: '/projects/$projectName',
+              to: '/projects/$projectName/discovery',
               params: { projectName },
-              search: { manageQueries: true },
+              search: (previous: Record<string, unknown>) => ({
+                ...previous,
+                manageQueries: undefined,
+                queries: 'tracked' as const,
+              }),
             })
           }}
           onPublished={() => {
@@ -2414,51 +2393,6 @@ function ProjectPageContent({
             meta={`${model.queryCounts.total} ${model.queryCounts.total === 1 ? 'query' : 'queries'}`}
             defaultOpen={isEmbed()}
           >
-            {!isEmbed() && (
-              <div className="mb-3 flex items-center justify-end">
-                <WriteButton type="button" variant="outline" size="sm" onClick={() => setManagingQueries(!managingQueries)}>
-                  {managingQueries ? 'Done' : 'Manage queries'}
-                </WriteButton>
-              </div>
-            )}
-            {!isEmbed() && managingQueries && (
-              <div className="mb-3 rounded-lg border border-base bg-bg-elevated/40 p-3">
-                {trackedQueries.length > 0 ? (
-                  <ul className="mb-3 max-h-64 divide-y divide-mono-800/60 overflow-y-auto rounded border border-default">
-                    {trackedQueries.map((q) => (
-                      <li key={q} className="flex items-center justify-between gap-3 px-3 py-2">
-                        <span className="min-w-0 truncate text-sm text-strong" title={q}>{q}</span>
-                        <button
-                          type="button"
-                          className="shrink-0 rounded px-1.5 py-0.5 text-xs text-muted transition-colors hover:text-negative-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-negative-500 disabled:opacity-50"
-                          aria-label={`Remove query ${q}`}
-                          title={`Stop tracking "${q}"`}
-                          disabled={removingQuery !== null}
-                          onClick={() => { void handleRemoveQuery(q) }}
-                        >
-                          {removingQuery === q ? 'Removing…' : 'Remove'}
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="mb-3 text-xs text-muted">No queries tracked yet. Add some below.</p>
-                )}
-                <textarea
-                  className="w-full resize-none rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
-                  rows={3}
-                  placeholder="Enter queries to add, one per line"
-                  value={newQueryText}
-                  onChange={(e) => setNewQueryText(e.target.value)}
-                />
-                <div className="mt-2 flex items-center justify-between">
-                  <p className="text-xs text-muted">{newQueryText.split('\n').filter(k => k.trim()).length} to add</p>
-                  <WriteButton type="button" size="sm" disabled={!newQueryText.trim() || querySaving} onClick={asyncHandler(handleAddQueries)}>
-                    {querySaving ? 'Adding...' : 'Add queries'}
-                  </WriteButton>
-                </div>
-              </div>
-            )}
             {model.project.locations.length > 0 && (
               <div className="filter-row mb-3" role="toolbar" aria-label="Location filters">
                 <button
@@ -2750,7 +2684,7 @@ function ProjectPageContent({
       ) : tab === 'report' ? (
         <ReportPage projectName={model.project.name} />
       ) : tab === 'discovery' ? (
-        <DiscoverySection projectName={projectName} />
+        <DiscoverySection projectName={projectName} workspace={projectSearchParams.queries} />
       ) : tab === 'technical-aeo' ? (
         <SiteHealthSection
           projectName={model.project.name}

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -66,8 +66,10 @@ export interface RouterContext {
 }
 
 type SearchParams = {
-  /** Opens the project's query manager after a navigation, so setup can hand off to it. */
+  /** Legacy handoff, redirected to the stable Queries workspace by ProjectPage. */
   manageQueries?: boolean
+  /** The stable, URL-backed surface within the project Queries workspace. */
+  queries?: 'tracked' | 'discover' | 'test'
   runId?: string
   /** Exact Site Health onboarding handoff; separate from the global run drawer. */
   siteHealthRunId?: string
@@ -106,6 +108,9 @@ export const rootRoute = createRootRouteWithContext<RouterContext>()({
   component: RootLayoutWithErrorBoundary,
   validateSearch: (search: Record<string, unknown>): SearchParams => ({
     manageQueries: search.manageQueries === true || search.manageQueries === 'true' ? true : undefined,
+    queries: search.queries === 'tracked' || search.queries === 'discover' || search.queries === 'test'
+      ? search.queries
+      : undefined,
     runId: typeof search.runId === 'string' ? search.runId : undefined,
     siteHealthRunId: typeof search.siteHealthRunId === 'string' ? search.siteHealthRunId : undefined,
     evidenceId: typeof search.evidenceId === 'string' ? search.evidenceId : undefined,

--- a/apps/web/test/app-embed.test.tsx
+++ b/apps/web/test/app-embed.test.tsx
@@ -180,19 +180,17 @@ test('embed hides the page-header run action that leaks on every tab', async () 
   expect(embed).toContain('Mention share')
 })
 
-test('embed hides the overview competitor and query managers', async () => {
+test('embed hides the overview competitor manager', async () => {
   const embed = await renderAt('/projects/project_citypoint', { enabled: true })
   const operator = await renderAt('/projects/project_citypoint')
 
   // Operator sees the overview write affordances. Identity editing now lives
   // in project Settings instead of the overview header.
   expect(operator).toContain('+ Add competitor')
-  expect(operator).toContain('Manage queries')
   expect(operator).not.toContain('+ add domain')
   expect(operator).not.toContain('Also known as')
   // The write affordances do not render in the embed.
   expect(embed).not.toContain('+ Add competitor')
-  expect(embed).not.toContain('Manage queries')
 
   // The locale tag-row (US/EN pills) duplicates the "· US/EN" subtitle, so the
   // embed drops it while the operator keeps it. The locale still shows once in

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -98,7 +98,7 @@ test('project route renders a concise visibility summary with progressive detail
   expect(html).toMatch(/Search Engines/)
   // The route/embed token remains `technical-aeo`; only the product label changes.
   expect(html).toMatch(/Site Health/)
-  expect(html).toMatch(/Query Discovery/)
+  expect(html).toMatch(/Queries/)
   expect(html).toMatch(/Visibility/)
   expect(html).toMatch(/Coverage now/)
   expect(html).toMatch(/Since last sweep/)

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -408,6 +408,19 @@ test('project navigation ignores stale Site Health onboarding markers', async ()
   expect(destination.search).toBe('')
 })
 
+test('project navigation preserves an open run drawer but clears one-shot onboarding markers', async () => {
+  const html = await renderAt('/projects/project_citypoint/technical-aeo?onboarding=site-health&runId=run-synthetic')
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const link = [...doc.querySelectorAll<HTMLAnchorElement>('nav[aria-label="Project sections"] a')]
+    .find(anchor => anchor.textContent === 'AI Visibility')
+
+  expect(link).toBeTruthy()
+  const destination = new URL(link!.href, 'http://localhost')
+  expect(destination.pathname).toBe('/projects/Citypoint%20Dental%20NYC')
+  expect(destination.searchParams.get('runId')).toBe('run-synthetic')
+  expect(destination.searchParams.get('onboarding')).toBeNull()
+})
+
 test('a stale Site Health onboarding marker cannot redirect the project overview', async () => {
   const fixture = createDashboardFixture({})
   const projectName = fixture.dashboard.projects.find(entry => entry.project.id === 'project_citypoint')!.project.name

--- a/apps/web/test/query-workspace.test.tsx
+++ b/apps/web/test/query-workspace.test.tsx
@@ -1,0 +1,423 @@
+import React from 'react'
+import { afterEach, expect, onTestFinished, test } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryHistory, createRootRoute, createRoute, createRouter, Outlet, RouterProvider } from '@tanstack/react-router'
+
+import { ResearchQueriesSection } from '../src/components/project/ResearchQueriesSection.js'
+import { jsonResponse, mockFetch } from './mock-fetch.js'
+
+afterEach(cleanup)
+
+const project = {
+  id: 'project_demo', name: 'demo', canonicalDomain: 'demo.example', ownedDomains: ['demo.example'], aliases: [],
+  country: 'US', language: 'en', tags: [], labels: {}, providers: ['openai'], providerModels: {},
+  locations: [], defaultLocation: null, autoExtractBacklinks: false, configSource: 'api', configRevision: 1,
+}
+
+const run = {
+  id: 'run_saved', projectId: 'project_demo', status: 'completed', provider: 'openai', requestedModel: null,
+  resolvedModel: 'sample-model', location: null, totalQueries: 2, completedQueries: 1, failedQueries: 1,
+  error: null, startedAt: '2026-08-01T10:00:00.000Z', finishedAt: '2026-08-01T10:01:00.000Z', createdAt: '2026-08-01T10:00:00.000Z',
+}
+
+const completedQuery = {
+  id: 'query_done', position: 0, query: 'How should a sample team measure answer visibility?', status: 'completed',
+  requestedModel: null, resolvedModel: 'sample-model', servedModel: 'sample-model', answerText: 'This is saved test evidence.',
+  groundingSources: [], citedDomains: [], searchQueries: [], namedCompetitors: [], citedCompetitorDomains: [],
+  answerMentioned: false, citationState: 'not-cited', error: null, startedAt: '2026-08-01T10:00:00.000Z',
+  finishedAt: '2026-08-01T10:00:01.000Z', createdAt: '2026-08-01T10:00:00.000Z',
+}
+
+const failedQuery = {
+  ...completedQuery,
+  id: 'query_failed',
+  position: 1,
+  query: 'This failed test query must not be offered for tracking',
+  status: 'failed',
+  answerText: null,
+  error: 'Provider unavailable',
+  answerMentioned: null,
+  citationState: null,
+}
+
+const secondCompletedQuery = {
+  ...completedQuery,
+  id: 'query_done_second',
+  position: 1,
+  query: 'Which sample visibility signal should we track?',
+  answerText: 'This is the second saved test evidence.',
+}
+
+test('promotes a completed saved test query through preview and receipt-backed commit', async () => {
+  const calls: Array<{ path: string; body?: unknown; headers?: HeadersInit }> = []
+  let commitAttempts = 0
+  const restoreFetch = mockFetch((url, init) => {
+    const path = new URL(url).pathname
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined
+    calls.push({ path, body, headers: init?.headers })
+
+    if (path === '/api/v1/projects/demo') return jsonResponse(project)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: false }, bing: { configured: false } })
+    if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [run] })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved') return jsonResponse({ ...run, queries: [completedQuery, failedQuery] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return jsonResponse({ state: 'simple', nextAction: 'start_setup', mode: 'simple', activeRevision: null, activeSchemaVersion: null, draft: null })
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse({ active: null })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved/queries/query_done/promotion-preview') {
+      return jsonResponse({
+        mode: 'simple', previewChecksum: 'preview-checksum', source: { runId: 'run_saved', queryId: 'query_done', query: completedQuery.query, normalizedQuery: completedQuery.query.toLowerCase(), status: 'completed', completedAt: completedQuery.finishedAt },
+        trackedQuery: { state: 'new', id: 'tracked_query', proposedId: 'tracked_query', query: completedQuery.query, normalizedQuery: completedQuery.query.toLowerCase() },
+        setup: { state: 'simple', mode: 'simple', activeRevision: null, activeCompiledChecksum: null, draftEtag: null },
+      })
+    }
+    if (path === '/api/v1/projects/demo/research/runs/run_saved/queries/query_done/promotion') {
+      commitAttempts += 1
+      if (commitAttempts === 1) return jsonResponse({ error: { message: 'The project changed. Preview again if needed.' } }, 409)
+      return jsonResponse({
+        status: 'tracked-awaiting-first-sweep', mode: 'simple', publishedRevision: null, compiledChecksum: null,
+        source: { runId: 'run_saved', queryId: 'query_done', query: completedQuery.query, normalizedQuery: completedQuery.query.toLowerCase(), status: 'completed', completedAt: completedQuery.finishedAt },
+        trackedQuery: { state: 'new', id: 'tracked_query', proposedId: 'tracked_query', query: completedQuery.query, normalizedQuery: completedQuery.query.toLowerCase() },
+      })
+    }
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><ResearchQueriesSection projectName="demo" /></QueryClientProvider>)
+
+  const preview = await screen.findByRole('button', { name: 'Preview assignment' })
+  expect(screen.getByText('This is saved test evidence.')).toBeTruthy()
+  expect(screen.getByText('Saved test evidence')).toBeTruthy()
+  expect(screen.queryByText('This failed test query must not be offered for tracking')).toBeTruthy()
+  expect(screen.getAllByRole('button', { name: 'Preview assignment' })).toHaveLength(1)
+  fireEvent.click(preview)
+
+  const confirm = await screen.findByRole('button', { name: 'Confirm tracking' })
+  fireEvent.click(confirm)
+  await waitFor(() => expect(calls.filter(call => call.path.endsWith('/promotion'))).toHaveLength(1))
+  fireEvent.click(screen.getByRole('button', { name: 'Confirm tracking' }))
+  expect(await screen.findByText('Tracked, awaiting first sweep.')).toBeTruthy()
+  expect(screen.queryByRole('button', { name: 'Preview assignment' })).toBeNull()
+  expect(screen.queryByRole('button', { name: 'Confirm tracking' })).toBeNull()
+
+  const previewCall = calls.find(call => call.path.endsWith('/promotion-preview'))
+  const commitCalls = calls.filter(call => call.path.endsWith('/promotion'))
+  const commitCall = commitCalls[0]
+  expect(previewCall?.body).toEqual({})
+  expect(commitCall?.body).toEqual({ previewChecksum: 'preview-checksum', request: {} })
+  expect(new Headers(commitCall?.headers).get('Idempotency-Key')).toMatch(/^research-promotion-/)
+  expect(new Headers(commitCalls[0]?.headers).get('Idempotency-Key')).toBe(new Headers(commitCalls[1]?.headers).get('Idempotency-Key'))
+  await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+})
+
+test('previews an Advanced assignment before it can be confirmed', async () => {
+  const calls: Array<{ path: string; body?: unknown; headers?: HeadersInit }> = []
+  const source = { runId: 'run_saved', queryId: 'query_done', query: completedQuery.query, normalizedQuery: completedQuery.query.toLowerCase(), status: 'completed', completedAt: completedQuery.finishedAt }
+  const trackedQuery = { state: 'new', id: 'tracked_query', proposedId: 'tracked_query', query: completedQuery.query, normalizedQuery: completedQuery.query.toLowerCase() }
+  const activePlan = {
+    active: {
+      revision: 4, checksum: 'plan-checksum', compiledChecksum: 'compiled-checksum', createdAt: '2026-08-01T00:00:00.000Z',
+      plan: {
+        schemaVersion: 2,
+        identities: { projectBrand: { canonicalHost: 'demo.example', ownedHosts: ['demo.example'], names: ['Demo'] } },
+        targets: [{ stableKey: 'property-sample', label: 'Sample Property', aliases: [], urlMatchers: [], mentionNotApplicable: false, discoveryIdentity: null }],
+        groups: [{ stableKey: 'group-sample', label: 'Sample Group', targetKeys: ['property-sample'], competitors: [] }],
+        querySnapshots: [], assignments: [], executionNodes: [], usageEdges: [], compiledChecksum: 'compiled-checksum',
+      },
+    },
+  }
+  const restoreFetch = mockFetch((url, init) => {
+    const path = new URL(url).pathname
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined
+    calls.push({ path, body, headers: init?.headers })
+    if (path === '/api/v1/projects/demo') return jsonResponse(project)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: false }, bing: { configured: false } })
+    if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [run] })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved') return jsonResponse({ ...run, queries: [completedQuery] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return jsonResponse({ state: 'operational', nextAction: 'view_measurement', mode: 'active-v2', activeRevision: 4, activeSchemaVersion: 2, draft: null })
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse(activePlan)
+    if (path.endsWith('/promotion-preview')) {
+      return jsonResponse({
+        mode: 'advanced', previewChecksum: 'advanced-preview', source, trackedQuery,
+        setup: { state: 'operational', mode: 'active-v2', activeRevision: 4, activeCompiledChecksum: 'compiled-checksum', draftEtag: null },
+        selection: { queryClass: 'branded', groupKeys: ['group-sample'] },
+        audience: { targetKeys: ['property-sample'], groups: [{ groupKey: 'group-sample', label: 'Sample Group', memberCount: 1 }], overlapCount: 0 },
+        assignments: { requested: 1, added: 1, alreadyPresent: 0, classifications: [{ targetKey: 'property-sample', queryId: 'tracked_query', queryClass: 'branded' }] },
+        execution: { addedNodes: 1, addedProviderCalls: 2, fullRunNodes: 12, fullRunProviderCalls: 24 },
+        candidate: { compiledChecksum: 'next-checksum', checks: [], plan: activePlan.active.plan, diff: { activeRevision: 4, targets: { added: [], removed: [], changed: [], unchanged: ['property-sample'] }, groups: { added: [], removed: [], changed: [], unchanged: ['group-sample'] }, assignments: { added: 1, removed: 0, reclassified: 0 }, execution: { addedNodeKeys: ['node-sample'], removedNodeKeys: [] } } },
+      })
+    }
+    if (path.endsWith('/promotion')) return jsonResponse({ status: 'tracked-awaiting-first-sweep', mode: 'advanced', source, trackedQuery, publishedRevision: 5, compiledChecksum: 'next-checksum' })
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><ResearchQueriesSection projectName="demo" /></QueryClientProvider>)
+
+  await screen.findByLabelText('Query class')
+  expect((screen.getByRole('button', { name: 'Preview assignment' }) as HTMLButtonElement).disabled).toBe(true)
+  fireEvent.change(screen.getByLabelText('Query class'), { target: { value: 'branded' } })
+  fireEvent.click(screen.getByLabelText(/Sample Group/))
+  fireEvent.click(screen.getByRole('button', { name: 'Preview assignment' }))
+
+  expect(await screen.findByText('Resolved Properties')).toBeTruthy()
+  expect(screen.getByText('1 added, 0 already tracked')).toBeTruthy()
+  expect(screen.getByText('2 added, 24 in the full sweep')).toBeTruthy()
+  expect(screen.queryByText('Published revision')).toBeNull()
+  const previewCall = calls.find(call => call.path.endsWith('/promotion-preview'))
+  expect(previewCall?.body).toEqual({ queryClass: 'branded', groupKeys: ['group-sample'] })
+
+  fireEvent.click(screen.getByRole('button', { name: 'Confirm tracking' }))
+  expect(await screen.findByText('Tracked, awaiting first sweep.')).toBeTruthy()
+  expect(screen.getByText('Published revision 5 will be measured by the next AI visibility sweep.')).toBeTruthy()
+  const commitCall = calls.find(call => call.path.endsWith('/promotion'))
+  expect(commitCall?.body).toEqual({ previewChecksum: 'advanced-preview', request: { queryClass: 'branded', groupKeys: ['group-sample'] } })
+  expect(new Headers(commitCall?.headers).get('Idempotency-Key')).toMatch(/^research-promotion-/)
+})
+
+test('does not confirm an Advanced preview that adds no assignments', async () => {
+  const calls: Array<{ path: string; body?: unknown }> = []
+  const source = { runId: 'run_saved', queryId: 'query_done', query: completedQuery.query, normalizedQuery: completedQuery.query.toLowerCase(), status: 'completed', completedAt: completedQuery.finishedAt }
+  const trackedQuery = { state: 'existing', id: 'tracked_query', proposedId: 'tracked_query', query: completedQuery.query, normalizedQuery: completedQuery.query.toLowerCase() }
+  const activePlan = {
+    active: {
+      revision: 4, checksum: 'plan-checksum', compiledChecksum: 'compiled-checksum', createdAt: '2026-08-01T00:00:00.000Z',
+      plan: {
+        schemaVersion: 2,
+        identities: { projectBrand: { canonicalHost: 'demo.example', ownedHosts: ['demo.example'], names: ['Demo'] } },
+        targets: [{ stableKey: 'property-sample', label: 'Sample Property', aliases: [], urlMatchers: [], mentionNotApplicable: false, discoveryIdentity: null }],
+        groups: [{ stableKey: 'group-sample', label: 'Sample Group', targetKeys: ['property-sample'], competitors: [] }],
+        querySnapshots: [], assignments: [], executionNodes: [], usageEdges: [], compiledChecksum: 'compiled-checksum',
+      },
+    },
+  }
+  const restoreFetch = mockFetch((url, init) => {
+    const path = new URL(url).pathname
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined
+    calls.push({ path, body })
+    if (path === '/api/v1/projects/demo') return jsonResponse(project)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: false }, bing: { configured: false } })
+    if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [run] })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved') return jsonResponse({ ...run, queries: [completedQuery] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return jsonResponse({ state: 'operational', nextAction: 'view_measurement', mode: 'active-v2', activeRevision: 4, activeSchemaVersion: 2, draft: null })
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse(activePlan)
+    if (path.endsWith('/promotion-preview')) {
+      return jsonResponse({
+        mode: 'advanced', previewChecksum: 'advanced-preview', source, trackedQuery,
+        setup: { state: 'operational', mode: 'active-v2', activeRevision: 4, activeCompiledChecksum: 'compiled-checksum', draftEtag: null },
+        selection: { queryClass: 'branded', groupKeys: ['group-sample'] },
+        audience: { targetKeys: ['property-sample'], groups: [{ groupKey: 'group-sample', label: 'Sample Group', memberCount: 1 }], overlapCount: 0 },
+        assignments: { requested: 1, added: 0, alreadyPresent: 1, classifications: [{ targetKey: 'property-sample', queryId: 'tracked_query', queryClass: 'branded' }] },
+        execution: { addedNodes: 0, addedProviderCalls: 0, fullRunNodes: 12, fullRunProviderCalls: 24 },
+        candidate: { compiledChecksum: 'plan-checksum', checks: [], plan: activePlan.active.plan, diff: { activeRevision: 4, targets: { added: [], removed: [], changed: [], unchanged: ['property-sample'] }, groups: { added: [], removed: [], changed: [], unchanged: ['group-sample'] }, assignments: { added: 0, removed: 0, reclassified: 0 }, execution: { addedNodeKeys: [], removedNodeKeys: [] } } },
+      })
+    }
+    if (path.endsWith('/promotion')) throw new Error('A zero-change preview must not be committed')
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><ResearchQueriesSection projectName="demo" /></QueryClientProvider>)
+
+  await screen.findByLabelText('Query class')
+  fireEvent.change(screen.getByLabelText('Query class'), { target: { value: 'branded' } })
+  fireEvent.click(screen.getByLabelText(/Sample Group/))
+  fireEvent.click(screen.getByRole('button', { name: 'Preview assignment' }))
+
+  const confirm = await screen.findByRole('button', { name: 'Confirm tracking' }) as HTMLButtonElement
+  expect(screen.getByText('0 added, 1 already tracked')).toBeTruthy()
+  expect(screen.getByText('Already tracked; no change to confirm.')).toBeTruthy()
+  expect(confirm.disabled).toBe(true)
+  fireEvent.click(confirm)
+  expect(calls.filter(call => call.path.endsWith('/promotion'))).toHaveLength(0)
+})
+
+test('keeps promotion state isolated to the selected completed saved test query', async () => {
+  const calls: Array<{ path: string; body?: unknown; headers?: HeadersInit }> = []
+  const completedRun = { ...run, totalQueries: 2, completedQueries: 2, failedQueries: 0 }
+  const restoreFetch = mockFetch((url, init) => {
+    const path = new URL(url).pathname
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined
+    calls.push({ path, body, headers: init?.headers })
+    if (path === '/api/v1/projects/demo') return jsonResponse(project)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: false }, bing: { configured: false } })
+    if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [completedRun] })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved') return jsonResponse({ ...completedRun, queries: [completedQuery, secondCompletedQuery] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return jsonResponse({ state: 'simple', nextAction: 'start_setup', mode: 'simple', activeRevision: null, activeSchemaVersion: null, draft: null })
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse({ active: null })
+    const source = path.includes('query_done_second') ? secondCompletedQuery : completedQuery
+    if (path.endsWith('/promotion-preview')) {
+      return jsonResponse({
+        mode: 'simple', previewChecksum: `preview-${source.id}`,
+        source: { runId: 'run_saved', queryId: source.id, query: source.query, normalizedQuery: source.query.toLowerCase(), status: 'completed', completedAt: source.finishedAt },
+        trackedQuery: { state: 'new', id: `tracked-${source.id}`, proposedId: `tracked-${source.id}`, query: source.query, normalizedQuery: source.query.toLowerCase() },
+        setup: { state: 'simple', mode: 'simple', activeRevision: null, activeCompiledChecksum: null, draftEtag: null },
+      })
+    }
+    if (path.endsWith('/promotion')) {
+      return jsonResponse({
+        status: 'tracked-awaiting-first-sweep', mode: 'simple', publishedRevision: null, compiledChecksum: null,
+        source: { runId: 'run_saved', queryId: source.id, query: source.query, normalizedQuery: source.query.toLowerCase(), status: 'completed', completedAt: source.finishedAt },
+        trackedQuery: { state: 'new', id: `tracked-${source.id}`, proposedId: `tracked-${source.id}`, query: source.query, normalizedQuery: source.query.toLowerCase() },
+      })
+    }
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><ResearchQueriesSection projectName="demo" /></QueryClientProvider>)
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Preview assignment' }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Confirm tracking' }))
+  expect(await screen.findByText('Tracked, awaiting first sweep.')).toBeTruthy()
+  const firstCommit = calls.find(call => call.path.endsWith('/queries/query_done/promotion'))
+  expect(firstCommit).toBeTruthy()
+
+  fireEvent.click(screen.getByRole('button', { name: secondCompletedQuery.query }))
+  expect(await screen.findByText(secondCompletedQuery.answerText)).toBeTruthy()
+  expect(screen.queryByText('Tracked, awaiting first sweep.')).toBeNull()
+  expect(screen.queryByRole('button', { name: 'Confirm tracking' })).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Preview assignment' }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Confirm tracking' }))
+  await waitFor(() => expect(calls.filter(call => call.path.endsWith('/promotion'))).toHaveLength(2))
+  const secondCommit = calls.find(call => call.path.endsWith('/queries/query_done_second/promotion'))
+  expect(secondCommit).toBeTruthy()
+  expect(new Headers(secondCommit?.headers).get('Idempotency-Key')).not.toBe(new Headers(firstCommit?.headers).get('Idempotency-Key'))
+})
+
+test('waits for tracking setup before it permits a simple promotion preview', async () => {
+  const calls: string[] = []
+  const restoreFetch = mockFetch((url) => {
+    const path = new URL(url).pathname
+    calls.push(path)
+    if (path === '/api/v1/projects/demo') return jsonResponse(project)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: false }, bing: { configured: false } })
+    if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [run] })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved') return jsonResponse({ ...run, queries: [completedQuery] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return new Promise<Response>(() => {})
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse({ active: null })
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><ResearchQueriesSection projectName="demo" /></QueryClientProvider>)
+
+  const preview = await screen.findByRole('button', { name: 'Preview assignment' })
+  expect((preview as HTMLButtonElement).disabled).toBe(true)
+  fireEvent.click(preview)
+  expect(calls.filter(path => path.endsWith('/promotion-preview'))).toHaveLength(0)
+})
+
+test('offers a local retry when tracking setup cannot be read', async () => {
+  let setupRequests = 0
+  const restoreFetch = mockFetch((url) => {
+    const path = new URL(url).pathname
+    if (path === '/api/v1/projects/demo') return jsonResponse(project)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: false }, bing: { configured: false } })
+    if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [run] })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved') return jsonResponse({ ...run, queries: [completedQuery] })
+    if (path === '/api/v1/projects/demo/measurement-setup') {
+      setupRequests += 1
+      return setupRequests === 1 ? jsonResponse({ error: { message: 'Setup is unavailable.' } }, 503) : jsonResponse({ state: 'simple', nextAction: 'start_setup', mode: 'simple', activeRevision: null, activeSchemaVersion: null, draft: null })
+    }
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse({ active: null })
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><ResearchQueriesSection projectName="demo" /></QueryClientProvider>)
+
+  expect(await screen.findByText('Could not load tracking setup.')).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: 'Retry setup' }))
+  await waitFor(() => expect(setupRequests).toBe(2))
+  await waitFor(() => expect((screen.getByRole('button', { name: 'Preview assignment' }) as HTMLButtonElement).disabled).toBe(false))
+})
+
+test('offers a local retry when the required published Portfolio setup cannot be read', async () => {
+  let planRequests = 0
+  const activePlan = {
+    active: {
+      revision: 4, checksum: 'plan-checksum', compiledChecksum: 'compiled-checksum', createdAt: '2026-08-01T00:00:00.000Z',
+      plan: {
+        schemaVersion: 2,
+        identities: { projectBrand: { canonicalHost: 'demo.example', ownedHosts: ['demo.example'], names: ['Demo'] } },
+        targets: [{ stableKey: 'property-sample', label: 'Sample Property', aliases: [], urlMatchers: [], mentionNotApplicable: false, discoveryIdentity: null }],
+        groups: [], querySnapshots: [], assignments: [], executionNodes: [], usageEdges: [], compiledChecksum: 'compiled-checksum',
+      },
+    },
+  }
+  const restoreFetch = mockFetch((url) => {
+    const path = new URL(url).pathname
+    if (path === '/api/v1/projects/demo') return jsonResponse(project)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: false }, bing: { configured: false } })
+    if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [run] })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved') return jsonResponse({ ...run, queries: [completedQuery] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return jsonResponse({ state: 'operational', nextAction: 'view_measurement', mode: 'active-v2', activeRevision: 4, activeSchemaVersion: 2, draft: null })
+    if (path === '/api/v1/projects/demo/measurement-plan') {
+      planRequests += 1
+      return planRequests === 1 ? jsonResponse({ error: { message: 'Plan is unavailable.' } }, 503) : jsonResponse(activePlan)
+    }
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><ResearchQueriesSection projectName="demo" /></QueryClientProvider>)
+
+  expect(await screen.findByText('Could not load the published Portfolio setup.')).toBeTruthy()
+  expect((screen.getByRole('button', { name: 'Preview assignment' }) as HTMLButtonElement).disabled).toBe(true)
+  fireEvent.click(screen.getByRole('button', { name: 'Retry Portfolio setup' }))
+  await waitFor(() => expect(planRequests).toBe(2))
+  expect(await screen.findByLabelText('Query class')).toBeTruthy()
+})
+
+test('uses the router base path for a refused Portfolio setup handoff', async () => {
+  const restoreFetch = mockFetch((url) => {
+    const path = new URL(url).pathname
+    if (path === '/api/v1/projects/demo') return jsonResponse(project)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: false }, bing: { configured: false } })
+    if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [run] })
+    if (path === '/api/v1/projects/demo/research/runs/run_saved') return jsonResponse({ ...run, queries: [completedQuery] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return jsonResponse({ state: 'operational', nextAction: 'view_measurement', mode: 'active-v1', activeRevision: 2, activeSchemaVersion: 1, draft: null })
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse({ active: null })
+    if (path.endsWith('/promotion-preview')) {
+      return jsonResponse({
+        mode: 'refused',
+        refusal: { reason: 'active-v1', message: 'Move this project to Portfolio setup before tracking this test query.' },
+      })
+    }
+    throw new Error(`Unexpected request: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const rootRoute = createRootRoute({ component: Outlet })
+  const discoveryRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/projects/$projectName/discovery',
+    component: () => <ResearchQueriesSection projectName="demo" />,
+  })
+  const portfolioRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/projects/$projectName/portfolio',
+    component: () => <p>Portfolio</p>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([discoveryRoute, portfolioRoute]),
+    basepath: '/workspace',
+    history: createMemoryHistory({ initialEntries: ['/workspace/projects/demo/discovery?queries=test&runId=run_saved&onboarding=site-health'] }),
+  })
+  await router.load()
+  render(<QueryClientProvider client={queryClient}><RouterProvider router={router as never} /></QueryClientProvider>)
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Preview assignment' }))
+  const handoff = await screen.findByRole('link', { name: 'Open Portfolio setup' })
+  expect(handoff.getAttribute('href')).toBe('/workspace/projects/demo/portfolio?runId=run_saved')
+})

--- a/apps/web/test/research-queries-section.test.tsx
+++ b/apps/web/test/research-queries-section.test.tsx
@@ -1,12 +1,33 @@
 import React from 'react'
 import { afterEach, expect, onTestFinished, test } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryHistory, createRootRoute, createRoute, createRouter, Outlet, RouterProvider } from '@tanstack/react-router'
 
 import { DiscoverySection } from '../src/components/project/DiscoverySection.js'
 import { jsonResponse, mockFetch } from './mock-fetch.js'
 
 afterEach(cleanup)
+
+async function renderWorkspace(workspace: 'tracked' | 'discover' | 'test') {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const rootRoute = createRootRoute({ component: Outlet })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <DiscoverySection projectName="demo" workspace={workspace} />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  await router.load()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
 
 function installApiMock() {
   const restoreFetch = mockFetch((url) => {
@@ -14,6 +35,8 @@ function installApiMock() {
 
     if (path === '/api/v1/projects/demo/discover/sessions') return jsonResponse([])
     if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return jsonResponse({ state: 'simple', nextAction: 'start_setup', mode: 'simple', activeRevision: null, activeSchemaVersion: null, draft: null })
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse({ active: null })
     if (path === '/api/v1/projects/demo') {
       return jsonResponse({
         id: 'project_demo', name: 'demo', canonicalDomain: 'demo.example', ownedDomains: ['demo.example'], aliases: [],
@@ -39,18 +62,47 @@ function installApiMock() {
   onTestFinished(restoreFetch)
 }
 
+test('gives every tracked-query removal a precise accessible name', async () => {
+  const queries = Array.from({ length: 40 }, (_, index) => ({
+    id: `query-${index + 1}`,
+    query: `Which fictional signal is number ${index + 1}?`,
+    createdAt: '2026-08-28T10:00:00.000Z',
+  }))
+  const target = queries[34]!
+  const requests: Array<{ method: string; body?: unknown }> = []
+  let currentQueries = queries
+  const restoreFetch = mockFetch((url, init) => {
+    const path = new URL(url).pathname
+    const method = init?.method ?? 'GET'
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined
+    if (path === '/api/v1/projects/demo/queries' && method === 'GET') return jsonResponse(currentQueries)
+    if (path === '/api/v1/projects/demo/queries' && method === 'DELETE') {
+      requests.push({ method, body })
+      currentQueries = currentQueries.filter(query => query.id !== target.id)
+      return jsonResponse(currentQueries)
+    }
+    throw new Error(`Unexpected fetch: ${method} ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  await renderWorkspace('tracked')
+
+  for (const query of queries) {
+    expect(await screen.findByRole('button', { name: `Remove ${query.query}` })).toBeTruthy()
+  }
+  fireEvent.click(screen.getByRole('button', { name: `Remove ${target.query}` }))
+
+  await waitFor(() => expect(requests).toContainEqual({
+    method: 'DELETE',
+    body: { queries: [target.query] },
+  }))
+})
+
 test('switches to research, deduplicates query lines, gates exact model choice, and states that research is not tracked', async () => {
   installApiMock()
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await renderWorkspace('test')
 
-  render(
-    <QueryClientProvider client={queryClient}>
-      <DiscoverySection projectName="demo" />
-    </QueryClientProvider>,
-  )
-
-  expect(screen.getByText('Discover or research queries')).toBeTruthy()
-  fireEvent.click(screen.getByRole('tab', { name: 'Research queries' }))
+  expect(screen.getByRole('heading', { name: 'Queries' })).toBeTruthy()
 
   const model = await screen.findByLabelText(/Exact model/)
   expect((model as HTMLInputElement).disabled).toBe(true)
@@ -82,6 +134,8 @@ test('resets the selected query when switching research history batches', async 
     if (path === '/api/v1/projects/demo/research/runs/run-a') return jsonResponse({ ...run('run-a', 'gpt-5-a'), queries: [query('query-a-first', 'First run first query'), query('query-shared', 'First run selected query')] })
     // Reusing the selected id makes this assert the state reset itself, rather than merely relying on the display fallback.
     if (path === '/api/v1/projects/demo/research/runs/run-b') return jsonResponse({ ...run('run-b', 'gpt-5-b'), queries: [query('query-b-first', 'Second run first query'), query('query-shared', 'Second run stale query')] })
+    if (path === '/api/v1/projects/demo/measurement-setup') return jsonResponse({ state: 'simple', nextAction: 'start_setup', mode: 'simple', activeRevision: null, activeSchemaVersion: null, draft: null })
+    if (path === '/api/v1/projects/demo/measurement-plan') return jsonResponse({ active: null })
     if (path === '/api/v1/projects/demo') {
       return jsonResponse({
         id: 'project_demo', name: 'demo', canonicalDomain: 'demo.example', ownedDomains: ['demo.example'], aliases: [],
@@ -93,10 +147,7 @@ test('resets the selected query when switching research history batches', async 
     throw new Error(`Unexpected fetch: ${url}`)
   })
   onTestFinished(restoreFetch)
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-
-  render(<QueryClientProvider client={queryClient}><DiscoverySection projectName="demo" /></QueryClientProvider>)
-  fireEvent.click(screen.getByRole('tab', { name: 'Research queries' }))
+  await renderWorkspace('test')
 
   await screen.findByText('First run first query answer')
   expect(screen.getByText('Named in answer')).toBeTruthy()

--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -131,10 +131,30 @@ test('/projects/$id/local renders the local presence tab', async () => {
   await waitFor(() => expect(container.innerHTML).toMatch(/Google Business Profile/))
 })
 
-test('/projects/$id/discovery renders the discovery tab with plain-language copy', async () => {
+test('/projects/$id/discovery keeps its stable route and defaults Queries to Discover', async () => {
   const { container } = await renderRoute('/projects/project_citypoint/discovery')
   expect(container.innerHTML).toMatch(/Generate and check questions/)
   expect(container.innerHTML).toMatch(/Describe your customer/)
+  expect(container.innerHTML).toMatch(/Queries/)
+  expect(container.innerHTML).toMatch(/Discover/)
+})
+
+test('/projects/$id/discovery selects the URL-backed tracked Queries workspace', async () => {
+  const { container } = await renderRoute('/projects/project_citypoint/discovery?queries=tracked')
+  expect(container.innerHTML).toMatch(/Tracked queries/)
+  expect(container.innerHTML).not.toMatch(/Manage queries/)
+})
+
+test('/projects/$id/discovery rejects an unknown Queries workspace and falls back to Discover', async () => {
+  const { container } = await renderRoute('/projects/project_citypoint/discovery?queries=unknown')
+  expect(container.innerHTML).toMatch(/Generate and check questions/)
+})
+
+test('legacy manageQueries hands off to tracked Queries without closing a run drawer', async () => {
+  const { router } = await renderRoute('/projects/project_citypoint?manageQueries=true&runId=run_citypoint_001')
+  await waitFor(() => expect(router.state.location.pathname).toMatch(/\/discovery$/))
+  expect(router.state.location.search).toMatchObject({ queries: 'tracked', runId: 'run_citypoint_001' })
+  expect(router.state.location.search.manageQueries).toBeUndefined()
 })
 
 // ── Smart redirects ──

--- a/apps/web/test/viewer-write-controls.test.tsx
+++ b/apps/web/test/viewer-write-controls.test.tsx
@@ -36,7 +36,7 @@ describe('project write controls', () => {
     'Run AI sweep',
     'Delete project',
     'Add competitor',
-    'Manage queries',
+    'Add queries',
     'Refresh',
   ]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.179.3",
+  "version": "4.179.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.179.3",
+  "version": "4.179.4",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.179.3",
+  "version": "4.179.4",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.179.3",
+  "version": "4.179.4",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.179.3",
+  "version": "4.179.4",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Summary

- replace split query controls with one Tracked, Discover, and Test workspace
- let completed Test results preview and confirm long-term tracking
- give every tracked-query removal a query-specific accessible name
- use server-confirmed revision truth and disable confirmation when the preview adds nothing
- preserve Run Drawer state and redirect the legacy query-manager URL
- bump the stack release boundary to 4.179.4

Validation: rebased onto main `ccd7affe` (4.179.0). Full-stack `pnpm verify` passed at #1069: generated-client drift, plugin parity, typecheck, lint, and 9,531 tests. No new matches in the known-client added-line scan. Browser visual recheck pending; newer query-workspace usability changes are a separate follow-up.