### PR TITLE
fix(measurement): a label-only republish keeps the dashboard, not a blank

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.178.2",
+  "version": "4.178.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.178.0",
+  "version": "4.178.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/measurement-draft-compile.ts
+++ b/packages/api-routes/src/measurement-draft-compile.ts
@@ -1,5 +1,6 @@
 import {
   brandKeyFromText,
+  canonicalMeasurementPlanV2,
   compileBrandAliases,
   matcherMatchesText,
   measurementPlanV2ChecksumJson,
@@ -575,4 +576,24 @@ export function diffCompiledPlans(
       removedNodeKeys: [...beforeNodes].filter(key => !afterNodes.has(key)).sort(compareText),
     },
   }
+}
+
+/**
+ * True when two compiled revisions froze the IDENTICAL execution surface: same
+ * node keys, and byte-identical canonical node content (question text, frozen
+ * location context, provider roster, model map, expected slot counts).
+ *
+ * This is deliberately stricter than "added and removed node keys both empty".
+ * A node's stable key hashes queryId/location/providers/models but NOT the
+ * query text, so a tracked query edited in place could keep its key while the
+ * frozen text moved — and a prior run served under the new revision would then
+ * fail manifest validation as corruption. Whole-node equality is exactly the
+ * condition under which a run pinned to the superseded revision satisfies the
+ * new revision's manifest checks, which is what publish-time continuity
+ * (`measurement_plan_versions.comparable_to_version_id`) promises the reads.
+ */
+export function plansShareExecutionSurface(active: MeasurementPlanV2, candidate: MeasurementPlanV2): boolean {
+  const surface = (plan: MeasurementPlanV2): string =>
+    JSON.stringify(canonicalJsonValue(canonicalMeasurementPlanV2(plan).executionNodes))
+  return surface(active) === surface(candidate)
 }

