### PR TITLE
feat: preserve measurement scope context

### DIFF
--- a/apps/web/src/components/project/MeasurementChangesRail.tsx
+++ b/apps/web/src/components/project/MeasurementChangesRail.tsx
@@ -1,0 +1,114 @@
+import { useQuery } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import type { MeasurementChangesResponse } from '@ainyc/canonry-api-client'
+import { getApiV1ProjectsByNameMeasurementChangesOptions } from '@ainyc/canonry-api-client/react-query'
+
+import { heyClient } from '../../api.js'
+import { Button } from '../ui/button.js'
+
+type ChangesQueryClass = 'all' | 'branded' | 'non-brand'
+
+type MeasurementChangesRailProps = {
+  project: string
+  queryClass: ChangesQueryClass
+  /** The resolved overview run. Never let this rail choose a newer default. */
+  runId: string
+} & (
+  | { scope: 'group'; groupKey: string }
+  | { scope: 'property'; targetKey: string }
+)
+
+const UNAVAILABLE_COPY = {
+  no_previous_run: 'No comparable sweep yet.',
+  incomplete: 'Latest measurement incomplete.',
+  execution_identity_changed: 'Answer-engine setup changed.',
+  not_comparable: 'Prior sweep differs in scope or setup.',
+} as const
+
+function percentagePoints(delta: number): string {
+  const points = Math.round(delta * 1_000) / 10
+  const digits = Number.isInteger(points) ? String(points) : points.toFixed(1)
+  return `${points > 0 ? '+' : ''}${digits} pp`
+}
+
+function Delta({
+  label,
+  metric,
+}: {
+  label: string
+  metric: Extract<MeasurementChangesResponse['comparison'], { state: 'available' }>['metrics']['mentionCoverage']
+}) {
+  const value = metric.state === 'available' && Number.isFinite(metric.delta)
+    ? percentagePoints(metric.delta)
+    : 'Unavailable'
+  return (
+    <div>
+      <dt className="text-xs text-secondary">{label}</dt>
+      <dd className="mt-0.5 font-mono text-base font-semibold tabular-nums text-heading">{value}</dd>
+    </div>
+  )
+}
+
+function Rail({ children, busy = false }: { children: ReactNode; busy?: boolean }) {
+  return (
+    <section aria-labelledby="measurement-changes-rail-heading" aria-busy={busy} className="border-y border-default py-4">
+      <h2 id="measurement-changes-rail-heading" className="text-base font-semibold text-heading">Since previous comparable sweep</h2>
+      <div className="mt-3">{children}</div>
+    </section>
+  )
+}
+
+export function MeasurementChangesRail(props: MeasurementChangesRailProps) {
+  const query = useQuery({
+    ...getApiV1ProjectsByNameMeasurementChangesOptions({
+      client: heyClient,
+      path: { name: props.project },
+      query: {
+        scope: props.scope,
+        ...(props.scope === 'group' ? { groupKey: props.groupKey } : { targetKey: props.targetKey }),
+        queryClass: props.queryClass,
+        runId: props.runId,
+      },
+    }),
+    enabled: Boolean(props.project) && Boolean(props.runId),
+    staleTime: 0,
+    refetchOnMount: 'always',
+  })
+
+  // Do not keep a prior scope or run's comparison on screen while this key is
+  // refreshing. The adjacent pulse and evidence stay mounted; only this local
+  // comparison waits for the exact requested run.
+  if (query.isPending || query.isFetching) {
+    return <Rail busy><p className="text-sm text-secondary">Loading changes…</p></Rail>
+  }
+
+  if (query.isError) {
+    return (
+      <Rail>
+        <div role="alert" className="flex flex-wrap items-center gap-3 text-sm text-negative">
+          <span>Could not load measurement changes.</span>
+          <Button type="button" size="sm" variant="outline" onClick={() => { void query.refetch() }}>Retry</Button>
+        </div>
+      </Rail>
+    )
+  }
+
+  const comparison = query.data.comparison
+  if (comparison.state === 'unavailable') {
+    return <Rail><p className="text-sm text-secondary">{UNAVAILABLE_COPY[comparison.reason]}</p></Rail>
+  }
+
+  return (
+    <Rail>
+      <dl className="flex flex-wrap items-start gap-x-8 gap-y-3">
+        <Delta label="Mention" metric={comparison.metrics.mentionCoverage} />
+        <Delta label="Citation" metric={comparison.metrics.citationCoverage} />
+      </dl>
+      {props.scope === 'group' ? (
+        <p className="mt-3 text-sm text-secondary">
+          {comparison.totalProperties} {comparison.totalProperties === 1 ? 'property' : 'properties'} changed
+        </p>
+      ) : null}
+    </Rail>
+  )
+}

