### PR TITLE
test: sanitize measurement fixtures

### DIFF
--- a/apps/web/src/pages/MeasurementPropertyPage.tsx
+++ b/apps/web/src/pages/MeasurementPropertyPage.tsx
@@ -175,8 +175,8 @@ function AnswerSources({ row }: { row: AnswerRow }) {
  *
  * The row above it can only ever say whether this Property was named. It cannot
  * say what the engine actually recommended, and that is the thing an operator
- * opens the row to find out: a "not mentioned" row on a Buckhead query turns
- * out to be an answer recommending two OTHER buildings from the same brand.
+ * opens the row to find out: a "not mentioned" row on a local-market query can
+ * turn out to be an answer recommending two other properties from the brand.
  * None of that is visible in a signal badge or a source count.
  *
  * Fetched per row rather than with the list because an answer runs to several

--- a/apps/web/test/measurement-property-page.test.tsx
+++ b/apps/web/test/measurement-property-page.test.tsx
@@ -1034,12 +1034,10 @@ describe('Reading the answer', () => {
   })
 })
 
-// Two queries repeated down almost every row — the production shape that
-// motivated collapsing the Queries cell into a count. A real screenshot had
-// nine rows where four carried this exact joined string and the rest carried
-// one half of it.
-const REPEATED_QUERY_A = 'best apartments in buckhead atlanta'
-const REPEATED_QUERY_B = 'luxury apartments buckhead atlanta'
+// Two fictional queries repeat down almost every row, which exercises the
+// production-shaped layout that collapses the Queries cell into a count.
+const REPEATED_QUERY_A = 'best apartments in north district'
+const REPEATED_QUERY_B = 'luxury apartments in north district'
 const REPEATED_QUERIES_TEXT = `${REPEATED_QUERY_A} · ${REPEATED_QUERY_B}`
 
 type CompetitorRowFixture = {


### PR DESCRIPTION
High level overview of the main changes

- Replace identifying market language with fictional, neutral measurement fixtures.
- Preserve the existing property-page behavior and layout coverage.
- Verify the web suite and repository privacy scan.