--- a/packages/api-routes/src/measurement-draft-compile.ts
+++ b/packages/api-routes/src/measurement-draft-compile.ts
@@ -592,8 +592,35 @@ export function diffCompiledPlans(
  * new revision's manifest checks, which is what publish-time continuity
  * (`measurement_plan_versions.comparable_to_version_id`) promises the reads.
  */
-export function plansShareExecutionSurface(active: MeasurementPlanV2, candidate: MeasurementPlanV2): boolean {
-  const surface = (plan: MeasurementPlanV2): string =>
-    JSON.stringify(canonicalJsonValue(canonicalMeasurementPlanV2(plan).executionNodes))
+export function plansAreLabelOnlyVariants(active: MeasurementPlanV2, candidate: MeasurementPlanV2): boolean {
+  /**
+   * Continuity is promised ONLY for a label-only republish, so the comparison
+   * is the FULL canonical document with display labels neutralized - not the
+   * execution nodes alone. Execution-node equality looked sufficient and was
+   * not: queryClass lives on assignments, aliases and urlMatchers on targets,
+   * brand names on identities, competitors on groups - all invisible to the
+   * node comparison, and every one of them changes what stored evidence MEANS
+   * when the reads hand the active plan to the report adapter. Admitting any
+   * of them as "cosmetic" reinterprets old answers under new semantics with
+   * zero new measurement, which is exactly what the frozen-revision doctrine
+   * exists to prevent.
+   */
+  const surface = (plan: MeasurementPlanV2): string => {
+    const doc = canonicalMeasurementPlanV2(plan)
+    const stripped = {
+      ...doc,
+      // compiledChecksum is DERIVED over the full document, labels included,
+      // so keeping it would smuggle the stripped labels back into the
+      // comparison. Everything else in the doc is semantic and stays.
+      compiledChecksum: '',
+      targets: doc.targets.map((target) => ({ ...target, label: '' })),
+      groups: doc.groups.map((group) => ({
+        ...group,
+        label: '',
+        competitors: group.competitors.map((competitor) => ({ ...competitor, label: '' })),
+      })),
+    }
+    return JSON.stringify(canonicalJsonValue(stripped))
+  }
   return surface(active) === surface(candidate)
 }

--- a/packages/api-routes/src/measurement-draft.ts
+++ b/packages/api-routes/src/measurement-draft.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto'
 import { and, asc, desc, eq, inArray } from 'drizzle-orm'
+import { comparableMeasurementVersionIds } from './measurement-report-adapter.js'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import {
   AppError,
@@ -63,7 +64,7 @@ import {
   compileMeasurementDraft,
   compileMeasurementDraftAssignmentExecution,
   diffCompiledPlans,
-  plansShareExecutionSurface,
+  plansAreLabelOnlyVariants,
   proposeQueryClassForTarget,
   type MeasurementDraftCompileContext,
 } from './measurement-draft-compile.js'
@@ -474,7 +475,10 @@ export async function measurementDraftRoutes(app: FastifyInstance, opts: Measure
     const completedRun = active
       ? app.db.select({ id: runs.id }).from(runs).where(and(
           eq(runs.projectId, project.id),
-          eq(runs.measurementPlanVersionId, active.id),
+          // The comparable chain, not the bare active id: a label-only
+          // republish must not flip setup back to awaiting_first_run while
+          // the overview keeps serving the prior run.
+          inArray(runs.measurementPlanVersionId, comparableMeasurementVersionIds(app.db, project.id, active.id)),
           eq(runs.status, RunStatuses.completed),
         )).get()
       : undefined
@@ -977,7 +981,7 @@ export async function measurementDraftRoutes(app: FastifyInstance, opts: Measure
       // execution model, so it never links.
       const comparableToVersionId = active !== null
         && active.schemaVersion === 2
-        && plansShareExecutionSurface(parseV2Plan(active), compiled.plan)
+        && plansAreLabelOnlyVariants(parseV2Plan(active), compiled.plan)
         ? active.id
         : null
 

--- a/packages/api-routes/src/measurement-draft.ts
+++ b/packages/api-routes/src/measurement-draft.ts
@@ -63,6 +63,7 @@ import {
   compileMeasurementDraft,
   compileMeasurementDraftAssignmentExecution,
   diffCompiledPlans,
+  plansShareExecutionSurface,
   proposeQueryClassForTarget,
   type MeasurementDraftCompileContext,
 } from './measurement-draft-compile.js'
@@ -967,6 +968,19 @@ export async function measurementDraftRoutes(app: FastifyInstance, opts: Measure
         }).run()
       }
 
+      // Publish-time continuity: when this publish changes NOTHING about
+      // execution — the superseded active revision froze the identical
+      // execution surface — record the link so reads keep serving the previous
+      // revision's runs instead of blanking until the next full sweep. An
+      // execution-changing publish leaves the link null and keeps today's
+      // refusal semantics exactly. A v1 active revision has no comparable
+      // execution model, so it never links.
+      const comparableToVersionId = active !== null
+        && active.schemaVersion === 2
+        && plansShareExecutionSurface(parseV2Plan(active), compiled.plan)
+        ? active.id
+        : null
+
       tx.insert(measurementPlanVersions).values({
         id: versionId,
         projectId: gate.project.id,
@@ -975,6 +989,7 @@ export async function measurementDraftRoutes(app: FastifyInstance, opts: Measure
         checksum: sha256Hex(canonicalJson),
         schemaVersion: 2,
         compiledChecksum: compiled.plan.compiledChecksum,
+        comparableToVersionId,
         publishedBy: serializeActor(gate.actor),
         sourceDraftId: row.id,
         createdAt: now.toISOString(),

--- a/packages/api-routes/src/measurement-overview.ts
+++ b/packages/api-routes/src/measurement-overview.ts
@@ -60,6 +60,7 @@ import {
   buildMeasurementPlanV2ReportInput,
   latestMeasurementRun,
   measurementRunExpectedSlots,
+  runVersionServesActiveVersion,
 } from './measurement-report-adapter.js'
 import { measurementRunCompleteness } from './measurement-run-completeness.js'
 
@@ -558,7 +559,10 @@ function selectDisplayedRun(
   }
   const run = db.select().from(runs).where(and(eq(runs.projectId, projectId), eq(runs.id, selectedRunId))).get()
   if (!run) throw notFound('Run', selectedRunId)
-  if (run.measurementPlanVersionId === active.version.id) return run
+  // A run pinned to a comparable prior revision (a label-only republish chain)
+  // measured exactly the questions the active revision asks, so naming it is
+  // continuity, not cross-revision mixing.
+  if (runVersionServesActiveVersion(db, projectId, active.version.id, run.measurementPlanVersionId)) return run
 
   const pinned = run.measurementPlanVersionId === null
     ? null

--- a/packages/api-routes/src/measurement-portfolio-reads.ts
+++ b/packages/api-routes/src/measurement-portfolio-reads.ts
@@ -57,7 +57,7 @@ import {
   materializeMeasurementQuestionRun,
   selectMeasurementQuestionRun,
 } from './measurement-question-reads.js'
-import { measurementRunExpectedSlots } from './measurement-report-adapter.js'
+import { comparableMeasurementVersionIds, measurementRunExpectedSlots } from './measurement-report-adapter.js'
 import { measurementRunCompleteness } from './measurement-run-completeness.js'
 
 /** Compact demo lists intentionally stop at ten unless the caller asks for more. */
@@ -671,7 +671,11 @@ function previousComparableRun(
     measurementExecutionIdentity: runs.measurementExecutionIdentity,
   }).from(runs).where(and(
     eq(runs.projectId, current.projectId),
-    eq(runs.measurementPlanVersionId, active.version.id),
+    // The comparable chain keeps period-over-period alive across a label-only
+    // republish: a run pinned to a comparable prior revision measured exactly
+    // the questions the active revision asks. The execution-identity and scope
+    // checks below still gate what actually compares.
+    inArray(runs.measurementPlanVersionId, comparableMeasurementVersionIds(db, current.projectId, active.version.id)),
     eq(runs.kind, RunKinds['answer-visibility']),
     inArray(runs.status, [RunStatuses.completed, RunStatuses.partial]),
     or(

--- a/packages/api-routes/src/measurement-property-evidence.ts
+++ b/packages/api-routes/src/measurement-property-evidence.ts
@@ -54,6 +54,7 @@ import {
   buildMeasurementPlanV2ReportInput,
   latestMeasurementRun,
   measurementRunExpectedSlots,
+  runVersionServesActiveVersion,
 } from './measurement-report-adapter.js'
 
 interface EvidenceCursor {
@@ -185,7 +186,10 @@ function selectDisplayedRun(
   }
   const run = db.select().from(runs).where(and(eq(runs.projectId, projectId), eq(runs.id, runId))).get()
   if (!run) throw notFound('Run', runId)
-  if (run.measurementPlanVersionId === active.version.id) return run
+  // A run pinned to a comparable prior revision (a label-only republish chain)
+  // measured exactly the questions the active revision asks, so naming it is
+  // continuity, not cross-revision mixing.
+  if (runVersionServesActiveVersion(db, projectId, active.version.id, run.measurementPlanVersionId)) return run
   const pinned = run.measurementPlanVersionId === null
     ? null
     : db.select({ revision: measurementPlanVersions.revision }).from(measurementPlanVersions)

--- a/packages/api-routes/src/measurement-question-reads.ts
+++ b/packages/api-routes/src/measurement-question-reads.ts
@@ -44,6 +44,7 @@ import {
   buildMeasurementPlanV2ReportInput,
   latestMeasurementRun,
   measurementRunExpectedSlots,
+  runVersionServesActiveVersion,
 } from './measurement-report-adapter.js'
 
 const DEFAULT_LIMIT = 50
@@ -185,7 +186,10 @@ export function selectMeasurementQuestionRun(
     eq(runs.projectId, projectId),
   )).get()
   if (!run) throw notFound('Run', runId)
-  if (run.measurementPlanVersionId !== active.version.id) {
+  // A run pinned to a comparable prior revision (a label-only republish chain)
+  // measured exactly the questions the active revision asks, so naming it is
+  // continuity, not cross-revision mixing.
+  if (!runVersionServesActiveVersion(db, projectId, active.version.id, run.measurementPlanVersionId)) {
     const pinned = run.measurementPlanVersionId === null
       ? null
       : db.select({ revision: measurementPlanVersions.revision }).from(measurementPlanVersions)

--- a/packages/api-routes/src/measurement-report-adapter.ts
+++ b/packages/api-routes/src/measurement-report-adapter.ts
@@ -451,11 +451,70 @@ function responseFromReport(
 }
 
 /**
+ * A cosmetic publish chain cannot realistically be deep, but the walk is still
+ * bounded so a corrupt or cyclic link column can never hang a read.
+ */
+export const MEASUREMENT_COMPARABLE_VERSION_WALK_LIMIT = 32
+
+/**
+ * The plan version ids whose runs may honestly serve a read pinned to
+ * `versionId`: the version itself, plus every predecessor reachable through
+ * the `comparable_to_version_id` continuity chain that publish records for an
+ * execution-identical (label-only) republish. Runs pinned to any of these
+ * versions answered exactly the questions `versionId` asks, so serving one is
+ * continuity rather than cross-revision mixing. The walk is backward-only,
+ * bounded, and cycle-safe.
+ */
+export function comparableMeasurementVersionIds(
+  db: DatabaseClient,
+  projectId: string,
+  versionId: string,
+): string[] {
+  const ids = [versionId]
+  const seen = new Set(ids)
+  let cursor = versionId
+  for (let step = 0; step < MEASUREMENT_COMPARABLE_VERSION_WALK_LIMIT; step++) {
+    const row = db.select({ comparableToVersionId: measurementPlanVersions.comparableToVersionId })
+      .from(measurementPlanVersions)
+      .where(and(
+        eq(measurementPlanVersions.projectId, projectId),
+        eq(measurementPlanVersions.id, cursor),
+      )).get()
+    const next = row?.comparableToVersionId ?? null
+    if (next === null || seen.has(next)) break
+    ids.push(next)
+    seen.add(next)
+    cursor = next
+  }
+  return ids
+}
+
+/**
+ * Whether a run's pinned version may serve a read of `activeVersionId`. Exact
+ * match, or membership in the comparable chain. A pre-plan run (null pin) never
+ * qualifies: it answered questions no revision froze.
+ */
+export function runVersionServesActiveVersion(
+  db: DatabaseClient,
+  projectId: string,
+  activeVersionId: string,
+  runVersionId: string | null,
+): boolean {
+  if (runVersionId === null) return false
+  if (runVersionId === activeVersionId) return true
+  return comparableMeasurementVersionIds(db, projectId, activeVersionId).includes(runVersionId)
+}
+
+/**
  * The default displayed run for one revision.
  *
  * A scoped spot check is excluded on purpose: it measured a slice the operator
  * named, so displaying it as the revision's result would report a subset as the
  * whole. It stays selectable by naming its id (§0.3).
+ *
+ * Selection accepts a run pinned to the named version OR to any prior version
+ * in its comparable chain, so a label-only republish keeps displaying the run
+ * it already had instead of blanking until the next sweep.
  */
 export function latestMeasurementRun(
   db: DatabaseClient,
@@ -466,7 +525,7 @@ export function latestMeasurementRun(
 ): typeof runs.$inferSelect | undefined {
   const conditions = [
     eq(runs.projectId, projectId),
-    eq(runs.measurementPlanVersionId, versionId),
+    inArray(runs.measurementPlanVersionId, comparableMeasurementVersionIds(db, projectId, versionId)),
     eq(runs.kind, RunKinds['answer-visibility']),
     inArray(runs.status, [...statuses]),
     ne(runs.trigger, RunTriggers.probe),
@@ -487,7 +546,7 @@ function pinnedMeasurementRun(
   return db.select().from(runs).where(and(
     eq(runs.id, runId),
     eq(runs.projectId, projectId),
-    eq(runs.measurementPlanVersionId, versionId),
+    inArray(runs.measurementPlanVersionId, comparableMeasurementVersionIds(db, projectId, versionId)),
     eq(runs.kind, RunKinds['answer-visibility']),
     inArray(runs.status, [RunStatuses.completed, RunStatuses.partial]),
     ne(runs.trigger, RunTriggers.probe),

--- a/packages/api-routes/src/measurement-report-adapter.ts
+++ b/packages/api-routes/src/measurement-report-adapter.ts
@@ -522,10 +522,17 @@ export function latestMeasurementRun(
   versionId: string,
   statuses: readonly RunStatus[],
   window: { from?: string; to?: string } = {},
+  opts: { exactVersion?: boolean } = {},
 ): typeof runs.$inferSelect | undefined {
   const conditions = [
     eq(runs.projectId, projectId),
-    inArray(runs.measurementPlanVersionId, comparableMeasurementVersionIds(db, projectId, versionId)),
+    // The revision-addressed report surface promises the revision AS-WAS and
+    // must never borrow a predecessor's run through the comparable chain; the
+    // active-dashboard surfaces want the chain so a label-only republish does
+    // not blank them. exactVersion selects the contract.
+    opts.exactVersion
+      ? eq(runs.measurementPlanVersionId, versionId)
+      : inArray(runs.measurementPlanVersionId, comparableMeasurementVersionIds(db, projectId, versionId)),
     eq(runs.kind, RunKinds['answer-visibility']),
     inArray(runs.status, [...statuses]),
     ne(runs.trigger, RunTriggers.probe),
@@ -542,11 +549,14 @@ function pinnedMeasurementRun(
   projectId: string,
   versionId: string,
   runId: string,
+  opts: { exactVersion?: boolean } = {},
 ): typeof runs.$inferSelect | undefined {
   return db.select().from(runs).where(and(
     eq(runs.id, runId),
     eq(runs.projectId, projectId),
-    inArray(runs.measurementPlanVersionId, comparableMeasurementVersionIds(db, projectId, versionId)),
+    opts.exactVersion
+      ? eq(runs.measurementPlanVersionId, versionId)
+      : inArray(runs.measurementPlanVersionId, comparableMeasurementVersionIds(db, projectId, versionId)),
     eq(runs.kind, RunKinds['answer-visibility']),
     inArray(runs.status, [RunStatuses.completed, RunStatuses.partial]),
     ne(runs.trigger, RunTriggers.probe),
@@ -576,8 +586,8 @@ function storedMeasurementPlanV2Report(
   runId?: string,
 ): StoredMeasurementReport {
   const run = runId
-    ? pinnedMeasurementRun(db, projectId, version.id, runId)
-    : latestMeasurementRun(db, projectId, version.id, [RunStatuses.completed, RunStatuses.partial])
+    ? pinnedMeasurementRun(db, projectId, version.id, runId, { exactVersion: true })
+    : latestMeasurementRun(db, projectId, version.id, [RunStatuses.completed, RunStatuses.partial], {}, { exactVersion: true })
   if (!run) {
     const empty = buildMeasurementPlanV2ReportInput(version.revision, plan, { schemaVersion: 1, expectedSlots: [] }, [])
     return {
@@ -620,7 +630,7 @@ export function buildStoredMeasurementReport(
   const plan = stored
 
   const run = runId
-    ? pinnedMeasurementRun(db, projectId, version.id, runId)
+    ? pinnedMeasurementRun(db, projectId, version.id, runId, { exactVersion: true })
     : db.select().from(runs).where(and(
         eq(runs.projectId, projectId),
         eq(runs.measurementPlanVersionId, version.id),

--- a/packages/api-routes/test/measurement-cosmetic-continuity.test.ts
+++ b/packages/api-routes/test/measurement-cosmetic-continuity.test.ts
@@ -250,6 +250,37 @@ describe('cosmetic-publish continuity', () => {
     expect(harbor?.mentionCoverage).toMatchObject({ state: 'available', value: 1, numerator: 2, denominator: 2 })
   })
 
+  it('keeps measurement-setup out of awaiting_first_run after a cosmetic republish', async () => {
+    const versionOne = seedVersion(1)
+    seedMeasuredRun(versionOne)
+    activate(seedVersion(2, renamedPlan(), versionOne))
+
+    const setup = await app.inject({ method: 'GET', url: '/api/v1/projects/northstar/measurement-setup' })
+    expect(setup.statusCode).toBe(200)
+    const body = setup.json()
+    // The overview keeps serving the prior run; setup must agree rather than
+    // demanding a first run that already happened.
+    expect(body.state).not.toBe('awaiting_first_run')
+    expect(body.nextAction).not.toBe('run_measurement')
+  })
+
+  it('revision-addressed reports never borrow a predecessor run through the chain', async () => {
+    const versionOne = seedVersion(1)
+    seedMeasuredRun(versionOne)
+    activate(seedVersion(2, renamedPlan(), versionOne))
+
+    // The explicit --revision surface promises the revision AS-WAS. Revision 2
+    // has no run of its own, and the comparable chain must not lend it one.
+    const rev2 = await app.inject({ method: 'GET', url: '/api/v1/projects/northstar/measurement-report?revision=2' })
+    expect(rev2.statusCode).toBe(200)
+    expect(rev2.json().run).toBeNull()
+
+    // Revision 1 still reports its own run, exactly as measured.
+    const rev1 = await app.inject({ method: 'GET', url: '/api/v1/projects/northstar/measurement-report?revision=1' })
+    expect(rev1.statusCode).toBe(200)
+    expect(rev1.json().run).not.toBeNull()
+  })
+
   it('still blanks after an execution-changing publish', async () => {
     const versionOne = seedVersion(1)
     seedMeasuredRun(versionOne)

--- a/packages/api-routes/test/measurement-cosmetic-continuity.test.ts
+++ b/packages/api-routes/test/measurement-cosmetic-continuity.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Cosmetic-publish continuity.
+ *
+ * Every measurement read pins to the active plan version row, and a publish
+ * mints a new row for ANY compiled-checksum change — labels included. Before
+ * the `comparable_to_version_id` link, renaming a group therefore blanked the
+ * whole dashboard until the next full sweep. These tests prove the link keeps
+ * the previous run's ACTUAL NUMBERS on the overview, the portfolio summary and
+ * period-over-period, while an execution-changing publish still blanks.
+ */
+
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { and, eq } from 'drizzle-orm'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  buildMeasurementExecutionIdentity,
+  canonicalMeasurementPlanV2Json,
+  type MeasurementChangesResponse,
+  type MeasurementOverviewResponse,
+  type MeasurementPlanV2,
+  type MeasurementPortfolioSummaryResponse,
+} from '@ainyc/canonry-contracts'
+import {
+  createClient,
+  measurementPlans,
+  measurementPlanVersions,
+  migrate,
+  projects,
+  querySnapshots,
+  runs,
+  type DatabaseClient,
+} from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+import { buildMeasurementPlanV2Manifest } from '../src/measurement-report-adapter.js'
+import { measurementPlanV2Fixture } from './measurement-plan-v2-fixture.js'
+
+const NOW = '2026-08-02T12:00:00.000Z'
+const IDENTITY = buildMeasurementExecutionIdentity({
+  providers: ['openai', 'gemini'],
+  models: { openai: 'gpt-measurement', gemini: 'gemini-measurement' },
+}, 'a'.repeat(64))
+
+let directory: string
+let db: DatabaseClient
+let app: FastifyInstance
+let projectId: string
+let plan: MeasurementPlanV2
+
+/** The identical plan content re-published under a renamed group: a cosmetic revision. */
+function renamedPlan(): MeasurementPlanV2 {
+  const renamed = measurementPlanV2Fixture()
+  renamed.groups[0]!.label = 'Regional comparison (renamed)'
+  return renamed
+}
+
+function seedVersion(
+  revision: number,
+  doc: MeasurementPlanV2 = plan,
+  comparableToVersionId: string | null = null,
+): string {
+  const id = crypto.randomUUID()
+  db.insert(measurementPlanVersions).values({
+    id,
+    projectId,
+    revision,
+    canonicalJson: canonicalMeasurementPlanV2Json(doc),
+    checksum: crypto.randomUUID().replace(/-/g, '').padEnd(64, '0'),
+    schemaVersion: 2,
+    compiledChecksum: doc.compiledChecksum,
+    comparableToVersionId,
+    createdAt: NOW,
+  }).run()
+  return id
+}
+
+function activate(versionId: string): void {
+  db.insert(measurementPlans).values({
+    projectId,
+    activeVersionId: versionId,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }).onConflictDoUpdate({
+    target: measurementPlans.projectId,
+    set: { activeVersionId: versionId, updatedAt: NOW },
+  }).run()
+}
+
+function seedRun(versionId: string, values: Partial<typeof runs.$inferInsert> = {}): string {
+  const id = crypto.randomUUID()
+  db.insert(runs).values({
+    id,
+    projectId,
+    kind: 'answer-visibility',
+    status: 'completed',
+    trigger: 'manual',
+    measurementPlanVersionId: versionId,
+    measurementManifest: buildMeasurementPlanV2Manifest(plan),
+    measurementExecutionIdentity: IDENTITY,
+    finishedAt: NOW,
+    createdAt: NOW,
+    ...values,
+  }).run()
+  return id
+}
+
+function seedSnapshot(runId: string, executionKey: string, provider: string): void {
+  const node = plan.executionNodes.find(candidate => candidate.stableKey === executionKey)!
+  db.insert(querySnapshots).values({
+    id: crypto.randomUUID(),
+    runId,
+    queryId: null,
+    queryText: node.queryText,
+    provider,
+    citationState: 'not-cited',
+    answerMentioned: false,
+    answerText: 'Another local option is worth considering.',
+    citedDomains: [],
+    citedUrls: [],
+    captureStatus: 'complete',
+    competitorOverlap: [],
+    recommendedCompetitors: [],
+    measurementExecutionId: executionKey,
+    requestedContext: node.context.location,
+    supportedContext: { status: 'applied', resolved: node.context.location },
+    location: node.context.location?.label ?? null,
+    retrievalStatus: 'used',
+    retrievalContract: 'native-auto-v1',
+    createdAt: NOW,
+  }).run()
+}
+
+/** A completed full sweep where Harbor is mentioned and cited on its Non-brand question only. */
+function seedMeasuredRun(versionId: string, values: Partial<typeof runs.$inferInsert> = {}): string {
+  const runId = seedRun(versionId, values)
+  for (const provider of ['openai', 'gemini']) {
+    seedSnapshot(runId, 'exec-nearby', provider)
+    seedSnapshot(runId, 'exec-brand', provider)
+  }
+  db.update(querySnapshots).set({
+    answerText: 'Harbor Homes is a strong option.',
+    citationState: 'cited',
+    citedUrls: ['https://northstar.example/locations/harbor/details'],
+  }).where(and(
+    eq(querySnapshots.runId, runId),
+    eq(querySnapshots.measurementExecutionId, 'exec-nearby'),
+  )).run()
+  return runId
+}
+
+async function overview(query: string): Promise<{ status: number; body: MeasurementOverviewResponse }> {
+  const response = await app.inject({ method: 'GET', url: `/api/v1/projects/northstar/measurement-overview?${query}` })
+  return { status: response.statusCode, body: response.json() as MeasurementOverviewResponse }
+}
+
+async function portfolio(query = ''): Promise<{ status: number; body: MeasurementPortfolioSummaryResponse }> {
+  const response = await app.inject({
+    method: 'GET',
+    url: `/api/v1/projects/northstar/measurement-portfolio-summary${query === '' ? '' : `?${query}`}`,
+  })
+  return { status: response.statusCode, body: response.json() as MeasurementPortfolioSummaryResponse }
+}
+
+async function changes(query = ''): Promise<{ status: number; body: MeasurementChangesResponse }> {
+  const response = await app.inject({
+    method: 'GET',
+    url: `/api/v1/projects/northstar/measurement-changes${query === '' ? '' : `?${query}`}`,
+  })
+  return { status: response.statusCode, body: response.json() as MeasurementChangesResponse }
+}
+
+beforeEach(async () => {
+  directory = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-measurement-cosmetic-continuity-'))
+  db = createClient(path.join(directory, 'test.db'))
+  migrate(db)
+  projectId = crypto.randomUUID()
+  db.insert(projects).values({
+    id: projectId,
+    name: 'northstar',
+    displayName: 'Northstar',
+    canonicalDomain: 'northstar.example',
+    ownedDomains: ['northstar.example'],
+    country: 'US',
+    language: 'en',
+    locations: [],
+    providers: [],
+    createdAt: NOW,
+    updatedAt: NOW,
+  }).run()
+  plan = measurementPlanV2Fixture()
+
+  app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true })
+  await app.ready()
+})
+
+afterEach(async () => {
+  await app.close()
+  fs.rmSync(directory, { recursive: true, force: true })
+})
+
+describe('cosmetic-publish continuity', () => {
+  it('keeps serving the prior run and its exact numbers after a label-only republish', async () => {
+    const versionOne = seedVersion(1)
+    const measured = seedMeasuredRun(versionOne)
+    activate(seedVersion(2, renamedPlan(), versionOne))
+
+    const all = await overview('scope=all')
+    expect(all.status).toBe(200)
+    expect(all.body.measurement).toMatchObject({ state: 'complete', displayedRunId: measured })
+    // A scoped Property is named and cited on the 2 exec-nearby slots and on
+    // neither exec-brand slot, so coverage is 2 of the 4 distinct expected
+    // slots — the numbers the run earned under revision 1.
+    expect(all.body.metrics.mentionCoverage).toMatchObject({
+      state: 'available', value: 2 / 4, numerator: 2, denominator: 4,
+    })
+    expect(all.body.metrics.citationCoverage).toMatchObject({
+      state: 'available', value: 2 / 4, numerator: 2, denominator: 4,
+    })
+    expect(all.body.metrics.propertiesMentioned).toMatchObject({
+      state: 'available', value: 1, numerator: 1, denominator: 2,
+    })
+
+    // The revision that is displayed stays the ACTIVE one, renamed label and
+    // all: continuity serves the old evidence, never the old labels.
+    const group = await overview('scope=group&groupKey=regional')
+    expect(group.status).toBe(200)
+    expect(group.body.scope).toMatchObject({ label: 'Regional comparison (renamed)' })
+    expect(group.body.measurement).toMatchObject({ state: 'complete', displayedRunId: measured })
+
+    const summary = await portfolio()
+    expect(summary.status).toBe(200)
+    // planRevision reports the active revision the plan content comes from;
+    // displayedRunId names the actual (prior-revision) run — nothing is faked.
+    expect(summary.body.measurement).toMatchObject({
+      state: 'complete', displayedRunId: measured, planRevision: 2,
+    })
+    // Default class is non-brand: the 2 shared exec-nearby slots, both of
+    // which name and cite Harbor.
+    expect(summary.body.metrics.mentionCoverage).toMatchObject({
+      state: 'available', value: 1, numerator: 2, denominator: 2,
+    })
+    expect(summary.body.metrics.citationCoverage).toMatchObject({
+      state: 'available', value: 1, numerator: 2, denominator: 2,
+    })
+    const harbor = summary.body.weakestProperties.find(row => row.targetKey === 'harbor')
+    expect(harbor?.mentionCoverage).toMatchObject({ state: 'available', value: 1, numerator: 2, denominator: 2 })
+  })
+
+  it('still blanks after an execution-changing publish', async () => {
+    const versionOne = seedVersion(1)
+    seedMeasuredRun(versionOne)
+    // No comparability link: publish decided the execution surface changed.
+    activate(seedVersion(2, renamedPlan(), null))
+
+    const { status, body } = await overview('scope=all')
+    expect(status).toBe(200)
+    expect(body.measurement.state).toBe('not_measured')
+    expect(body.metrics.mentionCoverage).toEqual({ state: 'unavailable', reason: 'no_completed_run' })
+
+    const summary = await portfolio()
+    expect(summary.body.measurement).toMatchObject({ state: 'not_measured', displayedRunId: null })
+    expect(summary.body.metrics.mentionCoverage).toEqual({ state: 'unavailable', reason: 'no_completed_run' })
+  })
+
+  it('follows the comparable chain across two consecutive cosmetic publishes', async () => {
+    const versionOne = seedVersion(1)
+    const measured = seedMeasuredRun(versionOne)
+    const versionTwo = seedVersion(2, renamedPlan(), versionOne)
+    activate(seedVersion(3, renamedPlan(), versionTwo))
+
+    const { status, body } = await overview('scope=all')
+    expect(status).toBe(200)
+    expect(body.measurement).toMatchObject({ state: 'complete', displayedRunId: measured })
+    expect(body.metrics.mentionCoverage).toMatchObject({
+      state: 'available', value: 2 / 4, numerator: 2, denominator: 4,
+    })
+
+    // Naming the served run explicitly (a drill-down) is continuity too.
+    const named = await portfolio(`runId=${measured}`)
+    expect(named.status).toBe(200)
+    expect(named.body.measurement).toMatchObject({ displayedRunId: measured, planRevision: 3 })
+  })
+
+  it('prefers a newer run on the active revision over the comparable predecessor', async () => {
+    const versionOne = seedVersion(1)
+    seedMeasuredRun(versionOne, { createdAt: '2026-08-02T08:00:00.000Z' })
+    const versionTwo = seedVersion(2, renamedPlan(), versionOne)
+    activate(versionTwo)
+    const fresh = seedMeasuredRun(versionTwo, { createdAt: '2026-08-02T09:00:00.000Z' })
+
+    const { body } = await overview('scope=all')
+    expect(body.measurement).toMatchObject({ state: 'complete', displayedRunId: fresh })
+  })
+
+  it('keeps period-over-period comparison alive across a cosmetic publish', async () => {
+    const versionOne = seedVersion(1)
+    const previous = seedMeasuredRun(versionOne, { createdAt: '2026-08-02T08:00:00.000Z' })
+    const current = seedMeasuredRun(versionOne, { createdAt: '2026-08-02T09:00:00.000Z' })
+    db.update(querySnapshots).set({
+      answerText: 'Harbor Homes and Bayside Homes are strong options.',
+      citationState: 'cited',
+      citedUrls: [
+        'https://northstar.example/locations/harbor/details',
+        'https://northstar.example/locations/bayside/details',
+      ],
+    }).where(eq(querySnapshots.runId, current)).run()
+    activate(seedVersion(2, renamedPlan(), versionOne))
+
+    const { status, body } = await changes('limit=2')
+    expect(status).toBe(200)
+    expect(body.current).toMatchObject({ displayedRunId: current, planRevision: 2 })
+    expect(body.comparison).toMatchObject({
+      state: 'available', previous: { displayedRunId: previous, planRevision: 2 },
+    })
+    if (body.comparison.state !== 'available') throw new Error('Expected a comparable measurement run.')
+    // Every slot now mentions and cites both Properties, up from Harbor's
+    // Non-brand-only presence: slot coverage moves 2/4 -> 4/4.
+    expect(body.comparison.metrics.mentionCoverage).toMatchObject({
+      state: 'available',
+      previous: { value: 2 / 4 },
+      current: { value: 1 },
+      delta: 1 - 2 / 4,
+    })
+    expect(body.comparison.metrics.citationCoverage).toMatchObject({
+      state: 'available',
+      previous: { value: 2 / 4 },
+      current: { value: 1 },
+      delta: 1 - 2 / 4,
+    })
+  })
+
+  it('never bridges through a version outside the comparable chain', async () => {
+    // v1 <- comparable v2, but v3 breaks the chain (execution changed), and a
+    // later v4 is comparable only to v3. Runs on v1/v2 must not leak into v4.
+    const versionOne = seedVersion(1)
+    seedMeasuredRun(versionOne)
+    const versionTwo = seedVersion(2, renamedPlan(), versionOne)
+    seedMeasuredRun(versionTwo)
+    const versionThree = seedVersion(3, renamedPlan(), null)
+    activate(seedVersion(4, renamedPlan(), versionThree))
+
+    const { body } = await overview('scope=all')
+    expect(body.measurement.state).toBe('not_measured')
+    expect(body.metrics.mentionCoverage).toEqual({ state: 'unavailable', reason: 'no_completed_run' })
+  })
+})

--- a/packages/api-routes/test/measurement-draft.test.ts
+++ b/packages/api-routes/test/measurement-draft.test.ts
@@ -1169,6 +1169,46 @@ describe('measurement draft publish', () => {
     expect(db.select().from(measurementPlanVersions).all()).toHaveLength(3)
   })
 
+  it('links a cosmetic publish to the revision it supersedes and withholds the link when execution changes', async () => {
+    const first = await readyDraft()
+    expect((await publish(first, null)).json()).toMatchObject({ published: true, active: { revision: 1 } })
+    const revisionOne = db.select().from(measurementPlanVersions)
+      .where(eq(measurementPlanVersions.revision, 1)).get()!
+    // A first revision supersedes nothing, so it has nothing to compare with.
+    expect(revisionOne.comparableToVersionId).toBeNull()
+
+    // A label-only rename changes the compiled checksum but not one provider
+    // call, so the new revision records the one it stays comparable with.
+    const second = await DraftSession.start(1)
+    await second.run('upsert-target', { target: { ...WIDGETS_TARGET, label: 'Widgets Renamed' } })
+    expect((await publish(second, 1)).json()).toMatchObject({ published: true, active: { revision: 2 } })
+    const revisionTwo = db.select().from(measurementPlanVersions)
+      .where(eq(measurementPlanVersions.revision, 2)).get()!
+    expect(revisionTwo.comparableToVersionId).toBe(revisionOne.id)
+
+    // A second cosmetic publish (a new mention alias) chains one step at a
+    // time: each link names the revision it directly superseded.
+    const third = await DraftSession.start(2)
+    await third.run('upsert-target', {
+      target: { ...WIDGETS_TARGET, label: 'Widgets Renamed', aliases: ['Northwind Widgets', 'NW Widgets'] },
+    })
+    expect((await publish(third, 2)).json()).toMatchObject({ published: true, active: { revision: 3 } })
+    const revisionThree = db.select().from(measurementPlanVersions)
+      .where(eq(measurementPlanVersions.revision, 3)).get()!
+    expect(revisionThree.comparableToVersionId).toBe(revisionTwo.id)
+
+    // Adding a Target with an assignment adds execution nodes. The prior runs
+    // did not measure them, so this publish keeps today's blank-until-swept
+    // semantics: no link.
+    const fourth = await DraftSession.start(3)
+    await fourth.run('upsert-target', { target: GADGETS_TARGET })
+    await fourth.run('apply-assignments', { targetKey: 'gadgets', queryIds: [queryId('widget delivery times')] })
+    expect((await publish(fourth, 3)).json()).toMatchObject({ published: true, active: { revision: 4 } })
+    const revisionFour = db.select().from(measurementPlanVersions)
+      .where(eq(measurementPlanVersions.revision, 4)).get()!
+    expect(revisionFour.comparableToVersionId).toBeNull()
+  })
+
   it('deletes only the active-plan pointer on deactivate', async () => {
     const session = await readyDraft()
     await publish(session, null)

--- a/packages/api-routes/test/measurement-draft.test.ts
+++ b/packages/api-routes/test/measurement-draft.test.ts
@@ -1186,27 +1186,51 @@ describe('measurement draft publish', () => {
       .where(eq(measurementPlanVersions.revision, 2)).get()!
     expect(revisionTwo.comparableToVersionId).toBe(revisionOne.id)
 
-    // A second cosmetic publish (a new mention alias) chains one step at a
-    // time: each link names the revision it directly superseded.
+    // A second label-only publish chains one step at a time: each link names
+    // the revision it directly superseded.
     const third = await DraftSession.start(2)
-    await third.run('upsert-target', {
-      target: { ...WIDGETS_TARGET, label: 'Widgets Renamed', aliases: ['Northwind Widgets', 'NW Widgets'] },
-    })
+    await third.run('upsert-target', { target: { ...WIDGETS_TARGET, label: 'Widgets Renamed Again' } })
     expect((await publish(third, 2)).json()).toMatchObject({ published: true, active: { revision: 3 } })
     const revisionThree = db.select().from(measurementPlanVersions)
       .where(eq(measurementPlanVersions.revision, 3)).get()!
     expect(revisionThree.comparableToVersionId).toBe(revisionTwo.id)
 
+    // An ALIAS edit leaves every execution node byte-identical, but it changes
+    // what stored answers MEAN: the reads re-match mention against the active
+    // plan's aliases, so linking here would flip old evidence to "mentioned"
+    // with zero new measurement. Meaning changes never link.
+    const aliasEdit = await DraftSession.start(3)
+    await aliasEdit.run('upsert-target', {
+      target: { ...WIDGETS_TARGET, label: 'Widgets Renamed Again', aliases: ['Northwind Widgets', 'NW Widgets'] },
+    })
+    expect((await publish(aliasEdit, 3)).json()).toMatchObject({ published: true, active: { revision: 4 } })
+    const aliasRevision = db.select().from(measurementPlanVersions)
+      .where(eq(measurementPlanVersions.revision, 4)).get()!
+    expect(aliasRevision.comparableToVersionId).toBeNull()
+
+    // A queryClass flip is the same trap one field over: the class lives on
+    // the assignment, not the execution node, and repools the basket a stored
+    // answer counts against. Never linked.
+    const classFlip = await DraftSession.start(4)
+    await classFlip.run('classify-assignments', {
+      queryClass: 'branded',
+      assignments: [{ targetKey: 'widgets', queryId: queryId('best widget supplier') }],
+    })
+    expect((await publish(classFlip, 4)).json()).toMatchObject({ published: true, active: { revision: 5 } })
+    const classRevision = db.select().from(measurementPlanVersions)
+      .where(eq(measurementPlanVersions.revision, 5)).get()!
+    expect(classRevision.comparableToVersionId).toBeNull()
+
     // Adding a Target with an assignment adds execution nodes. The prior runs
     // did not measure them, so this publish keeps today's blank-until-swept
     // semantics: no link.
-    const fourth = await DraftSession.start(3)
+    const fourth = await DraftSession.start(5)
     await fourth.run('upsert-target', { target: GADGETS_TARGET })
     await fourth.run('apply-assignments', { targetKey: 'gadgets', queryIds: [queryId('widget delivery times')] })
-    expect((await publish(fourth, 3)).json()).toMatchObject({ published: true, active: { revision: 4 } })
-    const revisionFour = db.select().from(measurementPlanVersions)
-      .where(eq(measurementPlanVersions.revision, 4)).get()!
-    expect(revisionFour.comparableToVersionId).toBeNull()
+    expect((await publish(fourth, 5)).json()).toMatchObject({ published: true, active: { revision: 6 } })
+    const revisionSix = db.select().from(measurementPlanVersions)
+      .where(eq(measurementPlanVersions.revision, 6)).get()!
+    expect(revisionSix.comparableToVersionId).toBeNull()
   })
 
   it('deletes only the active-plan pointer on deactivate', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.178.2",
+  "version": "4.178.3",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.178.0",
+  "version": "4.178.2",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -4023,6 +4023,21 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
          ON insight_notify_state(project_id)`,
     ],
   },
+  {
+    version: 149,
+    name: 'measurement-plan-version-continuity',
+    // Every measurement read pins to the active plan version row id, but a
+    // publish mints a new row for ANY compiled-checksum change — labels
+    // included — so renaming a group blanked the dashboard until the next full
+    // sweep. This column records, at publish time, the superseded version a
+    // cosmetic (execution-identical) revision stays comparable with, so reads
+    // can keep serving the previous run. Historic rows stay NULL on purpose:
+    // their execution equality was never verified at publish time, and
+    // backfilling one would claim a comparison nobody made.
+    statements: [
+      `ALTER TABLE measurement_plan_versions ADD COLUMN comparable_to_version_id TEXT`,
+    ],
+  },
 ]
 
 function addRunsMeasurementPlanVersionForeignKey(tx: MigrationDb): void {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -72,6 +72,17 @@ export const measurementPlanVersions = sqliteTable('measurement_plan_versions', 
    * never happened.
    */
   compiledChecksum: text('compiled_checksum'),
+  /**
+   * Continuity link written at publish time: the superseded active version this
+   * revision is measurement-comparable with. Set ONLY when the publish changed
+   * nothing about execution — the frozen execution nodes of both revisions are
+   * canonically identical — so a run pinned to the linked version answered
+   * exactly the questions this revision would ask. A label-only republish
+   * therefore keeps serving the previous run instead of blanking the dashboard
+   * until the next sweep. Null for the first revision, for every
+   * execution-changing publish, and on every historic row.
+   */
+  comparableToVersionId: text('comparable_to_version_id'),
   publishedBy: text('published_by'),
   sourceDraftId: text('source_draft_id'),
   createdAt: text('created_at').notNull(),

--- a/packages/db/test/measurement-plan-persistence.test.ts
+++ b/packages/db/test/measurement-plan-persistence.test.ts
@@ -190,7 +190,7 @@ test('execution context is nullable for legacy rows and unique per run, executio
 
 test('schema mirrors the Target plan persistence boundary', () => {
   const expectedTables = [
-    ['measurementPlanVersions', 'measurement_plan_versions', ['id', 'project_id', 'revision', 'canonical_json', 'checksum', 'schema_version', 'compiled_checksum', 'published_by', 'source_draft_id', 'created_at']],
+    ['measurementPlanVersions', 'measurement_plan_versions', ['id', 'project_id', 'revision', 'canonical_json', 'checksum', 'schema_version', 'compiled_checksum', 'comparable_to_version_id', 'published_by', 'source_draft_id', 'created_at']],
     ['measurementSegments', 'measurement_segments', ['id', 'project_id', 'stable_key', 'kind', 'retired_at', 'created_at']],
     ['measurementPlans', 'measurement_plans', ['project_id', 'active_version_id', 'created_at', 'updated_at']],
   ] as const

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.178.2",
+  "version": "4.178.3",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.178.0",
+  "version": "4.178.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.178.2",
+  "version": "4.178.3",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.178.0",
+  "version": "4.178.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.178.0",
+  "version": "4.178.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.178.2",
+  "version": "4.178.3",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
The root structural defect behind editing a live measurement plan: every measurement read pins to the active plan version row id, and publish mints a new version row for any compiled-checksum change — labels included. Renaming a group blanked the entire dashboard (overview, portfolio summary, property pages, evidence) until the next full sweep, and permanently severed period-over-period comparison. On a bi-monthly sweep cadence that blank lasts days.

## What this does

**Publish side.** When a draft publish supersedes a revision whose canonical document is identical up to display labels, the new version row records `comparable_to_version_id` (new nullable column, migration follows the repo's idempotent-migration rules). Execution-changing publishes record nothing and keep today's blank-until-swept semantics.

**Read side.** The displayed-run selectors accept a run pinned to the active version or any version reachable through the comparable chain (bounded, cycle-safe walk). Labels and plan content always come from the active revision; `displayedRunId` names the real run — continuity serves old evidence, never old labels.

## What counts as label-only, precisely

The comparison is the full canonical document with display labels neutralized and the derived `compiledChecksum` excluded — not execution-node equality. That distinction is load-bearing and came out of adversarial review of the first implementation: queryClass lives on assignments, aliases and urlMatchers on targets, brand names on identities, competitors on groups. All of those are invisible to a node-only comparison, and all of them change what stored evidence means at read time, so linking any of them would silently reinterpret old answers under new semantics with zero new measurement. A test now asserts the counter-examples (alias edit and queryClass flip must NOT link) alongside the positive case.

Two more review findings fixed in the same change: `measurement-setup` now follows the comparable chain (it reported `awaiting_first_run` after a cosmetic republish while the overview kept serving data), and the revision-addressed report surface (`measurement-report?revision=N`, the as-was contract) is pinned to `exactVersion` so it never borrows a predecessor's run through the chain.

## Verification

Every behavioural claim is mutation-tested: reverting the read-side chain fails the continuity tests, forcing the publish condition to always-link fails the draft test, reverting the setup selector and the exactVersion pin each fail exactly their test. Full verify green: 9,355 tests across 714 files.

4.178.3 (the .2 slot is claimed by #1058 — merge that first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)