--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementLanding.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementLanding.tsx
@@ -22,10 +22,12 @@ export interface AdvancedMeasurementLandingProps {
   onLoadMore?: (cursor: string) => void
   onPropertyExpand?: (targetKey: string) => void
   onRetryEvidence?: () => void
+  onLoadMoreEvidence?: () => void
   portfolioSummary?: MeasurementPortfolioSummaryResponse
   portfolioSummaryState?: 'loading' | 'ready' | 'error'
   onRetryPortfolioSummary?: () => void
   projectTrend?: ReactNode
+  changesRail?: ReactNode
   renderGroupLink?: (group: { id: string; name: string }) => ReactNode
   renderPortfolioLink?: () => ReactNode
   /** Passed straight through so the overview table can link a Property to its own page. */
@@ -51,10 +53,12 @@ export function AdvancedMeasurementLanding({
   onLoadMore,
   onPropertyExpand,
   onRetryEvidence,
+  onLoadMoreEvidence,
   portfolioSummary,
   portfolioSummaryState,
   onRetryPortfolioSummary,
   projectTrend,
+  changesRail,
   renderGroupLink,
   renderPortfolioLink,
   renderPropertyLink,
@@ -102,10 +106,12 @@ export function AdvancedMeasurementLanding({
           onLoadMore={onLoadMore}
           onPropertyExpand={onPropertyExpand}
           onRetryEvidence={onRetryEvidence}
+          onLoadMoreEvidence={onLoadMoreEvidence}
           portfolioSummary={portfolioSummary}
           portfolioSummaryState={portfolioSummaryState}
           onRetryPortfolioSummary={onRetryPortfolioSummary}
           projectTrend={projectTrend}
+          changesRail={changesRail}
           renderGroupLink={renderGroupLink}
           renderPortfolioLink={renderPortfolioLink}
           renderPropertyLink={renderPropertyLink}

--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -56,6 +56,9 @@ export interface AdvancedMeasurementProperty {
   assignedQueries: readonly string[]
   urls: readonly string[]
   evidence: readonly AdvancedMeasurementEvidence[]
+  /** The server count can exceed the pages loaded for this expanded Property. */
+  evidenceTotal?: number
+  hasMoreEvidence?: boolean
   evidenceState?: 'ready' | 'loading' | 'error'
   historical?: boolean
 }
@@ -182,11 +185,14 @@ export interface AdvancedMeasurementOverviewProps {
   onLoadMore?: (cursor: string) => void
   onPropertyExpand?: (propertyId: string) => void
   onRetryEvidence?: () => void
+  onLoadMoreEvidence?: () => void
   /** Compact portfolio/group roll-up, pinned to the same displayed run as `report`. */
   portfolioSummary?: MeasurementPortfolioSummaryResponse
   portfolioSummaryState?: 'loading' | 'ready' | 'error'
   onRetryPortfolioSummary?: () => void
   projectTrend?: ReactNode
+  /** Group continuity for the exact overview run; hidden while a Property search changes the population. */
+  changesRail?: ReactNode
   renderGroupLink?: (group: { id: string; name: string }) => ReactNode
   renderPortfolioLink?: () => ReactNode
   /**
@@ -330,17 +336,19 @@ function Truncation({
   total,
   onShowAll,
   itemLabel,
+  actionLabel,
 }: {
   shown: number
   total: number
   onShowAll: () => void
   itemLabel: string
+  actionLabel?: string
 }) {
   if (shown >= total) return null
   return (
     <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-secondary">
       <span>Showing {shown} of {total}</span>
-      <Button size="sm" variant="outline" onClick={onShowAll}>Show all {total} {itemLabel}</Button>
+      <Button size="sm" variant="outline" onClick={onShowAll}>{actionLabel ?? `Show all ${total} ${itemLabel}`}</Button>
     </div>
   )
 }
@@ -381,15 +389,20 @@ function CappedStringList({
 
 function CappedEvidenceList({
   evidence,
+  evidenceTotal,
   state = 'ready',
   onRetry,
+  onLoadMore,
 }: {
   evidence: readonly AdvancedMeasurementEvidence[]
+  evidenceTotal?: number
   state?: 'ready' | 'loading' | 'error'
   onRetry?: () => void
+  onLoadMore?: () => void
 }) {
   const [limit, setLimit] = useState(DETAIL_LIST_LIMIT)
   const shown = evidence.slice(0, limit)
+  const total = evidenceTotal ?? evidence.length
 
   return (
     <section aria-label="Evidence">
@@ -429,9 +442,13 @@ function CappedEvidenceList({
           </div>
           <Truncation
             shown={shown.length}
-            total={evidence.length}
+            total={total}
             itemLabel="evidence items"
-            onShowAll={() => setLimit(Number.MAX_SAFE_INTEGER)}
+            actionLabel={onLoadMore && evidence.length < total ? 'Show more evidence items' : undefined}
+            onShowAll={() => {
+              setLimit(Number.MAX_SAFE_INTEGER)
+              if (evidence.length < total) onLoadMore?.()
+            }}
           />
         </>
       )}
@@ -439,12 +456,26 @@ function CappedEvidenceList({
   )
 }
 
-function PropertyDetails({ property, onRetryEvidence }: { property: AdvancedMeasurementProperty; onRetryEvidence?: () => void }) {
+function PropertyDetails({
+  property,
+  onRetryEvidence,
+  onLoadMoreEvidence,
+}: {
+  property: AdvancedMeasurementProperty
+  onRetryEvidence?: () => void
+  onLoadMoreEvidence?: () => void
+}) {
   return (
     <div className="space-y-5 py-2">
       <CappedStringList title="Assigned queries" values={property.assignedQueries} emptyLabel="No queries are assigned." />
       <CappedStringList title="URLs" values={property.urls} emptyLabel="No URLs are assigned." valueClassName="break-all text-secondary" />
-      <CappedEvidenceList evidence={property.evidence} state={property.evidenceState} onRetry={onRetryEvidence} />
+      <CappedEvidenceList
+        evidence={property.evidence}
+        evidenceTotal={property.evidenceTotal}
+        state={property.evidenceState}
+        onRetry={onRetryEvidence}
+        onLoadMore={property.hasMoreEvidence ? onLoadMoreEvidence : undefined}
+      />
     </div>
   )
 }
@@ -609,10 +640,12 @@ export function AdvancedMeasurementOverview({
   onLoadMore,
   onPropertyExpand,
   onRetryEvidence,
+  onLoadMoreEvidence,
   portfolioSummary,
   portfolioSummaryState,
   onRetryPortfolioSummary,
   projectTrend,
+  changesRail,
   renderGroupLink,
   renderPortfolioLink,
   renderPropertyLink,
@@ -859,6 +892,8 @@ export function AdvancedMeasurementOverview({
         />
       ) : null}
 
+      {!hasPendingOrAppliedSearch ? changesRail : null}
+
       {!isViewLoading && showShareOfVoice ? <CompetitorShareOfVoice values={aggregate.shareOfVoice ?? []} /> : null}
 
       {!isViewLoading ? <section aria-labelledby="advanced-measurement-properties-title">
@@ -955,7 +990,7 @@ export function AdvancedMeasurementOverview({
                         <td />
                       </tr>
                     )) : null}
-                    {expanded ? <tr key={`${property.id}:details`}><td colSpan={4} className="bg-surface-subtle px-4"><PropertyDetails property={property} onRetryEvidence={onRetryEvidence} /></td></tr> : null}
+                    {expanded ? <tr key={`${property.id}:details`}><td colSpan={4} className="bg-surface-subtle px-4"><PropertyDetails property={property} onRetryEvidence={onRetryEvidence} onLoadMoreEvidence={onLoadMoreEvidence} /></td></tr> : null}
                   </Fragment>
                 )
               })}

--- a/apps/web/src/components/project/advanced-measurement/v2-overview-adapter.ts
+++ b/apps/web/src/components/project/advanced-measurement/v2-overview-adapter.ts
@@ -1,7 +1,7 @@
 import type {
   MeasurementOverviewResponse,
   MeasurementPlanResponse,
-  MeasurementReportResponse,
+  MeasurementPropertyEvidenceResponse,
 } from '@ainyc/canonry-api-client'
 
 import type {
@@ -15,13 +15,24 @@ import type {
 type ActivePlan = NonNullable<MeasurementPlanResponse['active']>
 type PlanV2 = Extract<ActivePlan['plan'], { schemaVersion: 2 }>
 type OverviewMetric = MeasurementOverviewResponse['metrics']['mentionCoverage']
-type ReportEvidence = MeasurementReportResponse['evidence'][number]
+type PropertyEvidence = NonNullable<MeasurementPropertyEvidenceResponse['evidence']>
+type PropertyEvidenceRow = PropertyEvidence['items'][number]
+
+export interface V2PropertyEvidencePage {
+  targetKey: string
+  displayedRunId?: string
+  items: readonly PropertyEvidenceRow[]
+  totalEstimate?: number
+  hasMore: boolean
+}
 
 export interface AdaptV2MeasurementOverviewInput {
   overview: MeasurementOverviewResponse
   activePlan: ActivePlan
-  report?: MeasurementReportResponse | null
-  reportState?: 'loading' | 'ready' | 'error'
+  /** Evidence is loaded lazily for the one expanded Property, not via the exact historical report. */
+  propertyEvidence?: V2PropertyEvidencePage | null
+  propertyEvidenceTargetKey?: string
+  propertyEvidenceState?: 'loading' | 'ready' | 'error'
   /** The ordering the caller requested; the response does not echo it. */
   sort?: AdvancedMeasurementSort
 }
@@ -53,7 +64,7 @@ export function matcherLabel(matcher: PlanV2['targets'][number]['urlMatchers'][n
   return `https://${matcher.host}/*`
 }
 
-function evidenceKind(classification: ReportEvidence['classification']): AdvancedMeasurementEvidence['kind'] {
+function evidenceKind(classification: PropertyEvidenceRow['classification']): AdvancedMeasurementEvidence['kind'] {
   if (classification === 'assigned') return 'this-property'
   if (classification === 'sibling') return 'another-property'
   if (classification === 'ownedUnmapped') return 'owned-unassigned'
@@ -62,39 +73,21 @@ function evidenceKind(classification: ReportEvidence['classification']): Advance
   return 'invalid-url'
 }
 
-function evidenceTone(classification: ReportEvidence['classification']): AdvancedMeasurementEvidence['tone'] {
+function evidenceTone(classification: PropertyEvidenceRow['classification']): AdvancedMeasurementEvidence['tone'] {
   if (classification === 'assigned') return 'positive'
   if (classification === 'external') return 'neutral'
   if (classification === 'invalid') return 'negative'
   return 'caution'
 }
 
-function edgeId(edge: PlanV2['usageEdges'][number]): string {
-  return `target:${edge.targetKey}:${edge.queryId}:${edge.executionNodeKey}`
-}
-
-/** One linear pass, independent of the number of Properties rendered. */
-export function indexV2EvidenceByTarget(
-  plan: PlanV2,
-  report?: MeasurementReportResponse | null,
-  queryClass?: 'branded' | 'non-brand',
+/** The route already filters to one Property, so no full-report reconstruction is needed. */
+function indexV2PropertyEvidence(
+  page?: V2PropertyEvidencePage | null,
 ): ReadonlyMap<string, AdvancedMeasurementEvidence[]> {
   const indexed = new Map<string, AdvancedMeasurementEvidence[]>()
-  if (!report) return indexed
-  const targetByEdge = new Map(plan.usageEdges.map(edge => [edgeId(edge), edge.targetKey]))
-  const classByAssignment = new Map(plan.assignments.map(assignment => [
-    `${assignment.targetKey}:${assignment.queryId}`,
-    assignment.queryClass,
-  ]))
-  const classByEdge = new Map(plan.usageEdges.map(edge => [
-    edgeId(edge),
-    classByAssignment.get(`${edge.targetKey}:${edge.queryId}`),
-  ]))
-  for (const item of report.evidence) {
-    if (queryClass && classByEdge.get(item.usageEdgeId) !== queryClass) continue
-    const targetKey = targetByEdge.get(item.usageEdgeId)
-    if (!targetKey) continue
-    const rows = indexed.get(targetKey) ?? []
+  if (!page) return indexed
+  const rows: AdvancedMeasurementEvidence[] = []
+  for (const item of page.items) {
     rows.push({
       id: `${item.observationId}:${item.expectedSlotId}:${item.usageEdgeId}:${item.sourceUrl}`,
       kind: evidenceKind(item.classification),
@@ -105,8 +98,8 @@ export function indexV2EvidenceByTarget(
       tone: evidenceTone(item.classification),
       historical: item.historical || item.bridged,
     })
-    indexed.set(targetKey, rows)
   }
+  indexed.set(page.targetKey, rows)
   return indexed
 }
 
@@ -151,8 +144,9 @@ function nextActionText(overview: MeasurementOverviewResponse): string | undefin
 export function adaptV2MeasurementOverview({
   overview,
   activePlan,
-  report,
-  reportState = report ? 'ready' : 'loading',
+  propertyEvidence,
+  propertyEvidenceTargetKey,
+  propertyEvidenceState = propertyEvidence ? 'ready' : 'loading',
   sort,
 }: AdaptV2MeasurementOverviewInput): AdvancedMeasurementOverviewReport {
   if (activePlan.plan.schemaVersion !== 2 || overview.mode !== 'active-v2') {
@@ -177,22 +171,13 @@ export function adaptV2MeasurementOverview({
     assignmentsByTarget.set(assignment.targetKey, values)
   }
 
-  const pinnedReport = report?.revision === activePlan.revision
-    && report.run?.id === overview.measurement.displayedRunId
-    ? report
+  const pinnedEvidence = propertyEvidence !== undefined
+    && propertyEvidence !== null
+    && propertyEvidence.displayedRunId === overview.measurement.displayedRunId
+    && propertyEvidence.targetKey === propertyEvidenceTargetKey
+    ? propertyEvidence
     : null
-  const evidenceState = overview.measurement.displayedRunId === undefined
-    ? 'ready' as const
-    : pinnedReport
-    ? 'ready' as const
-    : reportState === 'error' || report !== undefined && report !== null
-      ? 'error' as const
-      : 'loading' as const
-  const evidenceByTarget = indexV2EvidenceByTarget(
-    plan,
-    pinnedReport,
-    overview.queryClass === 'all' ? undefined : overview.queryClass,
-  )
+  const evidenceByTarget = indexV2PropertyEvidence(pinnedEvidence)
   // One Property belongs to at most one market in practice; when a plan puts it
   // in several, the first is named rather than a joined string, because the
   // subtitle is an identifier and not a list.
@@ -205,6 +190,13 @@ export function adaptV2MeasurementOverview({
   const properties = overview.properties.items.map(row => {
     const configured = targetByKey.get(row.targetKey)
     const evidence = evidenceByTarget.get(row.targetKey) ?? []
+    const evidenceState = overview.measurement.displayedRunId === undefined || row.targetKey !== propertyEvidenceTargetKey
+      ? 'ready' as const
+      : pinnedEvidence
+        ? 'ready' as const
+        : propertyEvidence !== undefined && propertyEvidence !== null
+          ? 'error' as const
+          : propertyEvidenceState
     return {
       id: row.targetKey,
       name: row.label,
@@ -220,6 +212,12 @@ export function adaptV2MeasurementOverview({
       assignedQueries: [...(assignmentsByTarget.get(row.targetKey) ?? [])],
       urls: configured?.urlMatchers.map(matcherLabel) ?? [],
       evidence,
+      ...(row.targetKey === propertyEvidenceTargetKey && pinnedEvidence
+        ? {
+            evidenceTotal: pinnedEvidence.totalEstimate ?? evidence.length,
+            hasMoreEvidence: pinnedEvidence.hasMore,
+          }
+        : {}),
       evidenceState,
       historical: evidence.some(item => item.historical),
     }

--- a/apps/web/src/lib/measurement-view-url.ts
+++ b/apps/web/src/lib/measurement-view-url.ts
@@ -18,6 +18,13 @@ export interface MeasurementViewState {
   queryClass: MeasurementQueryClass
 }
 
+/** A Property has one query class at a time; pooled coverage belongs to its Group. */
+export type MeasurementPropertyQueryClass = Exclude<MeasurementQueryClass, 'all'>
+
+export interface MeasurementPropertyViewState {
+  queryClass: MeasurementPropertyQueryClass
+}
+
 /**
  * Non-brand is the actionable default. Branded and non-brand answer different
  * questions, so the first view must not pool them into one headline rate. All
@@ -26,9 +33,14 @@ export interface MeasurementViewState {
 export const DEFAULT_MEASUREMENT_VIEW: MeasurementViewState = { scope: 'all', queryClass: 'non-brand' }
 
 const QUERY_CLASSES: readonly MeasurementQueryClass[] = ['all', 'non-brand', 'branded']
+const PROPERTY_QUERY_CLASSES: readonly MeasurementPropertyQueryClass[] = ['non-brand', 'branded']
 
 function isQueryClass(value: unknown): value is MeasurementQueryClass {
   return typeof value === 'string' && (QUERY_CLASSES as readonly string[]).includes(value)
+}
+
+function isPropertyQueryClass(value: unknown): value is MeasurementPropertyQueryClass {
+  return typeof value === 'string' && (PROPERTY_QUERY_CLASSES as readonly string[]).includes(value)
 }
 
 /**
@@ -47,6 +59,15 @@ export function parseMeasurementViewSearch(search: { scope?: string; class?: str
   // `group:` with nothing after it names no group, so it is not a group scope.
   if (!groupKey) return { scope: 'all', queryClass }
   return { scope: 'group', groupKey, queryClass }
+}
+
+/**
+ * Property pages intentionally do not support `all`: a Property is read in the
+ * branded or non-brand lane, never as a pooled result. The default is written
+ * explicitly so a copied Property URL always says which lane it shows.
+ */
+export function parseMeasurementPropertyViewSearch(search: { class?: string }): MeasurementPropertyViewState {
+  return { queryClass: isPropertyQueryClass(search.class) ? search.class : 'non-brand' }
 }
 
 /**
@@ -78,4 +99,9 @@ export function measurementViewSearch(view: MeasurementViewState): { scope?: str
     scope: view.scope === 'group' && view.groupKey ? `group:${view.groupKey}` : undefined,
     class: view.queryClass === DEFAULT_MEASUREMENT_VIEW.queryClass ? undefined : view.queryClass,
   }
+}
+
+/** Property URLs always carry their class, including the non-brand default. */
+export function measurementPropertyViewSearch(view: MeasurementPropertyViewState): { class: MeasurementPropertyQueryClass } {
+  return { class: view.queryClass }
 }

--- a/apps/web/src/pages/MeasurementPropertyPage.tsx
+++ b/apps/web/src/pages/MeasurementPropertyPage.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo, useState } from 'react'
-import { Link, useParams } from '@tanstack/react-router'
+import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { ArrowLeft } from 'lucide-react'
 import { MeasurementEvidenceShapes } from '@ainyc/canonry-contracts'
@@ -25,6 +25,13 @@ import { InfoTooltip } from '../components/shared/InfoTooltip.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
 import { useAccount } from '../contexts/account-context.js'
 import { matcherLabel } from '../components/project/advanced-measurement/v2-overview-adapter.js'
+import { MeasurementChangesRail } from '../components/project/MeasurementChangesRail.js'
+import {
+  measurementPropertyViewSearch,
+  measurementViewSearch,
+  parseMeasurementPropertyViewSearch,
+  parseMeasurementViewSearch,
+} from '../lib/measurement-view-url.js'
 
 type QueryClass = 'branded' | 'non-brand'
 type MetricValue = MeasurementOverviewResponse['metrics']['mentionCoverage']
@@ -241,11 +248,11 @@ function MetricCell({ metric, emphasis = false }: { metric: MetricValue; emphasi
   )
 }
 
-function overviewOptions(projectName: string, targetKey: string, queryClass: QueryClass) {
+function overviewOptions(projectName: string, targetKey: string, queryClass: QueryClass, runId?: string) {
   return getApiV1ProjectsByNameMeasurementOverviewOptions({
     client: heyClient,
     path: { name: projectName },
-    query: { scope: 'property', targetKey, queryClass },
+    query: { scope: 'property', targetKey, queryClass, ...(runId ? { runId } : {}) },
   })
 }
 
@@ -308,19 +315,20 @@ function PropertyProvenance({
  * which would read as missing data, name the market(s) where the comparison
  * actually exists and point at the overview that reports them.
  *
- * The market names are TEXT, not controls. There is no market-scoped route: the
- * overview picks its group from local state (`AdvancedMeasurementOverview`), so
- * every per-market button would have carried the reader to the same unscoped
- * URL and silently dropped the market they chose. One link with one destination
- * is honest; N buttons offering a choice the app cannot act on is not. Making
- * the market selectable from a URL is a routing change, not a label change.
+ * Group scope is URL-backed, so every member can now be a direct link to the
+ * exact market that holds its comparison rather than a label that asks readers
+ * to re-select it after navigation.
  */
 function MarketLink({
   project,
   groups,
+  queryClass,
+  measurementRunId,
 }: {
   project: string
   groups: readonly { stableKey: string; label: string; competitors: readonly unknown[] }[]
+  queryClass: QueryClass
+  measurementRunId: string | undefined
 }) {
   if (groups.length === 0) return null
   return (
@@ -334,13 +342,36 @@ function MarketLink({
           </h2>
         </div>
         <Button asChild type="button" size="sm" variant="outline">
-          <Link to="/projects/$projectName" params={{ projectName: project }}>Open measurement overview</Link>
+          <Link
+            to="/projects/$projectName"
+            params={{ projectName: project }}
+            search={(previous: Record<string, unknown>) => ({
+              ...previous,
+              ...measurementViewSearch({ scope: 'all', queryClass }),
+              measurementRunId,
+              runId: undefined,
+            })}
+          >
+            Open measurement overview
+          </Link>
         </Button>
       </div>
       <ul className="flex flex-wrap gap-2">
         {groups.map(group => (
           <li key={group.stableKey} className="rounded-md border border-default px-3 py-1.5 text-sm text-strong">
-            {group.label}
+            <Link
+              to="/projects/$projectName"
+              params={{ projectName: project }}
+              search={(previous: Record<string, unknown>) => ({
+                ...previous,
+                ...measurementViewSearch({ scope: 'group', groupKey: group.stableKey, queryClass }),
+                measurementRunId,
+                runId: undefined,
+              })}
+              className="rounded-sm font-medium text-link outline-none hover:underline focus-visible:ring-2 focus-visible:ring-mono-400"
+            >
+              {group.label}
+            </Link>
             <span className="ml-2 text-xs text-muted">
               {group.competitors.length} {group.competitors.length === 1 ? 'competitor' : 'competitors'}
             </span>
@@ -617,12 +648,23 @@ function competitorQueriesTooltipText(row: {
  * would also lose the `basis` — the count of answers this Property actually
  * missed, without which the occurrence numbers have no denominator.
  */
-function NamedInstead({ project, targetKey, queryClass }: { project: string; targetKey: string; queryClass: QueryClass }) {
+function NamedInstead({
+  project,
+  targetKey,
+  queryClass,
+  runId,
+}: {
+  project: string
+  targetKey: string
+  queryClass: QueryClass
+  /** This comparison is only meaningful for the displayed Property result. */
+  runId: string
+}) {
   const query = useQuery({
     ...getApiV1ProjectsByNameMeasurementPropertyCompetitorsOptions({
       client: heyClient,
       path: { name: project },
-      query: { targetKey, queryClass },
+      query: { targetKey, queryClass, runId },
     }),
   })
 
@@ -748,7 +790,13 @@ function PropertyUrls({ urls }: { urls: readonly string[] }) {
 
 export function MeasurementPropertyPage() {
   const { projectName, targetKey } = useParams({ strict: false }) as { projectName?: string; targetKey?: string }
-  const [queryClass, setQueryClass] = useState<QueryClass>('non-brand')
+  const navigate = useNavigate()
+  const propertySearch = useSearch({ strict: false }) as { scope?: string; class?: string; measurementRunId?: string }
+  const queryClass = parseMeasurementPropertyViewSearch(propertySearch).queryClass
+  const incomingMeasurementView = parseMeasurementViewSearch(propertySearch)
+  const requestedMeasurementRunId = typeof propertySearch.measurementRunId === 'string' && propertySearch.measurementRunId.length > 0
+    ? propertySearch.measurementRunId
+    : undefined
   const [expandedAnswers, setExpandedAnswers] = useState<ReadonlySet<string>>(new Set<string>())
   const project = projectName ?? ''
   const property = targetKey ?? ''
@@ -759,8 +807,19 @@ export function MeasurementPropertyPage() {
     ...getApiV1ProjectsByNameMeasurementPlanOptions({ client: heyClient, path: { name: project } }),
     enabled,
   })
-  const brandedQuery = useQuery({ ...overviewOptions(project, property, 'branded'), enabled })
-  const nonBrandQuery = useQuery({ ...overviewOptions(project, property, 'non-brand'), enabled })
+  const activePlan = planQuery.data?.active ?? null
+  // The backend owns validation: it admits the active revision and its
+  // comparable predecessor chain. Global `runId` remains exclusively drawer
+  // state and is intentionally ignored by this route.
+  const measurementReadsEnabled = enabled
+  const brandedQuery = useQuery({
+    ...overviewOptions(project, property, 'branded', requestedMeasurementRunId),
+    enabled: measurementReadsEnabled,
+  })
+  const nonBrandQuery = useQuery({
+    ...overviewOptions(project, property, 'non-brand', requestedMeasurementRunId),
+    enabled: measurementReadsEnabled,
+  })
 
   const brandedRow = propertyRowOf(brandedQuery.data)
   const nonBrandRow = propertyRowOf(nonBrandQuery.data)
@@ -803,7 +862,6 @@ export function MeasurementPropertyPage() {
     ),
   })
 
-  const activePlan = planQuery.data?.active ?? null
   const planV2 = activePlan?.plan.schemaVersion === 2 ? activePlan.plan as PlanV2 : null
   const legacyPlan = activePlan !== null && planV2 === null
   const target = planV2?.targets.find(candidate => candidate.stableKey === property) ?? null
@@ -855,6 +913,14 @@ export function MeasurementPropertyPage() {
     <Link
       to="/projects/$projectName"
       params={{ projectName: project }}
+      search={(previous: Record<string, unknown>) => ({
+        ...previous,
+        ...measurementViewSearch(incomingMeasurementView.scope === 'group'
+          ? { scope: 'group', groupKey: incomingMeasurementView.groupKey, queryClass }
+          : { scope: 'all', queryClass }),
+        measurementRunId: displayedRunId,
+        runId: undefined,
+      })}
       className="inline-flex items-center gap-1 text-xs text-muted hover:text-strong"
     >
       <ArrowLeft className="size-3.5" aria-hidden="true" />
@@ -976,7 +1042,16 @@ export function MeasurementPropertyPage() {
               : 'This Property needs a new measurement before coverage and source evidence are available.'}
           </p>
           <Button asChild type="button" className="h-11 px-4 text-sm md:h-11">
-            <Link to="/projects/$projectName" params={{ projectName: project }}>
+            <Link
+              to="/projects/$projectName"
+              params={{ projectName: project }}
+              search={(previous: Record<string, unknown>) => ({
+                ...previous,
+                ...measurementViewSearch({ scope: 'all', queryClass }),
+                measurementRunId: displayedRunId,
+                runId: undefined,
+              })}
+            >
               {canWrite ? 'Go to measurement overview' : 'View measurement overview'}
             </Link>
           </Button>
@@ -989,7 +1064,17 @@ export function MeasurementPropertyPage() {
           <select
             id="property-query-class"
             value={queryClass}
-            onChange={event => setQueryClass(event.target.value === 'branded' ? 'branded' : 'non-brand')}
+            onChange={event => {
+              const nextQueryClass = event.target.value === 'branded' ? 'branded' : 'non-brand'
+              void navigate({
+                to: '.',
+                search: (previous: Record<string, unknown>) => ({
+                  ...previous,
+                  ...measurementPropertyViewSearch({ queryClass: nextQueryClass }),
+                }),
+                replace: false,
+              })
+            }}
             className="h-11 rounded-md border border-default bg-surface px-3 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-mono-400"
           >
             <option value="non-brand">{CLASS_LABELS['non-brand'].technical}</option>
@@ -1006,10 +1091,19 @@ export function MeasurementPropertyPage() {
       <ProviderBreakdown row={selectedRow} queryClass={queryClass} isError={selectedClassUnavailable} />
       {/* Directly under coverage, because it is what coverage raises and cannot
           answer. The evidence table below is the receipts; this is the finding. */}
-      <NamedInstead project={project} targetKey={property} queryClass={queryClass} />
+      {displayedRunId ? (
+        <MeasurementChangesRail
+          project={project}
+          scope="property"
+          targetKey={property}
+          queryClass={queryClass}
+          runId={displayedRunId}
+        />
+      ) : null}
+      {displayedRunId ? <NamedInstead project={project} targetKey={property} queryClass={queryClass} runId={displayedRunId} /> : null}
       <AssignedQuestions questions={questions} queryClass={queryClass} />
       <PropertyUrls urls={urls} />
-      <MarketLink project={project} groups={memberGroups} />
+      <MarketLink project={project} groups={memberGroups} queryClass={queryClass} measurementRunId={displayedRunId} />
 
       <section aria-labelledby="property-evidence" className="page-section-divider">
         <div className="section-head section-head-inline">

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -3,7 +3,13 @@ import { ChevronDown, RefreshCw, Trash2 } from 'lucide-react'
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 
-import { DEFAULT_MEASUREMENT_VIEW, measurementViewSearch, parseMeasurementViewSearch, shouldResetMeasurementView } from '../lib/measurement-view-url.js'
+import {
+  DEFAULT_MEASUREMENT_VIEW,
+  measurementPropertyViewSearch,
+  measurementViewSearch,
+  parseMeasurementViewSearch,
+  shouldResetMeasurementView,
+} from '../lib/measurement-view-url.js'
 import { useQueryClient } from '@tanstack/react-query'
 import { RunKinds, RunStatuses } from '@ainyc/canonry-contracts'
 import type { MeasurementOverviewSort } from '@ainyc/canonry-contracts'
@@ -29,6 +35,7 @@ import { VisibilityTrendSection } from '../components/project/VisibilityTrendSec
 import { DiscoverySection } from '../components/project/DiscoverySection.js'
 import { SiteHealthSection } from '../components/project/SiteHealthSection.js'
 import { ProjectHistorySection } from '../components/project/ProjectHistorySection.js'
+import { MeasurementChangesRail } from '../components/project/MeasurementChangesRail.js'
 import { ConversionIntegrityWorkspace } from '../components/project/ConversionIntegrityWorkspace.js'
 import { GoogleAdsPerformanceSection } from '../components/project/GoogleAdsPerformanceSection.js'
 import { AdvancedMeasurementSection } from '../components/project/advanced-measurement/AdvancedMeasurementSection.js'
@@ -86,6 +93,7 @@ import {
   getApiV1ProjectsByNameGoogleConnectionsOptions,
   getApiV1ProjectsByNameMeasurementOverviewInfiniteOptions,
   getApiV1ProjectsByNameMeasurementPlanOptions,
+  getApiV1ProjectsByNameMeasurementPropertyEvidenceInfiniteOptions,
   getApiV1ProjectsByNameMeasurementPortfolioSummaryOptions,
   getApiV1ProjectsByNameMeasurementReportOptions,
   getApiV1ProjectsByNameMeasurementSetupOptions,
@@ -1571,6 +1579,7 @@ function ProjectPageContent({
   const projectSearchParams = useSearch({ strict: false }) as {
     manageQueries?: boolean
     queries?: 'tracked' | 'discover' | 'test'
+    measurementRunId?: string
     runId?: string
     siteHealthRunId?: string
     schedule?: 'edit'
@@ -1605,6 +1614,13 @@ function ProjectPageContent({
   // every navigation IS the interaction. `search` stays local: it changes on
   // every keystroke and belongs in neither the URL nor the history stack.
   const urlMeasurementView = parseMeasurementViewSearch(projectSearchParams)
+  // `runId` is global drawer state. Measurement snapshot context is explicit
+  // and server-authoritative: active reads accept the active revision or its
+  // comparable predecessor chain, while historical revision reports stay exact.
+  const requestedMeasurementRunId = typeof projectSearchParams.measurementRunId === 'string'
+    && projectSearchParams.measurementRunId.length > 0
+    ? projectSearchParams.measurementRunId
+    : undefined
   const [advancedMeasurementSearch, setAdvancedMeasurementSearch] = useState<string | undefined>(undefined)
   // Sort is a within-view refinement, not what the page is ABOUT, so it stays
   // in component state rather than the URL alongside scope and class.
@@ -1628,7 +1644,7 @@ function ProjectPageContent({
       replace: false,
     })
   }, [navigate])
-  const [hasExpandedAdvancedProperty, setHasExpandedAdvancedProperty] = useState(false)
+  const [expandedAdvancedPropertyKey, setExpandedAdvancedPropertyKey] = useState<string | undefined>(undefined)
 
   const visibilityEvidence = model?.visibilityEvidence ?? []
   const projectName = model?.project.name ?? ''
@@ -1699,7 +1715,6 @@ function ProjectPageContent({
         ? 'No upcoming AI sweep is scheduled'
         : 'AI sweep schedule is paused'
   const activeMeasurementPlan = activeMeasurementPlanQuery.data?.active ?? null
-
   // A bookmark outlives the group it names. Once the plan has actually loaded
   // and we can see which groups exist, a URL naming one that does not is
   // resolved to all-properties BEFORE any request goes out — otherwise the page
@@ -1740,7 +1755,7 @@ function ProjectPageContent({
     if (measurementPlanIdentity !== null) lastMeasurementPlanIdentity.current = measurementPlanIdentity
     if (!shouldResetMeasurementView(previous, measurementPlanIdentity)) return
     setAdvancedMeasurementView(DEFAULT_MEASUREMENT_VIEW)
-    setHasExpandedAdvancedProperty(false)
+    setExpandedAdvancedPropertyKey(undefined)
   }, [measurementPlanIdentity, setAdvancedMeasurementView])
   const advancedMeasurementOverviewQueryInput = {
     client: heyClient,
@@ -1751,6 +1766,7 @@ function ProjectPageContent({
       queryClass: advancedMeasurementView.queryClass,
       ...(advancedMeasurementView.search ? { search: advancedMeasurementView.search } : {}),
       ...(advancedMeasurementSort ? { sort: advancedMeasurementSort } : {}),
+      ...(requestedMeasurementRunId ? { runId: requestedMeasurementRunId } : {}),
       limit: 50,
     },
   } as const
@@ -1777,6 +1793,10 @@ function ProjectPageContent({
     refetchOnMount: 'always',
   })
   const advancedMeasurementDisplayedRunId = advancedMeasurementOverviewQuery.data?.pages[0]?.measurement.displayedRunId
+  // `keepPreviousData` intentionally retains the prior Property rows during a
+  // run transition. Its comparison rail is a separate claim, though, so keep
+  // it off screen until the overview has resolved the requested valid pin.
+  const isAdvancedMeasurementOverviewRunTransition = advancedMeasurementOverviewQuery.isPlaceholderData
   const advancedMeasurementReportQuery = useQuery({
     ...getApiV1ProjectsByNameMeasurementReportOptions({
       client: heyClient,
@@ -1791,11 +1811,57 @@ function ProjectPageContent({
     enabled: tab === 'overview'
       && Boolean(projectName)
       && activeMeasurementPlan !== null
-      && (activeMeasurementPlanSchemaVersion === 1
-        || hasExpandedAdvancedProperty && advancedMeasurementDisplayedRunId !== undefined),
+      && activeMeasurementPlanSchemaVersion === 1,
     staleTime: 0,
     refetchOnMount: 'always',
   })
+  const advancedMeasurementPropertyEvidenceQueryInput = {
+    client: heyClient,
+    path: { name: projectName },
+    query: {
+      targetKey: expandedAdvancedPropertyKey ?? '',
+      queryClass: advancedMeasurementView.queryClass,
+      ...(advancedMeasurementDisplayedRunId ? { runId: advancedMeasurementDisplayedRunId } : {}),
+      limit: 100,
+    },
+  } as const
+  const advancedMeasurementPropertyEvidenceQuery = useInfiniteQuery({
+    ...getApiV1ProjectsByNameMeasurementPropertyEvidenceInfiniteOptions(advancedMeasurementPropertyEvidenceQueryInput),
+    enabled: tab === 'overview'
+      && Boolean(projectName)
+      && activeMeasurementPlanSchemaVersion === 2
+      && expandedAdvancedPropertyKey !== undefined
+      && advancedMeasurementDisplayedRunId !== undefined,
+    initialPageParam: advancedMeasurementPropertyEvidenceQueryInput,
+    getNextPageParam: (lastPage, pages) => {
+      const nextCursor = lastPage.evidence?.nextCursor
+      if (!nextCursor) return undefined
+      const displayedRunId = pages[0]?.measurement.displayedRunId
+      return {
+        path: advancedMeasurementPropertyEvidenceQueryInput.path,
+        query: {
+          ...advancedMeasurementPropertyEvidenceQueryInput.query,
+          cursor: nextCursor,
+          ...(displayedRunId ? { runId: displayedRunId } : {}),
+        },
+      }
+    },
+    staleTime: 0,
+    refetchOnMount: 'always',
+  })
+  const advancedMeasurementPropertyEvidence = useMemo(() => {
+    const pages = advancedMeasurementPropertyEvidenceQuery.data?.pages
+    const first = pages?.[0]
+    const last = pages?.at(-1)
+    if (!first?.evidence || !last?.evidence) return undefined
+    return {
+      targetKey: first.property.targetKey,
+      displayedRunId: first.measurement.displayedRunId,
+      items: pages.flatMap(page => page.evidence?.items ?? []),
+      totalEstimate: first.evidence.totalEstimate,
+      hasMore: last.evidence.nextCursor !== null,
+    }
+  }, [advancedMeasurementPropertyEvidenceQuery.data])
   const hasCachedMeasurementPlan = activeMeasurementPlanQuery.data !== undefined
   const hasCachedPortfolioQueries = portfolioQueriesQuery.data !== undefined
   const isActiveMeasurementPlanLoading = activeMeasurementPlanQuery.isPending && !hasCachedMeasurementPlan
@@ -1885,23 +1951,26 @@ function ProjectPageContent({
           overview: mergedAdvancedMeasurementOverview,
           activePlan: activeMeasurementPlan,
           sort: advancedMeasurementSort,
-          report: advancedMeasurementReportQuery.data,
-          reportState: mergedAdvancedMeasurementOverview.measurement.displayedRunId === undefined
+          propertyEvidence: advancedMeasurementPropertyEvidence,
+          propertyEvidenceTargetKey: expandedAdvancedPropertyKey,
+          propertyEvidenceState: mergedAdvancedMeasurementOverview.measurement.displayedRunId === undefined
             ? 'ready'
-            : advancedMeasurementReportQuery.isFetching && advancedMeasurementReportQuery.data === undefined
+            : advancedMeasurementPropertyEvidenceQuery.isFetching && advancedMeasurementPropertyEvidenceQuery.data === undefined
             ? 'loading'
-            : advancedMeasurementReportQuery.isError && advancedMeasurementReportQuery.data === undefined
+            : advancedMeasurementPropertyEvidenceQuery.isError && advancedMeasurementPropertyEvidenceQuery.data === undefined
             ? 'error'
-            : advancedMeasurementReportQuery.data
+            : advancedMeasurementPropertyEvidenceQuery.data
               ? 'ready'
               : 'loading',
         })
       : undefined
   }, [
     activeMeasurementPlan,
-    advancedMeasurementReportQuery.data,
-    advancedMeasurementReportQuery.isError,
-    advancedMeasurementReportQuery.isFetching,
+    advancedMeasurementPropertyEvidence,
+    advancedMeasurementPropertyEvidenceQuery.data,
+    advancedMeasurementPropertyEvidenceQuery.isError,
+    advancedMeasurementPropertyEvidenceQuery.isFetching,
+    expandedAdvancedPropertyKey,
     mergedAdvancedMeasurementOverview,
   ])
   const advancedMeasurementReportState = activeMeasurementPlanSchemaVersion === 2
@@ -2557,6 +2626,19 @@ function ProjectPageContent({
                 analyticsRevision={latestVisibilityRevision}
               />
             ) : undefined}
+            changesRail={activeMeasurementPlanSchemaVersion === 2
+              && advancedMeasurementView.scope === 'group'
+              && advancedMeasurementView.groupKey
+              && !isAdvancedMeasurementOverviewRunTransition
+              && advancedMeasurementDisplayedRunId ? (
+                <MeasurementChangesRail
+                  project={projectName}
+                  scope="group"
+                  groupKey={advancedMeasurementView.groupKey}
+                  queryClass={advancedMeasurementView.queryClass}
+                  runId={advancedMeasurementDisplayedRunId}
+                />
+              ) : undefined}
             renderGroupLink={activeMeasurementPlanSchemaVersion === 2 && !isEmbed()
               ? ({ id, name }) => (
                   <Link
@@ -2569,6 +2651,10 @@ function ProjectPageContent({
                         groupKey: id,
                         queryClass: advancedMeasurementView.queryClass,
                       }),
+                      // Snapshot continuity is measurement-only context. Never
+                      // reuse the global drawer's `runId` namespace here.
+                      measurementRunId: advancedMeasurementDisplayedRunId,
+                      runId: undefined,
                     })}
                     className="rounded-sm font-medium text-link outline-none hover:underline focus-visible:ring-2 focus-visible:ring-mono-400"
                   >
@@ -2584,6 +2670,8 @@ function ProjectPageContent({
                     search={(previous: Record<string, unknown>) => ({
                       ...previous,
                       ...measurementViewSearch({ scope: 'all', queryClass: advancedMeasurementView.queryClass }),
+                      measurementRunId: advancedMeasurementDisplayedRunId,
+                      runId: undefined,
                     })}
                     className="rounded-sm text-link outline-none hover:underline focus-visible:ring-2 focus-visible:ring-mono-400"
                   >
@@ -2598,7 +2686,7 @@ function ProjectPageContent({
               if (activeMeasurementPlanSchemaVersion === 2) {
                 void Promise.all([
                   advancedMeasurementOverviewQuery.refetch(),
-                  advancedMeasurementReportQuery.refetch(),
+                  advancedMeasurementPropertyEvidenceQuery.refetch(),
                   advancedMeasurementPortfolioSummaryQuery.refetch(),
                 ])
               }
@@ -2617,18 +2705,33 @@ function ProjectPageContent({
                 void advancedMeasurementOverviewQuery.fetchNextPage()
               }
             }}
-            onPropertyExpand={() => {
-              if (hasExpandedAdvancedProperty && advancedMeasurementReportQuery.isError) {
-                void advancedMeasurementReportQuery.refetch()
+            onPropertyExpand={(propertyId) => {
+              if (propertyId === expandedAdvancedPropertyKey && advancedMeasurementPropertyEvidenceQuery.isError) {
+                void advancedMeasurementPropertyEvidenceQuery.refetch()
               }
-              setHasExpandedAdvancedProperty(true)
+              setExpandedAdvancedPropertyKey(propertyId)
             }}
-            onRetryEvidence={() => { void advancedMeasurementReportQuery.refetch() }}
+            onRetryEvidence={() => { void advancedMeasurementPropertyEvidenceQuery.refetch() }}
+            onLoadMoreEvidence={() => { void advancedMeasurementPropertyEvidenceQuery.fetchNextPage() }}
             renderPropertyLink={activeMeasurementPlanSchemaVersion === 2 && !isEmbed()
               ? ({ id, name }) => (
                   <Link
                     to="/projects/$projectName/properties/$targetKey"
                     params={{ projectName, targetKey: id }}
+                    search={(previous: Record<string, unknown>) => {
+                      const propertyQueryClass = advancedMeasurementView.queryClass === 'branded' ? 'branded' : 'non-brand'
+                      return {
+                        ...previous,
+                        ...measurementViewSearch({
+                          scope: advancedMeasurementView.scope,
+                          ...(advancedMeasurementView.groupKey ? { groupKey: advancedMeasurementView.groupKey } : {}),
+                          queryClass: propertyQueryClass,
+                        }),
+                        ...measurementPropertyViewSearch({ queryClass: propertyQueryClass }),
+                        measurementRunId: advancedMeasurementDisplayedRunId,
+                        runId: undefined,
+                      }
+                    }}
                     className="text-link hover:underline"
                   >
                     {name}

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -70,6 +70,8 @@ type SearchParams = {
   manageQueries?: boolean
   /** The stable, URL-backed surface within the project Queries workspace. */
   queries?: 'tracked' | 'discover' | 'test'
+  /** Measurement snapshot context. Deliberately separate from the global run drawer. */
+  measurementRunId?: string
   runId?: string
   /** Exact Site Health onboarding handoff; separate from the global run drawer. */
   siteHealthRunId?: string
@@ -113,6 +115,7 @@ export const rootRoute = createRootRouteWithContext<RouterContext>()({
     queries: search.queries === 'tracked' || search.queries === 'discover' || search.queries === 'test'
       ? search.queries
       : undefined,
+    measurementRunId: typeof search.measurementRunId === 'string' ? search.measurementRunId : undefined,
     runId: typeof search.runId === 'string' ? search.runId : undefined,
     siteHealthRunId: typeof search.siteHealthRunId === 'string' ? search.siteHealthRunId : undefined,
     schedule: search.schedule === 'edit' ? 'edit' : undefined,

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -1098,6 +1098,38 @@ describe('outcome count row', () => {
     expect(screen.getAllByLabelText('Property outcomes')).toHaveLength(1)
   })
 
+  it('places a supplied continuity rail after the pulse and hides it while a Property search is active', () => {
+    const continuityRail = (
+      <section aria-label="Continuity rail">
+        <h2>Since previous comparable sweep</h2>
+      </section>
+    )
+    const { unmount } = renderOverviewReturning({
+      report: withOutcomes({
+        bothSignals: 1, mentionedOnly: 1, citedOnly: 1, neither: 1, notMeasured: 1, total: 5,
+      }),
+      portfolioSummaryState: 'ready',
+      portfolioSummary: portfolioSummary(),
+      changesRail: continuityRail,
+    })
+
+    const pulse = screen.getByRole('heading', { name: 'Portfolio pulse' })
+    const rail = screen.getByRole('region', { name: 'Continuity rail' })
+    expect(Boolean(pulse.compareDocumentPosition(rail) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
+    expect(screen.getAllByLabelText('Property outcomes')).toHaveLength(1)
+    unmount()
+
+    renderOverview({
+      report: withOutcomes({
+        bothSignals: 1, mentionedOnly: 1, citedOnly: 1, neither: 1, notMeasured: 1, total: 5,
+      }),
+      viewSearch: 'harbor',
+      changesRail: continuityRail,
+    })
+    expect(screen.queryByRole('region', { name: 'Continuity rail' })).toBeNull()
+    expect(screen.getAllByLabelText('Property outcomes')).toHaveLength(1)
+  })
+
   it('does not flash the cached Pulse while a cleared search is still applied by the parent', () => {
     renderOverview({
       report: withOutcomes({

--- a/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
+++ b/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type {
   MeasurementOverviewResponse,
   MeasurementPlanResponse,
-  MeasurementReportResponse,
 } from '@ainyc/canonry-api-client'
 
 import { AdvancedMeasurementOverview } from '../src/components/project/advanced-measurement/AdvancedMeasurementOverview.js'
@@ -205,7 +204,7 @@ describe('version-two measurement overview adapter', () => {
     }
   })
 
-  it('indexes evidence once by its assigned Property and translates sibling language', () => {
+  it('uses chain-aware Property evidence for a comparable predecessor run', () => {
     const { activePlan, overview } = fixture(2)
     if (activePlan.plan.schemaVersion !== 2) throw new Error('Expected a version-two fixture.')
     activePlan.plan.assignments.push({
@@ -214,23 +213,26 @@ describe('version-two measurement overview adapter', () => {
     })
     activePlan.plan.targets[0]!.urlMatchers.push({ kind: 'host', host: 'homes.northstar.example' })
     overview.properties = { items: overview.properties.items.slice(0, 2), nextCursor: null, totalEstimate: 2 }
-    const evidenceReport = {
-      revision: 2,
-      run: null,
-      groups: [],
-      targets: [],
-      diagnostics: {
-        bridgedObservationIds: [], historicalObservationIds: [], evidenceIncompleteObservationIds: [], ambiguousObservationIds: [], unmatchedObservationIds: [],
-      },
-      evidence: [{
+    overview.measurement.displayedRunId = 'run-v1-comparable'
+    const propertyEvidence = {
+      targetKey: 'property-1',
+      displayedRunId: 'run-v1-comparable',
+      items: [{
         observationId: 'observation-1', expectedSlotId: 'slot-1', executionId: 'execution-nearby',
         usageEdgeId: 'target:property-1:query-nearby:execution-nearby', usageEdgeType: 'target', provider: 'openai',
         queryText: 'apartments near downtown', location: null, sourceUrl: 'https://northstar.example/properties/2',
         bridged: false, historical: false, evidenceComplete: true, classification: 'sibling',
         normalizedUrl: 'https://northstar.example/properties/2', matchedTargetIds: ['property-2'], matchedUrlIds: ['property-2:url:0'],
       }],
-    } as MeasurementReportResponse
-    const report = adaptV2MeasurementOverview({ overview, activePlan, report: evidenceReport })
+      totalEstimate: 1,
+      hasMore: false,
+    } as const
+    const report = adaptV2MeasurementOverview({
+      overview,
+      activePlan,
+      propertyEvidence,
+      propertyEvidenceTargetKey: 'property-1',
+    })
 
     expect(report.currentView?.aggregate.properties[0]?.evidence).toHaveLength(1)
     expect(report.currentView?.aggregate.properties[0]?.evidence[0]?.kind).toBe('another-property')
@@ -251,7 +253,7 @@ describe('version-two measurement overview adapter', () => {
     const report = adaptV2MeasurementOverview({
       overview,
       activePlan,
-      reportState: 'loading',
+      propertyEvidenceState: 'loading',
     })
     render(<AdvancedMeasurementOverview report={report} canEdit />)
 
@@ -287,19 +289,29 @@ describe('version-two measurement overview adapter', () => {
     expect(onLoadMore).toHaveBeenCalledWith('page-2')
   })
 
-  it('shows an honest evidence error when the deep report fails or belongs to another run', () => {
+  it('shows an honest evidence error when the Property evidence read fails or belongs to another snapshot or Property', () => {
     const { activePlan, overview } = fixture(1)
     overview.properties = { items: overview.properties.items.slice(0, 1), nextCursor: null, totalEstimate: 1 }
     overview.measurement.displayedRunId = 'run-a'
     const onRetryEvidence = vi.fn()
 
-    const loading = adaptV2MeasurementOverview({ overview, activePlan, reportState: 'loading' })
+    const loading = adaptV2MeasurementOverview({
+      overview,
+      activePlan,
+      propertyEvidenceTargetKey: 'property-1',
+      propertyEvidenceState: 'loading',
+    })
     render(<AdvancedMeasurementOverview report={loading} canEdit />)
     fireEvent.click(screen.getByRole('button', { name: 'Show details for Property 1' }))
     expect(screen.getByText('Loading evidence…')).toBeTruthy()
     cleanup()
 
-    const failed = adaptV2MeasurementOverview({ overview, activePlan, reportState: 'error' })
+    const failed = adaptV2MeasurementOverview({
+      overview,
+      activePlan,
+      propertyEvidenceTargetKey: 'property-1',
+      propertyEvidenceState: 'error',
+    })
     render(<AdvancedMeasurementOverview report={failed} canEdit onRetryEvidence={onRetryEvidence} />)
     fireEvent.click(screen.getByRole('button', { name: 'Show details for Property 1' }))
     expect(screen.getByText('Evidence could not be loaded.')).toBeTruthy()
@@ -310,9 +322,31 @@ describe('version-two measurement overview adapter', () => {
     const mismatched = adaptV2MeasurementOverview({
       overview,
       activePlan,
-      report: { ...({} as MeasurementReportResponse), revision: 2, run: { id: 'run-b' } } as MeasurementReportResponse,
+      propertyEvidence: {
+        targetKey: 'property-1',
+        displayedRunId: 'run-b',
+        items: [],
+        hasMore: false,
+      },
+      propertyEvidenceTargetKey: 'property-1',
     })
     render(<AdvancedMeasurementOverview report={mismatched} canEdit />)
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Property 1' }))
+    expect(screen.getByText('Evidence could not be loaded.')).toBeTruthy()
+    cleanup()
+
+    const wrongProperty = adaptV2MeasurementOverview({
+      overview,
+      activePlan,
+      propertyEvidence: {
+        targetKey: 'property-2',
+        displayedRunId: 'run-a',
+        items: [],
+        hasMore: false,
+      },
+      propertyEvidenceTargetKey: 'property-1',
+    })
+    render(<AdvancedMeasurementOverview report={wrongProperty} canEdit />)
     fireEvent.click(screen.getByRole('button', { name: 'Show details for Property 1' }))
     expect(screen.getByText('Evidence could not be loaded.')).toBeTruthy()
   })

--- a/apps/web/test/measurement-changes-rail.test.tsx
+++ b/apps/web/test/measurement-changes-rail.test.tsx
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { MeasurementChangesResponse } from '@ainyc/canonry-api-client'
+
+import { MeasurementChangesRail } from '../src/components/project/MeasurementChangesRail.js'
+import { jsonResponse, mockFetch, pathOf } from './mock-fetch.js'
+
+let restoreFetch: (() => void) | undefined
+
+afterEach(() => {
+  cleanup()
+  restoreFetch?.()
+  restoreFetch = undefined
+})
+
+function availableMetric(delta: number) {
+  return {
+    state: 'available' as const,
+    previous: { state: 'available' as const, value: 0.5 },
+    current: { state: 'available' as const, value: 0.5 + delta },
+    delta,
+  }
+}
+
+function availableChanges(): MeasurementChangesResponse {
+  return {
+    current: {
+      state: 'complete',
+      displayedRunId: 'run-current',
+      planRevision: 4,
+      completedAt: '2026-08-28T12:00:00.000Z',
+      executionIdentity: 'openai:model-a',
+      measurementScope: 'full',
+    },
+    comparison: {
+      state: 'available',
+      previous: {
+        displayedRunId: 'run-previous',
+        planRevision: 4,
+        completedAt: '2026-08-27T12:00:00.000Z',
+        executionIdentity: 'openai:model-a',
+        measurementScope: 'full',
+      },
+      metrics: {
+        propertiesMentioned: availableMetric(0.25),
+        mentionCoverage: availableMetric(0.125),
+        citationCoverage: availableMetric(-0.05),
+      },
+      changedProperties: [],
+      totalProperties: 8,
+      truncated: false,
+    },
+  }
+}
+
+function unavailableChanges(reason: 'no_previous_run' | 'incomplete' | 'execution_identity_changed' | 'not_comparable'): MeasurementChangesResponse {
+  return {
+    current: {
+      state: 'complete',
+      displayedRunId: 'run-current',
+      planRevision: 4,
+      completedAt: '2026-08-28T12:00:00.000Z',
+      executionIdentity: 'openai:model-a',
+      measurementScope: 'full',
+    },
+    comparison: { state: 'unavailable', reason },
+  }
+}
+
+function renderRail(
+  props: {
+    scope?: 'group' | 'property'
+    runId?: string
+  } = {},
+  handler: (url: string) => Response | Promise<Response> = () => jsonResponse(availableChanges()),
+) {
+  restoreFetch = mockFetch(url => handler(url))
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const shared = {
+    project: 'demo',
+    queryClass: 'non-brand' as const,
+    runId: props.runId ?? 'run-current',
+  }
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {props.scope === 'property' ? (
+        <MeasurementChangesRail {...shared} scope="property" targetKey="property-a" />
+      ) : (
+        <MeasurementChangesRail {...shared} scope="group" groupKey="group-a" />
+      )}
+    </QueryClientProvider>,
+  )
+}
+
+describe('MeasurementChangesRail', () => {
+  it('renders separate signed mention and citation percentage-point deltas for a Group', async () => {
+    const requested: string[] = []
+    renderRail({}, url => {
+      requested.push(url)
+      return jsonResponse(availableChanges())
+    })
+
+    await screen.findByText('+12.5 pp')
+    const rail = screen.getByRole('region', { name: 'Since previous comparable sweep' })
+    expect(within(rail).getByText('Mention')).toBeTruthy()
+    expect(within(rail).getByText('+12.5 pp')).toBeTruthy()
+    expect(within(rail).getByText('Citation')).toBeTruthy()
+    expect(within(rail).getByText('-5 pp')).toBeTruthy()
+    expect(within(rail).getByText('8 properties changed')).toBeTruthy()
+
+    const query = new URL(requested[0]!).searchParams
+    expect(pathOf(requested[0]!)).toContain('/measurement-changes')
+    expect(query.get('scope')).toBe('group')
+    expect(query.get('groupKey')).toBe('group-a')
+    expect(query.get('queryClass')).toBe('non-brand')
+    expect(query.get('runId')).toBe('run-current')
+  })
+
+  it('keeps Property continuity to the two coverage deltas', async () => {
+    renderRail({ scope: 'property' })
+
+    await screen.findByText('+12.5 pp')
+    const rail = screen.getByRole('region', { name: 'Since previous comparable sweep' })
+    expect(within(rail).getByText('+12.5 pp')).toBeTruthy()
+    expect(within(rail).getByText('-5 pp')).toBeTruthy()
+    expect(within(rail).queryByText(/properties changed/)).toBeNull()
+  })
+
+  it.each([
+    ['no_previous_run', 'No comparable sweep yet.'],
+    ['incomplete', 'Latest measurement incomplete.'],
+    ['execution_identity_changed', 'Answer-engine setup changed.'],
+    ['not_comparable', 'Prior sweep differs in scope or setup.'],
+  ] as const)('maps %s without inventing a zero', async (reason, copy) => {
+    renderRail({}, () => jsonResponse(unavailableChanges(reason)))
+
+    await screen.findByText(copy)
+    const rail = screen.getByRole('region', { name: 'Since previous comparable sweep' })
+    expect(within(rail).getByText(copy)).toBeTruthy()
+    expect(within(rail).queryByText(/0(?:\.0)? pp/)).toBeNull()
+  })
+
+  it('marks the local loading section busy', () => {
+    renderRail({}, () => new Promise<Response>(() => {}))
+
+    expect(screen.getByRole('region', { name: 'Since previous comparable sweep' }).getAttribute('aria-busy')).toBe('true')
+  })
+
+  it('renders a local alert and retries after an error', async () => {
+    let attempts = 0
+    renderRail({}, () => {
+      attempts += 1
+      return attempts === 1
+        ? jsonResponse({ message: 'temporary failure' }, 500)
+        : jsonResponse(availableChanges())
+    })
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not load measurement changes.')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await screen.findByText('+12.5 pp')
+    expect(attempts).toBe(2)
+  })
+
+  it('does not retain stale deltas when a new pinned run fails', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    restoreFetch = mockFetch(url => (
+      new URL(url).searchParams.get('runId') === 'run-old'
+        ? jsonResponse(availableChanges())
+        : jsonResponse({ message: 'temporary failure' }, 500)
+    ))
+    const page = render(
+      <QueryClientProvider client={queryClient}>
+        <MeasurementChangesRail
+          project="demo"
+          scope="group"
+          groupKey="group-a"
+          queryClass="non-brand"
+          runId="run-old"
+        />
+      </QueryClientProvider>,
+    )
+
+    await screen.findByText('+12.5 pp')
+    page.rerender(
+      <QueryClientProvider client={queryClient}>
+        <MeasurementChangesRail
+          project="demo"
+          scope="group"
+          groupKey="group-a"
+          queryClass="non-brand"
+          runId="run-new"
+        />
+      </QueryClientProvider>,
+    )
+
+    await screen.findByRole('alert')
+    expect(screen.queryByText('+12.5 pp')).toBeNull()
+    expect(screen.queryByText('-5 pp')).toBeNull()
+  })
+})

--- a/apps/web/test/measurement-property-page.test.tsx
+++ b/apps/web/test/measurement-property-page.test.tsx
@@ -1,14 +1,17 @@
 import { afterEach, beforeAll, describe, expect, it, onTestFinished } from 'vitest'
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { RouterProvider } from '@tanstack/react-router'
+import { createMemoryHistory, createRootRoute, createRoute, createRouter, Outlet, RouterProvider } from '@tanstack/react-router'
 
 import { createDashboardFixture } from '../src/mock-data.js'
 import { createAppRouter } from '../src/router/router.js'
+import { AccountProvider } from '../src/contexts/account-context.js'
 import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 import { preloadAllLazyRoutes } from '../src/router/routes.js'
+import { MeasurementPropertyPage } from '../src/pages/MeasurementPropertyPage.js'
 import { heyClient } from '../src/api.js'
 import {
+  getApiV1ProjectsByNameMeasurementChangesQueryKey,
   getApiV1ProjectsByNameMeasurementOverviewQueryKey,
   getApiV1ProjectsByNameMeasurementPlanQueryKey,
   getApiV1ProjectsByNameMeasurementPropertyEvidenceInfiniteQueryKey,
@@ -235,6 +238,39 @@ function evidenceResponse(
   }
 }
 
+function measurementChangesResponse(runId = RUN_ID) {
+  return {
+    current: {
+      state: 'complete' as const,
+      displayedRunId: runId,
+      planRevision: 7,
+      completedAt: '2026-08-02T12:05:00.000Z',
+      executionIdentity: 'openai:search-model',
+      measurementScope: 'full' as const,
+    },
+    comparison: { state: 'unavailable' as const, reason: 'no_previous_run' as const },
+  }
+}
+
+function runDetailResponse(id: string, kind: 'answer-visibility' | 'site-audit') {
+  return {
+    id,
+    projectId: 'project_citypoint',
+    kind,
+    status: 'completed' as const,
+    trigger: 'manual' as const,
+    measurementPlanVersionId: kind === 'answer-visibility' ? 'measurement-plan-v7' : null,
+    measurementScope: null,
+    location: null,
+    queries: null,
+    startedAt: '2026-08-02T12:00:00.000Z',
+    finishedAt: '2026-08-02T12:05:00.000Z',
+    error: null,
+    createdAt: '2026-08-02T12:00:00.000Z',
+    snapshots: [],
+  }
+}
+
 /** The panel's own table, addressed by the caption every test shares. */
 function answersTable() {
   return screen.findByRole('table', { name: 'Answers measured for this Property' })
@@ -257,6 +293,14 @@ async function renderPropertyPage(options: {
   queryClient.setQueryData(
     getApiV1ProjectsByNameMeasurementPlanQueryKey({ client: heyClient, path: { name: projectName } }),
     options.plan ?? planResponse(),
+  )
+  queryClient.setQueryData(
+    getApiV1ProjectsByNameMeasurementChangesQueryKey({
+      client: heyClient,
+      path: { name: projectName },
+      query: { scope: 'property', targetKey: TARGET_KEY, queryClass: 'non-brand', runId: RUN_ID },
+    }),
+    measurementChangesResponse(),
   )
   for (const [queryClass, response] of [['branded', options.branded], ['non-brand', options.nonBrand]] as const) {
     queryClient.setQueryData(
@@ -301,14 +345,19 @@ async function renderPropertyPage(options: {
   )
 }
 
-async function renderPropertyPageFromApi(handler: (url: string) => Response | Promise<Response>) {
+async function renderPropertyPageFromApi(
+  handler: (url: string) => Response | Promise<Response>,
+  initialEntry?: string,
+  seed?: (queryClient: QueryClient, projectName: string) => void,
+) {
   const fixture = createDashboardFixture({})
   const projectName = fixture.dashboard.projects.find(project => project.project.id === 'project_citypoint')!.project.name
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  seed?.(queryClient, projectName)
   const restoreFetch = mockFetch(url => handler(url))
   onTestFinished(restoreFetch)
   const router = createAppRouter(queryClient, {
-    initialEntries: [`/projects/${projectName}/properties/${TARGET_KEY}`],
+    initialEntries: [initialEntry ?? `/projects/${projectName}/properties/${TARGET_KEY}`],
   })
   await router.load()
 
@@ -319,7 +368,36 @@ async function renderPropertyPageFromApi(handler: (url: string) => Response | Pr
       </DashboardProvider>
     </QueryClientProvider>,
   )
-  return { projectName, queryClient }
+  return { projectName, queryClient, router }
+}
+
+/** AuthGate mounts the router without DashboardProvider in production. */
+async function renderPropertyPageWithoutDashboardContext(
+  handler: (url: string) => Response | Promise<Response>,
+  initialEntry: string,
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const restoreFetch = mockFetch(url => handler(url))
+  onTestFinished(restoreFetch)
+  const rootRoute = createRootRoute({ component: Outlet })
+  const propertyRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/projects/$projectName/properties/$targetKey',
+    component: MeasurementPropertyPage,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([propertyRoute]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+  await router.load()
+  render(
+    <AccountProvider account={null}>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router as never} />
+      </QueryClientProvider>
+    </AccountProvider>,
+  )
+  return { queryClient, router }
 }
 
 function propertyPageResponses({
@@ -333,6 +411,10 @@ function propertyPageResponses({
 } = {}) {
   return (url: string) => {
     const path = pathOf(url)
+    if (/\/api\/v1\/projects\/[^/?]+(?:\?.*)?$/.test(path)) {
+      return jsonResponse({ id: 'project_citypoint', name: 'citypoint' })
+    }
+    if (path.endsWith(`/runs/${RUN_ID}`)) return jsonResponse(runDetailResponse(RUN_ID, 'answer-visibility'))
     if (path.endsWith('/measurement-plan')) return jsonResponse(planResponse())
     if (path.includes('/measurement-overview')) {
       return new URL(url).searchParams.get('queryClass') === 'branded'
@@ -340,6 +422,7 @@ function propertyPageResponses({
         : jsonResponse(nonBrand)
     }
     if (path.includes('/measurement-property-evidence')) return jsonResponse(evidence)
+    if (path.includes('/measurement-changes')) return jsonResponse(measurementChangesResponse())
     if (path.includes('/measurement-property-competitors')) {
       return jsonResponse({
         property: { targetKey: TARGET_KEY, label: 'Harbor House' },
@@ -385,6 +468,303 @@ function propertyPageResponses({
 }
 
 describe('Property page', () => {
+  it('forwards a measurement snapshot without DashboardProvider or a run-detail classifier', async () => {
+    const observed: string[] = []
+    const responses = propertyPageResponses()
+
+    await renderPropertyPageWithoutDashboardContext(url => {
+      observed.push(url)
+      return responses(url)
+    }, `/projects/project_citypoint/properties/${TARGET_KEY}?measurementRunId=${RUN_ID}`)
+
+    expect(await screen.findByRole('heading', { name: 'Harbor House' })).toBeTruthy()
+    const overviewRequests = observed.filter(url => pathOf(url).includes('/measurement-overview'))
+    expect(overviewRequests).not.toHaveLength(0)
+    expect(overviewRequests.every(url => new URL(url).searchParams.get('runId') === RUN_ID)).toBe(true)
+    expect(observed.some(url => pathOf(url).endsWith(`/runs/${RUN_ID}`))).toBe(false)
+  })
+
+  it('leaves an invalid measurement snapshot to the server instead of silently unpinning it', async () => {
+    const observed: string[] = []
+    const otherProjectRunId = 'run-other-project'
+    const responses = propertyPageResponses()
+
+    await renderPropertyPageWithoutDashboardContext(url => {
+      observed.push(url)
+      if (pathOf(url).includes('/measurement-overview') && new URL(url).searchParams.get('runId') === otherProjectRunId) {
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Run belongs to another project' }, 422)
+      }
+      return responses(url)
+    }, `/projects/project_citypoint/properties/${TARGET_KEY}?measurementRunId=${otherProjectRunId}`)
+
+    expect(await screen.findByText('Could not load this Property.')).toBeTruthy()
+    const overviewRequests = observed.filter(url => pathOf(url).includes('/measurement-overview'))
+    expect(overviewRequests).not.toHaveLength(0)
+    expect(overviewRequests.every(url => new URL(url).searchParams.get('runId') === otherProjectRunId)).toBe(true)
+    expect(observed.some(url => pathOf(url).endsWith(`/runs/${otherProjectRunId}`))).toBe(false)
+  })
+
+  it('starts pinned Property reads before the active plan resolves and never fetches run detail', async () => {
+    const observed: string[] = []
+    let releasePlan: (() => void) | undefined
+    const planGate = new Promise<void>(resolve => { releasePlan = resolve })
+    const responses = propertyPageResponses()
+
+    await renderPropertyPageFromApi(url => {
+      observed.push(url)
+      const path = pathOf(url)
+      if (path.endsWith('/measurement-plan')) return planGate.then(() => responses(url))
+      return responses(url)
+    }, `/projects/project_citypoint/properties/${TARGET_KEY}?measurementRunId=${RUN_ID}`)
+
+    await waitFor(() => {
+      expect(observed.some(url => pathOf(url).endsWith('/measurement-plan'))).toBe(true)
+      expect(observed.some(url => pathOf(url).includes('/measurement-overview'))).toBe(true)
+    })
+    expect(observed.some(url => pathOf(url).endsWith(`/runs/${RUN_ID}`))).toBe(false)
+    await act(async () => { releasePlan?.() })
+    await waitFor(() => expect(observed.some(url => pathOf(url).includes('/measurement-overview'))).toBe(true))
+    expect(await screen.findByRole('heading', { name: 'Harbor House', hidden: true })).toBeTruthy()
+    const overviewRequests = observed.filter(url => pathOf(url).includes('/measurement-overview'))
+    expect(overviewRequests.every(url => new URL(url).searchParams.get('runId') === RUN_ID)).toBe(true)
+  })
+
+  it('keeps a non-measurement run drawer separate from Property measurement reads', async () => {
+    const observed: string[] = []
+    const drawerRunId = 'run-site-audit'
+    const responses = propertyPageResponses()
+    const { router } = await renderPropertyPageFromApi(url => {
+      observed.push(url)
+      const path = pathOf(url)
+      if (path.endsWith(`/runs/${drawerRunId}`)) return jsonResponse(runDetailResponse(drawerRunId, 'site-audit'))
+      if (path.includes('/measurement-overview') && new URL(url).searchParams.get('runId') === drawerRunId) {
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Not a measurement run' }, 422)
+      }
+      if (path.includes('/measurement-changes') && new URL(url).searchParams.get('runId') === drawerRunId) {
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Not a measurement run' }, 422)
+      }
+      return responses(url)
+    }, `/projects/project_citypoint/properties/${TARGET_KEY}?scope=group:north&class=branded&runId=${drawerRunId}&keep=fixture`)
+
+    expect(await screen.findByRole('heading', { name: 'Harbor House' })).toBeTruthy()
+    await screen.findByRole('region', { name: /Named instead of this Property/ })
+
+    const runSensitiveRequests = observed.filter(url => (
+      /measurement-overview|measurement-property-evidence|measurement-property-competitors|measurement-changes/.test(pathOf(url))
+    ))
+    expect(runSensitiveRequests).not.toHaveLength(0)
+    expect(runSensitiveRequests.every(url => new URL(url).searchParams.get('runId') !== drawerRunId)).toBe(true)
+
+    const back = screen.getByRole('link', { name: 'Back to measurement overview' })
+    const backDestination = new URL(back.getAttribute('href')!, window.location.origin)
+    expect(backDestination.searchParams.get('scope')).toBe('group:north')
+    expect(backDestination.searchParams.get('class')).toBe('branded')
+    expect(backDestination.searchParams.get('measurementRunId')).toBe(RUN_ID)
+    expect(backDestination.searchParams.get('runId')).toBeNull()
+    expect(backDestination.searchParams.get('keep')).toBe('fixture')
+    expect(router.state.location.search.runId).toBe(drawerRunId)
+
+    const market = screen.getByRole('region', { name: /Measured at the market level/ })
+    const overviewDestination = new URL(
+      within(market).getByRole('link', { name: 'Open measurement overview' }).getAttribute('href')!,
+      window.location.origin,
+    )
+    const groupDestination = new URL(
+      within(market).getByRole('link', { name: 'North' }).getAttribute('href')!,
+      window.location.origin,
+    )
+    expect(overviewDestination.searchParams.get('measurementRunId')).toBe(RUN_ID)
+    expect(groupDestination.searchParams.get('measurementRunId')).toBe(RUN_ID)
+    expect(overviewDestination.searchParams.get('runId')).toBeNull()
+    expect(groupDestination.searchParams.get('runId')).toBeNull()
+  })
+
+  it('does not pin Property reads to an answer run from another plan version', async () => {
+    const observed: string[] = []
+    const staleRunId = 'run-prior-plan'
+    const responses = propertyPageResponses()
+
+    await renderPropertyPageFromApi(url => {
+      observed.push(url)
+      const path = pathOf(url)
+      if (path.endsWith(`/runs/${staleRunId}`)) {
+        return jsonResponse({
+          ...runDetailResponse(staleRunId, 'answer-visibility'),
+          measurementPlanVersionId: 'measurement-plan-v6',
+        })
+      }
+      if (path.includes('/measurement-overview') && new URL(url).searchParams.get('runId') === staleRunId) {
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Run belongs to a prior plan' }, 422)
+      }
+      return responses(url)
+    }, `/projects/project_citypoint/properties/${TARGET_KEY}?runId=${staleRunId}`)
+
+    expect(await screen.findByRole('heading', { name: 'Harbor House' })).toBeTruthy()
+    await screen.findByRole('region', { name: /Named instead of this Property/ })
+
+    const runSensitiveRequests = observed.filter(url => (
+      /measurement-overview|measurement-property-evidence|measurement-property-competitors|measurement-changes/.test(pathOf(url))
+    ))
+    expect(runSensitiveRequests).not.toHaveLength(0)
+    expect(runSensitiveRequests.every(url => new URL(url).searchParams.get('runId') !== staleRunId)).toBe(true)
+  })
+
+  it('falls back unpinned when cached active-plan revalidation fails', async () => {
+    const observed: string[] = []
+    const stalePlanRunId = 'run-stale-active-plan'
+    const responses = propertyPageResponses()
+
+    await renderPropertyPageFromApi(url => {
+      observed.push(url)
+      const path = pathOf(url)
+      if (path.endsWith(`/runs/${stalePlanRunId}`)) return jsonResponse(runDetailResponse(stalePlanRunId, 'answer-visibility'))
+      if (path.endsWith('/measurement-plan')) return jsonResponse({ code: 'INTERNAL_ERROR', message: 'Synthetic revalidation failure' }, 500)
+      if (path.includes('/measurement-overview') && new URL(url).searchParams.get('runId') === stalePlanRunId) {
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Stale plan cannot validate this pin' }, 422)
+      }
+      return responses(url)
+    }, `/projects/project_citypoint/properties/${TARGET_KEY}?runId=${stalePlanRunId}`, (queryClient) => {
+      queryClient.setQueryData(
+        getApiV1ProjectsByNameMeasurementPlanQueryKey({ client: heyClient, path: { name: 'project_citypoint' } }),
+        planResponse(),
+      )
+    })
+
+    await waitFor(() => expect(observed.some(url => pathOf(url).endsWith('/measurement-plan'))).toBe(true))
+    expect(await screen.findByText('Harbor House')).toBeTruthy()
+    const measurementRequests = observed.filter(url => (
+      /measurement-overview|measurement-property-evidence|measurement-property-competitors|measurement-changes/.test(pathOf(url))
+    ))
+    expect(measurementRequests).not.toHaveLength(0)
+    expect(measurementRequests.every(url => new URL(url).searchParams.get('runId') !== stalePlanRunId)).toBe(true)
+  })
+
+  it('waits for the resolved overview run before reading named competitors', async () => {
+    const observed: string[] = []
+    let releaseOverview: (() => void) | undefined
+    const overviewGate = new Promise<void>(resolve => { releaseOverview = resolve })
+    const responses = propertyPageResponses()
+
+    await renderPropertyPageFromApi(url => {
+      observed.push(url)
+      if (pathOf(url).includes('/measurement-overview')) {
+        return overviewGate.then(() => responses(url))
+      }
+      return responses(url)
+    })
+
+    await screen.findByLabelText('Query type')
+    await waitFor(() => expect(observed.filter(url => pathOf(url).includes('/measurement-overview'))).toHaveLength(2))
+    expect(observed.some(url => pathOf(url).includes('/measurement-property-competitors'))).toBe(false)
+    expect(screen.queryByRole('region', { name: /Named instead of this Property/ })).toBeNull()
+
+    releaseOverview?.()
+    await screen.findByRole('region', { name: /Named instead of this Property/ })
+    const competitorRequest = observed.find(url => pathOf(url).includes('/measurement-property-competitors'))
+    expect(competitorRequest).toBeDefined()
+    expect(new URL(competitorRequest!).searchParams.get('runId')).toBe(RUN_ID)
+  })
+
+  it('does not read named competitors when both overview reads fail', async () => {
+    const observed: string[] = []
+    const responses = propertyPageResponses()
+
+    await renderPropertyPageFromApi(url => {
+      observed.push(url)
+      if (pathOf(url).includes('/measurement-overview')) {
+        return jsonResponse({ code: 'INTERNAL_ERROR', message: 'Synthetic failure' }, 500)
+      }
+      return responses(url)
+    })
+
+    await screen.findByText('Could not load this Property.')
+    expect(observed.filter(url => pathOf(url).includes('/measurement-overview'))).toHaveLength(2)
+    expect(observed.some(url => pathOf(url).includes('/measurement-property-competitors'))).toBe(false)
+    expect(screen.queryByRole('region', { name: /Named instead of this Property/ })).toBeNull()
+  })
+
+  it('keeps Property class and measurement snapshot continuity in the URL across back and forward navigation', async () => {
+    const pinnedRunId = 'run-pinned'
+    const observed: string[] = []
+    const pinnedOverview = (queryClass: 'branded' | 'non-brand') => ({
+      ...overviewResponse(queryClass, { mentionCoverage: available(1, 2), citationCoverage: available(1, 2) }),
+      measurement: {
+        ...overviewResponse(queryClass, { mentionCoverage: available(1, 2), citationCoverage: available(1, 2) }).measurement,
+        displayedRunId: pinnedRunId,
+      },
+    })
+    const responses = propertyPageResponses({
+      branded: pinnedOverview('branded'),
+      nonBrand: pinnedOverview('non-brand'),
+    })
+    const { router } = await renderPropertyPageFromApi(url => {
+      observed.push(url)
+      return responses(url)
+    }, `/projects/project_citypoint/properties/${TARGET_KEY}?scope=group:north&class=branded&measurementRunId=${pinnedRunId}&keep=fixture`)
+
+    const queryType = await screen.findByLabelText('Query type') as HTMLSelectElement
+    expect(queryType.value).toBe('branded')
+    await screen.findByRole('heading', { name: 'Since previous comparable sweep' })
+    await screen.findByRole('region', { name: /Named instead of this Property/ })
+
+    const pinSensitiveRequests = observed.filter(url => (
+      /measurement-overview|measurement-property-evidence|measurement-property-competitors|measurement-changes/.test(pathOf(url))
+    ))
+    expect(pinSensitiveRequests.length).toBeGreaterThan(0)
+    for (const url of pinSensitiveRequests) {
+      expect(new URL(url).searchParams.get('runId')).toBe(pinnedRunId)
+    }
+
+    fireEvent.change(queryType, { target: { value: 'non-brand' } })
+    await waitFor(() => {
+      const search = router.state.location.search as Record<string, unknown>
+      expect(search.class).toBe('non-brand')
+      expect(search.scope).toBe('group:north')
+      expect(search.measurementRunId).toBe(pinnedRunId)
+      expect(search.runId).toBeUndefined()
+      expect(search.keep).toBe('fixture')
+    })
+
+    await act(async () => { router.history.back() })
+    await waitFor(() => expect((screen.getByLabelText('Query type') as HTMLSelectElement).value).toBe('branded'))
+    await act(async () => { router.history.forward() })
+    await waitFor(() => expect((screen.getByLabelText('Query type') as HTMLSelectElement).value).toBe('non-brand'))
+  })
+
+  it('returns to the incoming Group and makes each member Group link scoped', async () => {
+    const { router } = await renderPropertyPageFromApi(propertyPageResponses(),
+      `/projects/project_citypoint/properties/${TARGET_KEY}?scope=group:north&class=non-brand&measurementRunId=${RUN_ID}`)
+
+    // The header link is intentionally visible while the overview is loading,
+    // but it cannot claim a run until the displayed snapshot resolves.
+    await screen.findByRole('heading', { name: 'Since previous comparable sweep' })
+    const back = await screen.findByRole('link', { name: 'Back to measurement overview' })
+    const backDestination = new URL(back.getAttribute('href')!, window.location.origin)
+    expect(backDestination.searchParams.get('scope')).toBe('group:north')
+    expect(backDestination.searchParams.get('measurementRunId')).toBe(RUN_ID)
+    expect(backDestination.searchParams.get('runId')).toBeNull()
+
+    const market = await screen.findByRole('region', { name: /Measured at the market level/ })
+    const memberGroup = within(market).getByRole('link', { name: 'North' })
+    const groupDestination = new URL(memberGroup.getAttribute('href')!, window.location.origin)
+    expect(groupDestination.searchParams.get('scope')).toBe('group:north')
+    expect(groupDestination.searchParams.get('measurementRunId')).toBe(RUN_ID)
+    expect(groupDestination.searchParams.get('runId')).toBeNull()
+    expect(router.state.location.search.scope).toBe('group:north')
+  })
+
+  it('returns a direct Property link to the Portfolio', async () => {
+    await renderPropertyPageFromApi(propertyPageResponses(),
+      `/projects/project_citypoint/properties/${TARGET_KEY}?class=branded&measurementRunId=${RUN_ID}`)
+
+    await screen.findByRole('heading', { name: 'Since previous comparable sweep' })
+    const back = await screen.findByRole('link', { name: 'Back to measurement overview' })
+    const backDestination = new URL(back.getAttribute('href')!, window.location.origin)
+    expect(backDestination.searchParams.get('scope')).toBeNull()
+    expect(backDestination.searchParams.get('measurementRunId')).toBe(RUN_ID)
+    expect(backDestination.searchParams.get('runId')).toBeNull()
+  })
+
   it('keeps the compact loading skeleton inside a readable status', async () => {
     await renderPropertyPageFromApi(() => new Promise<Response>(() => {}))
 
@@ -976,11 +1356,24 @@ describe('Property facts and market link', () => {
     expect(within(market).queryByText('South')).toBeNull()
     expect(within(market).getByText('2 competitors')).toBeTruthy()
 
-    // One destination, one control. Per-market buttons all resolved to this
-    // same unscoped URL, so the market a reader picked was silently dropped.
+    // Group identity is in the URL, so each member link lands on the market it
+    // names instead of silently turning into the all-properties overview.
     const links = within(market).getAllByRole('link')
-    expect(links).toHaveLength(1)
-    expect(links[0]!.textContent).toBe('Open measurement overview')
+    expect(links).toHaveLength(2)
+    const overview = within(market).getByRole('link', { name: 'Open measurement overview' })
+    expect(overview).toBeTruthy()
+    const north = within(market).getByRole('link', { name: 'North' })
+    const overviewDestination = new URL(overview.getAttribute('href')!, window.location.origin)
+    const groupDestination = new URL(north.getAttribute('href')!, window.location.origin)
+    expect(overviewDestination.searchParams.get('measurementRunId')).toBe(RUN_ID)
+    expect(overviewDestination.searchParams.get('runId')).toBeNull()
+    expect(groupDestination.searchParams.get('scope')).toBe('group:north')
+    expect(groupDestination.searchParams.get('measurementRunId')).toBe(RUN_ID)
+    expect(groupDestination.searchParams.get('runId')).toBeNull()
+    // Portfolio defaults remain elided even as the resolved snapshot is made
+    // explicit, keeping the Group/Portfolio URL contract compact.
+    expect(overviewDestination.searchParams.get('class')).toBeNull()
+    expect(groupDestination.searchParams.get('class')).toBeNull()
   })
 
   it('does not claim the Property was never swept while a class is failing', async () => {

--- a/apps/web/test/measurement-view-url.test.ts
+++ b/apps/web/test/measurement-view-url.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, test } from 'vitest'
 
 import {
   DEFAULT_MEASUREMENT_VIEW,
+  measurementPropertyViewSearch,
   measurementViewSearch,
+  parseMeasurementPropertyViewSearch,
   parseMeasurementViewSearch,
   shouldResetMeasurementView,
 } from '../src/lib/measurement-view-url.js'
@@ -99,4 +101,22 @@ test('the default view is non-brand and all queries remains explicit', () => {
   expect(measurementViewSearch(DEFAULT_MEASUREMENT_VIEW).class).toBeUndefined()
   expect(parseMeasurementViewSearch({ class: 'all' }).queryClass).toBe('all')
   expect(parseMeasurementViewSearch({ class: 'branded' }).queryClass).toBe('branded')
+})
+
+describe('Property measurement view state', () => {
+  it('only accepts Property-compatible classes from a URL', () => {
+    expect(parseMeasurementPropertyViewSearch({ class: 'branded' })).toEqual({ queryClass: 'branded' })
+    expect(parseMeasurementPropertyViewSearch({ class: 'non-brand' })).toEqual({ queryClass: 'non-brand' })
+  })
+
+  it('treats pooled, malformed, and absent classes as the actionable Property default', () => {
+    for (const queryClass of [undefined, '', 'all', 'ALL', 'nonbrand', 'both']) {
+      expect(parseMeasurementPropertyViewSearch({ class: queryClass })).toEqual({ queryClass: 'non-brand' })
+    }
+  })
+
+  it('always writes an explicit Property class', () => {
+    expect(measurementPropertyViewSearch({ queryClass: 'non-brand' })).toEqual({ class: 'non-brand' })
+    expect(measurementPropertyViewSearch({ queryClass: 'branded' })).toEqual({ class: 'branded' })
+  })
 })

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -13,6 +13,7 @@ import { projectScheduleQueryOptions } from '../src/queries/schedule-query.js'
 import {
   getApiV1ProjectsByNameMeasurementOverviewInfiniteQueryKey,
   getApiV1ProjectsByNameMeasurementPlanQueryKey,
+  getApiV1ProjectsByNameMeasurementPortfolioSummaryQueryKey,
   getApiV1ProjectsByNameMeasurementSetupQueryKey,
   getApiV1ProjectsByNameMeasurementReportQueryKey,
   getApiV1ProjectsByNameQueriesQueryKey,
@@ -40,7 +41,8 @@ async function renderAt(
       | ReturnType<typeof activeMeasurementSetupResponse>
     report?: ReturnType<typeof measurementReportResponse>
     overview?: ReturnType<typeof measurementOverviewResponse>
-    overviewKey?: { scope?: 'all' | 'group'; groupKey?: string; queryClass?: 'all' | 'non-brand' | 'branded' }
+    summary?: ReturnType<typeof measurementPortfolioSummaryResponse>
+    overviewKey?: { scope?: 'all' | 'group'; groupKey?: string; queryClass?: 'all' | 'non-brand' | 'branded'; runId?: string }
   },
   /**
    * `seedPlan: false` leaves the measurement-plan query unseeded, which is the
@@ -108,6 +110,7 @@ async function renderAt(
       scope: measurement.overviewKey?.scope ?? 'all',
       ...(measurement.overviewKey?.groupKey ? { groupKey: measurement.overviewKey.groupKey } : {}),
       queryClass: measurement.overviewKey?.queryClass ?? 'non-brand',
+      ...(measurement.overviewKey?.runId ? { runId: measurement.overviewKey.runId } : {}),
       limit: 50,
     }
     queryClient.setQueryData(
@@ -118,6 +121,21 @@ async function renderAt(
       }),
       { pages: [measurement.overview], pageParams: [{ path: { name: projectName }, query: q }] },
     )
+    if (measurement.summary) {
+      const summaryQuery = {
+        queryClass: q.queryClass,
+        ...(q.groupKey ? { groupKey: q.groupKey } : {}),
+        ...(measurement.overview.measurement.displayedRunId ? { runId: measurement.overview.measurement.displayedRunId } : {}),
+      }
+      queryClient.setQueryData(
+        getApiV1ProjectsByNameMeasurementPortfolioSummaryQueryKey({
+          client: heyClient,
+          path: { name: projectName },
+          query: summaryQuery,
+        }),
+        measurement.summary,
+      )
+    }
   }
   const router = createAppRouter(queryClient, { initialEntries: [pathname] })
   await router.load()
@@ -250,6 +268,7 @@ function measurementOverviewResponse(overrides: {
   label?: string
   targetKey?: string
   queryClass?: 'all' | 'non-brand' | 'branded'
+  displayedRunId?: string
 } = {}) {
   return {
     mode: 'active-v2' as const,
@@ -261,7 +280,7 @@ function measurementOverviewResponse(overrides: {
     queryClass: (overrides.queryClass ?? 'non-brand') as 'all' | 'non-brand' | 'branded',
     measurement: {
       state: 'complete' as const,
-      displayedRunId: 'run-synthetic',
+      displayedRunId: overrides.displayedRunId ?? 'run-synthetic',
       completed: 1,
       expected: 1,
       completedAt: '2026-08-02T12:05:00.000Z',
@@ -319,6 +338,67 @@ function measurementPortfolioSummaryResponse(groupKey?: string, queryClass: 'all
     }],
     totalProperties: groupKey ? 1 : 218,
     truncated: false,
+  }
+}
+
+function measurementChangesResponse() {
+  const metric = (delta: number) => ({
+    state: 'available' as const,
+    previous: { state: 'available' as const, value: 0.5 },
+    current: { state: 'available' as const, value: 0.5 + delta },
+    delta,
+  })
+  return {
+    current: {
+      state: 'complete' as const,
+      displayedRunId: 'run-synthetic',
+      planRevision: 4,
+      completedAt: '2026-08-02T12:05:00.000Z',
+      executionIdentity: 'openai:search-model',
+      measurementScope: 'full' as const,
+    },
+    comparison: {
+      state: 'available' as const,
+      previous: {
+        displayedRunId: 'run-previous',
+        planRevision: 4,
+        completedAt: '2026-08-01T12:05:00.000Z',
+        executionIdentity: 'openai:search-model',
+        measurementScope: 'full' as const,
+      },
+      metrics: {
+        propertiesMentioned: metric(0),
+        mentionCoverage: metric(0.1),
+        citationCoverage: metric(-0.1),
+      },
+      changedProperties: [],
+      totalProperties: 1,
+      truncated: false,
+    },
+  }
+}
+
+function runDetailResponse(
+  id: string,
+  kind: 'answer-visibility' | 'site-audit',
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    projectId: 'project_citypoint',
+    kind,
+    status: 'completed' as const,
+    trigger: 'manual' as const,
+    measurementPlanVersionId: kind === 'answer-visibility' ? 'measurement-plan-v4' : null,
+    measurementScope: null,
+    location: null,
+    queries: null,
+    startedAt: '2026-08-02T12:00:00.000Z',
+    finishedAt: '2026-08-02T12:05:00.000Z',
+    error: null,
+    createdAt: '2026-08-02T12:00:00.000Z',
+    snapshots: [],
+    ...overrides,
   }
 }
 
@@ -531,13 +611,74 @@ test('a version-two setup never renders version-one class metrics as if they wer
   expect(html).not.toContain('Republish setup to enable Non-brand and Branded reporting.')
 })
 
+test('a Property link carries the overview snapshot without opening a run drawer', async () => {
+  const html = await renderAt('/projects/project_citypoint?scope=group:north&class=non-brand', undefined, {
+    plan: measurementPlanV2Response(4),
+    overview: measurementOverviewResponse({
+      scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'North Property', displayedRunId: 'run-synthetic',
+    }),
+    overviewKey: { scope: 'group', groupKey: 'north', queryClass: 'non-brand' },
+  })
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const propertyLink = [...doc.querySelectorAll<HTMLAnchorElement>('a')]
+    .find(anchor => anchor.textContent === 'North Property')
+
+  expect(propertyLink).toBeTruthy()
+  const destination = new URL(propertyLink!.href, window.location.origin)
+  expect(destination.searchParams.get('scope')).toBe('group:north')
+  expect(destination.searchParams.get('class')).toBe('non-brand')
+  expect(destination.searchParams.get('measurementRunId')).toBe('run-synthetic')
+  expect(destination.searchParams.get('runId')).toBeNull()
+})
+
+test('Portfolio and Group links carry the overview snapshot without a drawer param', async () => {
+  const portfolioHtml = await renderAt('/projects/project_citypoint', undefined, {
+    plan: measurementPlanV2Response(4),
+    overview: measurementOverviewResponse({ displayedRunId: 'run-synthetic' }),
+    summary: measurementPortfolioSummaryResponse(),
+    overviewKey: { scope: 'all', queryClass: 'non-brand' },
+  })
+  const portfolioDocument = new DOMParser().parseFromString(portfolioHtml, 'text/html')
+  const groupLink = [...portfolioDocument.querySelectorAll<HTMLAnchorElement>('a')]
+    .find(anchor => anchor.textContent === 'North')
+  expect(groupLink).toBeTruthy()
+  const groupDestination = new URL(groupLink!.href, window.location.origin)
+  expect(groupDestination.searchParams.get('scope')).toBe('group:north')
+  expect(groupDestination.searchParams.get('measurementRunId')).toBe('run-synthetic')
+  expect(groupDestination.searchParams.get('runId')).toBeNull()
+  expect(groupDestination.searchParams.get('class')).toBeNull()
+
+  const groupHtml = await renderAt('/projects/project_citypoint?scope=group:north', undefined, {
+    plan: measurementPlanV2Response(4),
+    overview: measurementOverviewResponse({
+      scope: 'group', scopeKey: 'north', scopeLabel: 'North', displayedRunId: 'run-synthetic',
+    }),
+    summary: measurementPortfolioSummaryResponse('north'),
+    overviewKey: { scope: 'group', groupKey: 'north', queryClass: 'non-brand' },
+  })
+  const groupDocument = new DOMParser().parseFromString(groupHtml, 'text/html')
+  const portfolioLink = [...groupDocument.querySelectorAll<HTMLAnchorElement>('a')]
+    .find(anchor => {
+      const destination = new URL(anchor.href, window.location.origin)
+      return anchor.textContent === 'Portfolio'
+        && destination.pathname.startsWith('/projects/')
+        && destination.pathname.split('/').filter(Boolean).length === 2
+    })
+  expect(portfolioLink).toBeTruthy()
+  const portfolioDestination = new URL(portfolioLink!.href, window.location.origin)
+  expect(portfolioDestination.searchParams.get('scope')).toBeNull()
+  expect(portfolioDestination.searchParams.get('measurementRunId')).toBe('run-synthetic')
+  expect(portfolioDestination.searchParams.get('runId')).toBeNull()
+  expect(portfolioDestination.searchParams.get('class')).toBeNull()
+})
+
 test('a version-two Overview uses server scope, search and pagination and defers evidence until a Property expands', async () => {
   const observed: string[] = []
   let releaseSearch: (() => void) | undefined
   let failRetrySearch = true
   const searchGate = new Promise<void>(resolve => { releaseSearch = resolve })
   const fixture = createDashboardFixture({})
-  const drawerRunId = fixture.dashboard.projects.flatMap(project => project.recentRuns)[0]!.id
+  const measurementRunId = 'run-measurement'
   const realFetch = globalThis.fetch
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const raw = input instanceof Request ? input.url : String(input)
@@ -558,6 +699,7 @@ test('a version-two Overview uses server scope, search and pagination and defers
       })
     }
     if (url.pathname.endsWith('/measurement-overview')) {
+      const displayedRunId = url.searchParams.get('runId') ?? 'run-synthetic'
       if (url.searchParams.get('search') === 'retry') {
         if (failRetrySearch) {
           failRetrySearch = false
@@ -568,6 +710,7 @@ test('a version-two Overview uses server scope, search and pagination and defers
           scopeKey: 'north',
           scopeLabel: 'North',
           label: 'Recovered Search Result',
+          displayedRunId,
         }))
       }
       if (url.searchParams.get('cursor') === 'cursor-2') {
@@ -575,6 +718,7 @@ test('a version-two Overview uses server scope, search and pagination and defers
           label: 'Harbor Annex',
           targetKey: 'harbor-annex',
           totalEstimate: 2,
+          displayedRunId,
         }))
       }
       if (url.searchParams.get('search') === 'harbor') {
@@ -584,6 +728,7 @@ test('a version-two Overview uses server scope, search and pagination and defers
           scopeKey: 'north',
           scopeLabel: 'North',
           label: 'Harbor Search Result',
+          displayedRunId,
         }))
       }
       if (url.searchParams.get('groupKey') === 'north') {
@@ -592,9 +737,10 @@ test('a version-two Overview uses server scope, search and pagination and defers
           scopeKey: 'north',
           scopeLabel: 'North',
           label: 'North Property',
+          displayedRunId,
         }))
       }
-      return jsonResponse(measurementOverviewResponse({ nextCursor: 'cursor-2', totalEstimate: 2 }))
+      return jsonResponse(measurementOverviewResponse({ nextCursor: 'cursor-2', totalEstimate: 2, displayedRunId }))
     }
     if (url.pathname.endsWith('/measurement-portfolio-summary')) {
       return jsonResponse(measurementPortfolioSummaryResponse(
@@ -602,13 +748,43 @@ test('a version-two Overview uses server scope, search and pagination and defers
         (url.searchParams.get('queryClass') ?? 'non-brand') as 'all' | 'non-brand' | 'branded',
       ))
     }
-    if (url.pathname.endsWith('/measurement-report')) return jsonResponse(measurementReportResponse(4))
+    if (url.pathname.endsWith('/measurement-changes')) return jsonResponse(measurementChangesResponse())
+    if (url.pathname.endsWith('/measurement-property-evidence')) {
+      const displayedRunId = url.searchParams.get('runId') ?? 'run-synthetic'
+      return jsonResponse({
+        property: { targetKey: url.searchParams.get('targetKey') ?? 'harbor-house', label: 'Harbor Search Result' },
+        queryClass: url.searchParams.get('queryClass') ?? 'non-brand',
+        measurement: { state: 'complete', displayedRunId },
+        evidence: {
+          items: [{
+            observationId: 'observation-1',
+            expectedSlotId: 'slot-1',
+            executionId: 'node-old',
+            usageEdgeId: 'edge-1',
+            usageEdgeType: 'target',
+            provider: 'openai',
+            queryText: 'old service query',
+            location: null,
+            sourceUrl: 'https://locations.example/harbor-house',
+            bridged: false,
+            historical: false,
+            evidenceComplete: true,
+            classification: 'assigned',
+            normalizedUrl: 'https://locations.example/harbor-house',
+            matchedTargetIds: ['harbor-house'],
+            matchedUrlIds: ['url-1'],
+          }],
+          nextCursor: null,
+          totalEstimate: 1,
+        },
+      })
+    }
     return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
   }) as typeof fetch
   onTestFinished(() => { globalThis.fetch = realFetch })
 
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  const router = createAppRouter(queryClient, { initialEntries: [`/projects/project_citypoint?runId=${drawerRunId}`] })
+  const router = createAppRouter(queryClient, { initialEntries: [`/projects/project_citypoint?measurementRunId=${measurementRunId}`] })
   await router.load()
   const page = render(
     <QueryClientProvider client={queryClient}>
@@ -622,32 +798,45 @@ test('a version-two Overview uses server scope, search and pagination and defers
   const firstOverviewUrl = observed.find(path => path.includes('/measurement-overview?'))
   expect(firstOverviewUrl).toContain('scope=all')
   expect(firstOverviewUrl).toContain('queryClass=non-brand')
+  expect(firstOverviewUrl).toContain(`runId=${measurementRunId}`)
   expect(firstOverviewUrl).toContain('limit=50')
   expect(observed.some(path => path.includes('/measurement-report?'))).toBe(false)
-  expect(await page.findByRole('heading', { name: 'Portfolio pulse' })).toBeTruthy()
-  expect(page.getByRole('dialog')).toBeTruthy()
+  expect(await page.findByRole('heading', { name: 'Portfolio pulse', hidden: true })).toBeTruthy()
+  expect(page.queryByRole('dialog')).toBeNull()
+  expect(observed.some(path => path.includes(`/runs/${measurementRunId}`))).toBe(false)
   await waitFor(() => expect(observed.some(path => path.includes('/measurement-portfolio-summary?')
     && path.includes('queryClass=non-brand')
-    && path.includes('runId=run-synthetic'))).toBe(true))
+    && path.includes(`runId=${measurementRunId}`))).toBe(true))
 
-  fireEvent.click(page.getByRole('button', { name: 'Show 50 more' }))
+  fireEvent.click(page.getByRole('button', { name: 'Show 50 more', hidden: true }))
   expect(await page.findByText('Harbor Annex')).toBeTruthy()
-  expect(observed.some(path => path.includes('cursor=cursor-2') && path.includes('runId=run-synthetic'))).toBe(true)
+  expect(observed.some(path => path.includes('cursor=cursor-2') && path.includes(`runId=${measurementRunId}`))).toBe(true)
 
   // The Pulse row is a real URL-backed link, so Groups remain shareable rather
   // than becoming local dropdown state.
-  const pulseGroups = page.getByRole('table', { name: /Advanced measurement Groups/ })
-  fireEvent.click(within(pulseGroups).getByRole('link', { name: 'North' }))
+  const pulseGroups = page.getByRole('table', { name: /Advanced measurement Groups/, hidden: true })
+  fireEvent.click(within(pulseGroups).getByRole('link', { name: 'North', hidden: true }))
   expect(await page.findByText('North Property')).toBeTruthy()
-  expect(router.state.location.search.runId).toBe(drawerRunId)
-  expect(page.getByRole('dialog')).toBeTruthy()
+  // A resolved measurement snapshot owns continuity between Portfolio and a
+  // Group without reusing the global drawer's `runId` namespace.
+  expect(router.state.location.search.measurementRunId).toBe(measurementRunId)
+  expect(router.state.location.search.runId).toBeUndefined()
+  expect(page.queryByRole('dialog')).toBeNull()
   expect(observed.some(path => path.includes('scope=group') && path.includes('groupKey=north'))).toBe(true)
   await waitFor(() => expect(observed.some(path => path.includes('/measurement-portfolio-summary?')
     && path.includes('groupKey=north')
     && path.includes('queryClass=non-brand')
-    && path.includes('runId=run-synthetic'))).toBe(true))
+    && path.includes(`runId=${measurementRunId}`))).toBe(true))
 
-  expect(page.getByRole('heading', { name: 'North' })).toBeTruthy()
+  expect(page.getByRole('heading', { name: 'North', hidden: true })).toBeTruthy()
+  expect(await page.findByRole('heading', { name: 'Since previous comparable sweep', hidden: true })).toBeTruthy()
+  expect(page.getAllByLabelText('Property outcomes')).toHaveLength(1)
+  const propertyLink = page.getByRole('link', { name: 'North Property', hidden: true })
+  const propertyDestination = new URL(propertyLink.getAttribute('href')!, window.location.origin)
+  expect(propertyDestination.searchParams.get('scope')).toBe('group:north')
+  expect(propertyDestination.searchParams.get('class')).toBe('non-brand')
+  expect(propertyDestination.searchParams.get('measurementRunId')).toBe(measurementRunId)
+  expect(propertyDestination.searchParams.get('runId')).toBeNull()
   fireEvent.change(page.getByLabelText('Search properties'), { target: { value: 'harbor' } })
   await waitFor(() => expect(observed.some(path => path.includes('search=harbor'))).toBe(true))
   await waitFor(() => expect(page.queryByRole('heading', { name: 'North' })).toBeNull())
@@ -661,20 +850,397 @@ test('a version-two Overview uses server scope, search and pagination and defers
 
   fireEvent.click(page.getByText('Harbor Search Result').closest('tr')!)
   expect(await page.findByText('Assigned queries')).toBeTruthy()
-  await waitFor(() => expect(observed.some(path => path.includes('/measurement-report?revision=4') && path.includes('runId=run-synthetic'))).toBe(true))
+  await waitFor(() => expect(observed.some(path => path.includes('/measurement-property-evidence?')
+    && path.includes('targetKey=harbor-house')
+    && path.includes(`runId=${measurementRunId}`))).toBe(true))
+  expect(observed.some(path => path.includes('/measurement-report?'))).toBe(false)
 
   fireEvent.change(page.getByLabelText('Search properties'), { target: { value: 'retry' } })
   expect(await page.findByText('Could not load the advanced measurement report.')).toBeTruthy()
-  fireEvent.click(page.getByRole('button', { name: 'Retry report' }))
+  fireEvent.click(page.getByRole('button', { name: 'Retry report', hidden: true }))
   expect(await page.findByText('Recovered Search Result')).toBeTruthy()
   expect((page.getByLabelText('Search properties') as HTMLInputElement).value).toBe('retry')
 
   fireEvent.change(page.getByLabelText('Search properties'), { target: { value: '' } })
-  const groupPulse = (await page.findByRole('heading', { name: 'North' })).closest('section')!
-  fireEvent.click(within(groupPulse).getByRole('link', { name: 'Portfolio' }))
-  expect(await page.findByRole('heading', { name: 'Portfolio pulse' })).toBeTruthy()
+  const groupPulse = (await page.findByRole('heading', { name: 'North', hidden: true })).closest('section')!
+  fireEvent.click(within(groupPulse).getByRole('link', { name: 'Portfolio', hidden: true }))
+  expect(await page.findByRole('heading', { name: 'Portfolio pulse', hidden: true })).toBeTruthy()
+  expect(router.state.location.search.measurementRunId).toBe(measurementRunId)
+  expect(router.state.location.search.runId).toBeUndefined()
+  expect(page.queryByRole('dialog')).toBeNull()
+})
+
+test('a non-measurement run drawer does not pin Group measurement reads', async () => {
+  const observed: string[] = []
+  const drawerRunId = 'run-site-audit'
+  const fixture = createDashboardFixture({})
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const raw = input instanceof Request ? input.url : String(input)
+    const url = new URL(raw, window.location.origin)
+    const path = `${decodeURIComponent(url.pathname)}${url.search}`
+    observed.push(path)
+
+    if (url.pathname.endsWith(`/runs/${drawerRunId}`)) return jsonResponse(runDetailResponse(drawerRunId, 'site-audit'))
+    if (path.endsWith('/runs?kind=answer-visibility')) return jsonResponse([])
+    if (path.endsWith('/measurement-plan')) return jsonResponse(measurementPlanV2Response(4))
+    if (path.endsWith('/measurement-setup')) return jsonResponse(activeMeasurementSetupResponse(4))
+    if (url.pathname.endsWith('/measurement-overview')) {
+      if (url.searchParams.has('runId')) {
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Not a measurement run' }, 422)
+      }
+      return jsonResponse(measurementOverviewResponse({ scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'North Property' }))
+    }
+    if (url.pathname.endsWith('/measurement-portfolio-summary')) return jsonResponse(measurementPortfolioSummaryResponse('north'))
+    if (url.pathname.endsWith('/measurement-changes')) {
+      if (url.searchParams.get('runId') === drawerRunId) {
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Not a measurement run' }, 422)
+      }
+      return jsonResponse(measurementChangesResponse())
+    }
+    return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
+  }) as typeof fetch
+  onTestFinished(() => { globalThis.fetch = realFetch })
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createAppRouter(queryClient, { initialEntries: [`/projects/project_citypoint?scope=group:north&runId=${drawerRunId}`] })
+  await router.load()
+  const page = render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+
+  expect(await page.findByText('North Property')).toBeTruthy()
+  expect(await page.findByRole('heading', { name: 'Since previous comparable sweep', hidden: true })).toBeTruthy()
   expect(router.state.location.search.runId).toBe(drawerRunId)
   expect(page.getByRole('dialog')).toBeTruthy()
+
+  const overviewRequests = observed.filter(path => path.includes('/measurement-overview?'))
+  expect(overviewRequests).not.toHaveLength(0)
+  expect(overviewRequests.every(path => new URL(path, window.location.origin).searchParams.get('runId') === null)).toBe(true)
+  const changesRequests = observed.filter(path => path.includes('/measurement-changes?'))
+  expect(changesRequests).not.toHaveLength(0)
+  expect(changesRequests.every(path => new URL(path, window.location.origin).searchParams.get('runId') === 'run-synthetic')).toBe(true)
+})
+
+test.each([
+  ["another project's answer-visibility run", { projectId: 'project-other' }],
+  ['an unplanned answer-visibility run', { measurementPlanVersionId: 'measurement-plan-old' }],
+  ['a full probe run', { trigger: 'probe', measurementScope: null }],
+  ['a scoped probe run', {
+    trigger: 'probe',
+    measurementScope: { groups: ['north'], targets: [], queries: [], resolvedTargets: ['harbor-house'] },
+  }],
+])('%s does not pin Group measurement reads', async (_label, overrides) => {
+  const observed: string[] = []
+  const drawerRunId = 'run-rejected-measurement'
+  const fixture = createDashboardFixture({})
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const raw = input instanceof Request ? input.url : String(input)
+    const url = new URL(raw, window.location.origin)
+    const path = `${decodeURIComponent(url.pathname)}${url.search}`
+    observed.push(path)
+
+    if (url.pathname.endsWith(`/runs/${drawerRunId}`)) {
+      return jsonResponse(runDetailResponse(drawerRunId, 'answer-visibility', overrides))
+    }
+    if (path.endsWith('/runs?kind=answer-visibility')) return jsonResponse([])
+    if (path.endsWith('/measurement-plan')) return jsonResponse(measurementPlanV2Response(4))
+    if (path.endsWith('/measurement-setup')) return jsonResponse(activeMeasurementSetupResponse(4))
+    if (url.pathname.endsWith('/measurement-overview')) {
+      if (url.searchParams.has('runId')) return jsonResponse({ code: 'INVALID_RUN' }, 422)
+      return jsonResponse(measurementOverviewResponse({ scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'North Property' }))
+    }
+    if (url.pathname.endsWith('/measurement-portfolio-summary')) return jsonResponse(measurementPortfolioSummaryResponse('north'))
+    if (url.pathname.endsWith('/measurement-changes')) return jsonResponse(measurementChangesResponse())
+    return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
+  }) as typeof fetch
+  onTestFinished(() => { globalThis.fetch = realFetch })
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createAppRouter(queryClient, { initialEntries: [`/projects/project_citypoint?scope=group:north&runId=${drawerRunId}`] })
+  await router.load()
+  const page = render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+
+  expect(await page.findByText('North Property')).toBeTruthy()
+  const overviewRequests = observed.filter(path => path.includes('/measurement-overview?'))
+  expect(overviewRequests).not.toHaveLength(0)
+  expect(overviewRequests.every(path => new URL(path, window.location.origin).searchParams.get('runId') === null)).toBe(true)
+  expect(router.state.location.search.runId).toBe(drawerRunId)
+})
+
+test('a cached active plan cannot validate a drawer run after revalidation fails', async () => {
+  const observed: string[] = []
+  const stalePlanRunId = 'run-stale-active-plan'
+  const fixture = createDashboardFixture({})
+  const projectName = fixture.dashboard.projects.find(project => project.project.id === 'project_citypoint')!.project.name
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const raw = input instanceof Request ? input.url : String(input)
+    const url = new URL(raw, window.location.origin)
+    const path = `${decodeURIComponent(url.pathname)}${url.search}`
+    observed.push(path)
+
+    if (url.pathname.endsWith(`/runs/${stalePlanRunId}`)) return jsonResponse(runDetailResponse(stalePlanRunId, 'answer-visibility'))
+    if (path.endsWith('/runs?kind=answer-visibility')) return jsonResponse([])
+    if (path.endsWith('/measurement-plan')) return jsonResponse({ code: 'INTERNAL_ERROR', message: 'Synthetic revalidation failure' }, 500)
+    if (path.endsWith('/measurement-setup')) return jsonResponse(activeMeasurementSetupResponse(4))
+    if (url.pathname.endsWith('/measurement-overview')) {
+      if (url.searchParams.get('runId') === stalePlanRunId) {
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Stale plan cannot validate this pin' }, 422)
+      }
+      return jsonResponse(measurementOverviewResponse({
+        scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'North Property', displayedRunId: 'run-unpinned',
+      }))
+    }
+    if (url.pathname.endsWith('/measurement-portfolio-summary')) return jsonResponse(measurementPortfolioSummaryResponse('north'))
+    if (url.pathname.endsWith('/measurement-changes')) return jsonResponse(measurementChangesResponse())
+    return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
+  }) as typeof fetch
+  onTestFinished(() => { globalThis.fetch = realFetch })
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData(
+    getApiV1ProjectsByNameMeasurementPlanQueryKey({ client: heyClient, path: { name: projectName } }),
+    measurementPlanV2Response(4),
+  )
+  const router = createAppRouter(queryClient, {
+    initialEntries: [`/projects/project_citypoint?scope=group:north&runId=${stalePlanRunId}`],
+  })
+  await router.load()
+  const page = render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+
+  await waitFor(() => expect(observed.some(path => path.endsWith('/measurement-plan'))).toBe(true))
+  expect(await page.findByText('North Property')).toBeTruthy()
+  const measurementRequests = observed.filter(path => /measurement-overview|measurement-changes/.test(path))
+  expect(measurementRequests).not.toHaveLength(0)
+  expect(measurementRequests.every(path => new URL(path, window.location.origin).searchParams.get('runId') !== stalePlanRunId)).toBe(true)
+})
+
+test('Group changes clear while a new valid overview pin is resolving', async () => {
+  const observed: string[] = []
+  let releaseNextOverview: (() => void) | undefined
+  const nextOverview = new Promise<void>(resolve => { releaseNextOverview = resolve })
+  const fixture = createDashboardFixture({})
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const raw = input instanceof Request ? input.url : String(input)
+    const url = new URL(raw, window.location.origin)
+    const path = `${decodeURIComponent(url.pathname)}${url.search}`
+    observed.push(path)
+
+    if (path.endsWith('/runs?kind=answer-visibility')) return jsonResponse([])
+    if (path.endsWith('/measurement-plan')) return jsonResponse(measurementPlanV2Response(4))
+    if (path.endsWith('/measurement-setup')) return jsonResponse(activeMeasurementSetupResponse(4))
+    if (url.pathname.endsWith('/measurement-overview')) {
+      if (url.searchParams.get('runId') === 'run-measurement-new') {
+        await nextOverview
+        return jsonResponse(measurementOverviewResponse({
+          scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'New Property', displayedRunId: 'run-measurement-new',
+        }))
+      }
+      return jsonResponse(measurementOverviewResponse({
+        scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'Old Property', displayedRunId: 'run-measurement-old',
+      }))
+    }
+    if (url.pathname.endsWith('/measurement-portfolio-summary')) return jsonResponse(measurementPortfolioSummaryResponse('north'))
+    if (url.pathname.endsWith('/measurement-changes')) {
+      const response = measurementChangesResponse()
+      const runId = url.searchParams.get('runId')!
+      response.current.displayedRunId = runId
+      response.comparison.metrics.mentionCoverage.delta = runId === 'run-measurement-new' ? 0.2 : 0.1
+      return jsonResponse(response)
+    }
+    return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
+  }) as typeof fetch
+  onTestFinished(() => { globalThis.fetch = realFetch })
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createAppRouter(queryClient, {
+    initialEntries: ['/projects/project_citypoint?scope=group:north&measurementRunId=run-measurement-old'],
+  })
+  await router.load()
+  const page = render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+
+  expect(await page.findByText('Old Property')).toBeTruthy()
+  expect(await page.findByText('+10 pp')).toBeTruthy()
+
+  await act(async () => {
+    await router.navigate({
+      to: '/projects/$projectName',
+      params: { projectName: 'project_citypoint' },
+      search: previous => ({ ...previous, measurementRunId: 'run-measurement-new' }),
+    })
+  })
+  await waitFor(() => expect(observed.some(path => path.includes('/measurement-overview?') && path.includes('runId=run-measurement-new'))).toBe(true))
+  expect(page.queryByText('+10 pp')).toBeNull()
+
+  releaseNextOverview!()
+  expect(await page.findByText('New Property')).toBeTruthy()
+  expect(await page.findByText('+20 pp')).toBeTruthy()
+})
+
+test('Group changes clear while closing a valid pin reloads the unpinned overview', async () => {
+  const observed: string[] = []
+  let releaseUnpinnedOverview: (() => void) | undefined
+  const unpinnedOverview = new Promise<void>(resolve => { releaseUnpinnedOverview = resolve })
+  const fixture = createDashboardFixture({})
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const raw = input instanceof Request ? input.url : String(input)
+    const url = new URL(raw, window.location.origin)
+    const path = `${decodeURIComponent(url.pathname)}${url.search}`
+    observed.push(path)
+
+    if (path.endsWith('/runs?kind=answer-visibility')) return jsonResponse([])
+    if (path.endsWith('/measurement-plan')) return jsonResponse(measurementPlanV2Response(4))
+    if (path.endsWith('/measurement-setup')) return jsonResponse(activeMeasurementSetupResponse(4))
+    if (url.pathname.endsWith('/measurement-overview')) {
+      if (!url.searchParams.has('runId')) {
+        await unpinnedOverview
+        return jsonResponse(measurementOverviewResponse({
+          scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'Unpinned Property', displayedRunId: 'run-unpinned',
+        }))
+      }
+      return jsonResponse(measurementOverviewResponse({
+        scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'Old Property', displayedRunId: 'run-measurement-old',
+      }))
+    }
+    if (url.pathname.endsWith('/measurement-portfolio-summary')) return jsonResponse(measurementPortfolioSummaryResponse('north'))
+    if (url.pathname.endsWith('/measurement-changes')) {
+      const response = measurementChangesResponse()
+      const runId = url.searchParams.get('runId')!
+      response.current.displayedRunId = runId
+      response.comparison.metrics.mentionCoverage.delta = runId === 'run-unpinned' ? 0.2 : 0.1
+      return jsonResponse(response)
+    }
+    return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
+  }) as typeof fetch
+  onTestFinished(() => { globalThis.fetch = realFetch })
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createAppRouter(queryClient, {
+    initialEntries: ['/projects/project_citypoint?scope=group:north&measurementRunId=run-measurement-old'],
+  })
+  await router.load()
+  const page = render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+
+  expect(await page.findByText('Old Property')).toBeTruthy()
+  expect(await page.findByText('+10 pp')).toBeTruthy()
+
+  await act(async () => {
+    await router.navigate({
+      to: '/projects/$projectName',
+      params: { projectName: 'project_citypoint' },
+      search: previous => ({ ...previous, measurementRunId: undefined }),
+    })
+  })
+  await waitFor(() => expect(observed.some(path => (
+    path.includes('/measurement-overview?') && !new URL(path, window.location.origin).searchParams.has('runId')
+  ))).toBe(true))
+  expect(page.queryByText('+10 pp')).toBeNull()
+
+  releaseUnpinnedOverview!()
+  expect(await page.findByText('Unpinned Property')).toBeTruthy()
+  expect(await page.findByText('+20 pp')).toBeTruthy()
+})
+
+test('an invalid measurement snapshot never falls back to an unpinned overview', async () => {
+  const observed: string[] = []
+  let releaseInvalidOverview: (() => void) | undefined
+  const invalidOverview = new Promise<void>(resolve => { releaseInvalidOverview = resolve })
+  const fixture = createDashboardFixture({})
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const raw = input instanceof Request ? input.url : String(input)
+    const url = new URL(raw, window.location.origin)
+    const path = `${decodeURIComponent(url.pathname)}${url.search}`
+    observed.push(path)
+
+    if (path.endsWith('/runs?kind=answer-visibility')) return jsonResponse([])
+    if (path.endsWith('/measurement-plan')) return jsonResponse(measurementPlanV2Response(4))
+    if (path.endsWith('/measurement-setup')) return jsonResponse(activeMeasurementSetupResponse(4))
+    if (url.pathname.endsWith('/measurement-overview')) {
+      if (url.searchParams.get('runId') === 'run-invalid') {
+        await invalidOverview
+        return jsonResponse({ code: 'INVALID_RUN', message: 'Snapshot is not comparable to this active plan' }, 422)
+      }
+      return jsonResponse(measurementOverviewResponse({
+        scope: 'group', scopeKey: 'north', scopeLabel: 'North', label: 'Old Property', displayedRunId: 'run-measurement-old',
+      }))
+    }
+    if (url.pathname.endsWith('/measurement-portfolio-summary')) return jsonResponse(measurementPortfolioSummaryResponse('north'))
+    if (url.pathname.endsWith('/measurement-changes')) {
+      const response = measurementChangesResponse()
+      const runId = url.searchParams.get('runId')!
+      response.current.displayedRunId = runId
+      response.comparison.metrics.mentionCoverage.delta = runId === 'run-unpinned' ? 0.2 : 0.1
+      return jsonResponse(response)
+    }
+    return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
+  }) as typeof fetch
+  onTestFinished(() => { globalThis.fetch = realFetch })
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createAppRouter(queryClient, {
+    initialEntries: ['/projects/project_citypoint?scope=group:north&measurementRunId=run-measurement-old'],
+  })
+  await router.load()
+  const page = render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+
+  expect(await page.findByText('Old Property')).toBeTruthy()
+  expect(await page.findByText('+10 pp')).toBeTruthy()
+
+  await act(async () => {
+    await router.navigate({
+      to: '/projects/$projectName',
+      params: { projectName: 'project_citypoint' },
+      search: previous => ({ ...previous, measurementRunId: 'run-invalid' }),
+    })
+  })
+  await waitFor(() => expect(observed.some(path => (
+    path.includes('/measurement-overview?') && path.includes('runId=run-invalid')
+  ))).toBe(true))
+  expect(page.queryByText('+10 pp')).toBeNull()
+
+  await act(async () => { releaseInvalidOverview!() })
+  const overviewRequests = observed.filter(path => path.includes('/measurement-overview?'))
+  expect(overviewRequests.some(path => new URL(path, window.location.origin).searchParams.get('runId') === null)).toBe(false)
+  expect(observed.some(path => path.includes('/runs/run-invalid'))).toBe(false)
 })
 
 test('a direct Portfolio URL falls back safely in embed mode', async () => {

--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -247,6 +247,13 @@ test('?runId= opens the run drawer', async () => {
   }
 })
 
+test('measurementRunId is retained as measurement context without opening the run drawer', async () => {
+  const { container, router } = await renderRoute('/?measurementRunId=run_citypoint_001')
+
+  expect(router.state.location.search.measurementRunId).toBe('run_citypoint_001')
+  expect(container.querySelector('[role="dialog"]')).toBeNull()
+})
+
 // ── Browser back/forward ──
 
 test('back/forward navigation works via router history', async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.179.5",
+  "version": "4.179.6",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/test/measurement-cosmetic-continuity.test.ts
+++ b/packages/api-routes/test/measurement-cosmetic-continuity.test.ts
@@ -248,6 +248,18 @@ describe('cosmetic-publish continuity', () => {
     })
     const harbor = summary.body.weakestProperties.find(row => row.targetKey === 'harbor')
     expect(harbor?.mentionCoverage).toMatchObject({ state: 'available', value: 1, numerator: 2, denominator: 2 })
+
+    // The property drill-down uses the same server-authoritative predecessor
+    // chain as the overview. It must not ask a browser to compare version IDs.
+    const evidence = await app.inject({
+      method: 'GET',
+      url: `/api/v1/projects/northstar/measurement-property-evidence?targetKey=harbor&queryClass=non-brand&runId=${measured}`,
+    })
+    expect(evidence.statusCode).toBe(200)
+    expect(evidence.json()).toMatchObject({
+      property: { targetKey: 'harbor' },
+      measurement: { state: 'complete', displayedRunId: measured },
+    })
   })
 
   it('keeps measurement-setup out of awaiting_first_run after a cosmetic republish', async () => {
@@ -266,7 +278,7 @@ describe('cosmetic-publish continuity', () => {
 
   it('revision-addressed reports never borrow a predecessor run through the chain', async () => {
     const versionOne = seedVersion(1)
-    seedMeasuredRun(versionOne)
+    const measured = seedMeasuredRun(versionOne)
     activate(seedVersion(2, renamedPlan(), versionOne))
 
     // The explicit --revision surface promises the revision AS-WAS. Revision 2
@@ -274,6 +286,15 @@ describe('cosmetic-publish continuity', () => {
     const rev2 = await app.inject({ method: 'GET', url: '/api/v1/projects/northstar/measurement-report?revision=2' })
     expect(rev2.statusCode).toBe(200)
     expect(rev2.json().run).toBeNull()
+
+    // An explicit predecessor run is not a request to widen an exact,
+    // revision-addressed historical report. This is deliberately 404 rather
+    // than silently presenting revision 1 evidence as revision 2.
+    const incompatibleRun = await app.inject({
+      method: 'GET',
+      url: `/api/v1/projects/northstar/measurement-report?revision=2&runId=${measured}`,
+    })
+    expect(incompatibleRun.statusCode).toBe(404)
 
     // Revision 1 still reports its own run, exactly as measured.
     const rev1 = await app.inject({ method: 'GET', url: '/api/v1/projects/northstar/measurement-report?revision=1' })

--- a/packages/api-routes/test/measurement-plan.test.ts
+++ b/packages/api-routes/test/measurement-plan.test.ts
@@ -257,7 +257,9 @@ describe('Target measurement-plan API', () => {
     expect((second.json() as { active: { revision: number } }).active.revision).toBe(2)
 
     const active = await request('GET', '/api/v1/projects/example/measurement-plan')
-    expect((active.json() as { active: { revision: number } }).active.revision).toBe(2)
+    const activeBody = active.json() as { active: { revision: number } }
+    expect(activeBody.active.revision).toBe(2)
+    expect(activeBody.active).not.toHaveProperty('id')
     const versions = await request('GET', '/api/v1/projects/example/measurement-plan/versions')
     expect((versions.json() as { versions: Array<{ revision: number; active: boolean }> }).versions)
       .toEqual([

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.179.5",
+  "version": "4.179.6",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/test/measurement-plan-version-dispatch.test.ts
+++ b/packages/contracts/test/measurement-plan-version-dispatch.test.ts
@@ -88,6 +88,7 @@ describe('stored measurement plan version dispatch', () => {
 
   it('types v2 plans on both active and revision-detail read responses', () => {
     const metadata = {
+      id: 'version-active',
       revision: 2,
       checksum: 'd'.repeat(64),
       createdAt: '2026-08-01T00:00:00.000Z',

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.179.5",
+  "version": "4.179.6",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.179.5",
+  "version": "4.179.6",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.179.5",
+  "version": "4.179.6",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Summary

- preserve Group, Property, query-class, and resolved sweep context across Advanced Measurement URLs
- use a dedicated measurementRunId so measurement navigation never opens the global Run Drawer
- honor the server-resolved comparable-version chain for current v2 evidence while keeping explicit historical revision reads exact
- add a shared comparable-sweep rail with honest loading, unavailable, and retry states
- bump the stack release boundary to 4.179.6

Validation: rebased onto main `ccd7affe` (4.179.0). Full-stack `pnpm verify` passed at #1069: generated-client drift, plugin parity, typecheck, lint, and 9,531 tests. No new matches in the known-client added-line scan. Browser visual recheck pending; newer query-workspace usability changes are a separate follow-up.