### PR TITLE
fix(web): keep portfolio sweeps schedule-driven

### DIFF
--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -682,7 +682,7 @@ export function VisibilityTrendSection({
         <p className="text-sm text-secondary">
           {metric === 'mentionShare'
             ? `No answer-text brand mentions for you or tracked competitors on ${mentionShareScopeLabel(mentionShareScope)} in this window yet.`
-            : 'Run a sweep to start tracking citations and mentions over time.'}
+            : 'No measured citation or mention data in this window.'}
         </p>
       )
     } else if (byProviderMode && series.length === 0) {

--- a/apps/web/src/pages/MeasurementPropertyPage.tsx
+++ b/apps/web/src/pages/MeasurementPropertyPage.tsx
@@ -1038,7 +1038,7 @@ export function MeasurementPropertyPage() {
         <section className="flex flex-wrap items-center justify-between gap-3 border-y border-default py-4" aria-label="Measurement next step">
           <p className="text-sm text-secondary">
             {canWrite
-              ? 'Run a measurement from the project overview to collect this Property’s coverage and source evidence.'
+              ? 'Open the project overview to check the AI visibility sweep schedule for this Property.'
               : 'This Property needs a new measurement before coverage and source evidence are available.'}
           </p>
           <Button asChild type="button" className="h-11 px-4 text-sm md:h-11">
@@ -1127,7 +1127,7 @@ export function MeasurementPropertyPage() {
         ) : evidenceState === 'not_measured' ? (
           // Not measured is not "no evidence". Saying "none" here would report
           // an absent measurement as a measured result.
-          <p className="text-sm text-secondary">Not measured yet. Run a measurement to collect the answers for this Property.</p>
+          <p className="text-sm text-secondary">Not measured yet. Answers appear after this Property is included in a completed measurement.</p>
         ) : evidenceShapeMismatch ? (
           <p role="alert" className="text-sm text-caution">
             This measurement was returned in an older format, so the answers cannot be shown here.

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -101,7 +101,7 @@ import {
   getApiV1ProjectsQueryKey,
   getApiV1ProjectsByNameQueryKey,
 } from '@ainyc/canonry-api-client/react-query'
-import { useAppendQueries, useTriggerRun } from '../queries/mutations.js'
+import { useAppendQueries } from '../queries/mutations.js'
 import { GSC_STALE_MS } from '../queries/query-client.js'
 import { invalidateProjectQueryDomain } from '../queries/query-invalidation.js'
 import { projectScheduleQueryOptions } from '../queries/schedule-query.js'
@@ -1180,7 +1180,7 @@ function OverviewBrief({
           {!comparison.hasPreviousRun ? (
             <>
               <p className="overview-brief-panel-title">No comparison yet</p>
-              <p className="overview-brief-panel-copy">Run another sweep to measure mention and citation movement.</p>
+              <p className="overview-brief-panel-copy">Comparisons need two completed AI visibility sweeps.</p>
             </>
           ) : (
             <>
@@ -1665,7 +1665,6 @@ function ProjectPageContent({
       replace: true,
     })
   }, [manageQueriesRequested, navigate, projectName])
-  const triggerRunMutation = useTriggerRun()
   const portfolioQueriesQuery = useQuery({
     ...getApiV1ProjectsByNameQueriesOptions({ client: heyClient, path: { name: projectName } }),
     enabled: tab === 'portfolio' && Boolean(projectName),
@@ -1673,9 +1672,9 @@ function ProjectPageContent({
     refetchOnMount: 'always',
   })
   // The header states when the next AI sweep fires. On a managed instance the
-  // sweep is scheduled, so "it runs itself" is the honest headline and the
-  // manual trigger beside it is the override. `nextRunAt` is computed from the
-  // cron server-side (`schedules.ts`) — the browser never parses a cron.
+  // sweep is scheduled, so the schedule is the only measurement control here.
+  // `nextRunAt` is computed from the cron server-side (`schedules.ts`), and the
+  // browser never parses a cron.
   // A 404 is normalized to the meaningful empty state by
   // `projectScheduleQueryOptions`; other failures remain retryable errors.
   const sweepScheduleQuery = useQuery({
@@ -1700,7 +1699,7 @@ function ProjectPageContent({
   // returns a row with a stale `nextRunAt`, and announcing that would promise a
   // sweep that never fires.
   const sweepSchedule = sweepScheduleQuery.data
-  const nextSweepLabel = sweepSchedule?.enabled && sweepSchedule.nextRunAt
+  const nextSweepLabel = !sweepScheduleQuery.isError && sweepSchedule?.enabled && sweepSchedule.nextRunAt
     ? `Next AI sweep ${new Date(sweepSchedule.nextRunAt).toLocaleString()}`
     : null
   const noSweepState = sweepScheduleQuery.isPending
@@ -1714,6 +1713,17 @@ function ProjectPageContent({
       : sweepSchedule.enabled
         ? 'No upcoming AI sweep is scheduled'
         : 'AI sweep schedule is paused'
+  const showScheduleLink = !sweepScheduleQuery.isError
+    && sweepSchedule !== undefined
+    && (sweepSchedule !== null || canWrite)
+  const scheduleLinkLabel = nextSweepLabel ?? (sweepSchedule === null
+    ? 'Schedule AI sweep'
+    : canWrite ? 'Manage AI sweep schedule' : 'View AI sweep schedule')
+  const scheduleLinkAriaLabel = !canWrite
+    ? 'View AI visibility sweep schedule'
+    : sweepSchedule === null
+      ? 'Create AI visibility sweep schedule'
+      : nextSweepLabel ? 'Edit AI visibility sweep schedule' : 'Manage AI visibility sweep schedule'
   const activeMeasurementPlan = activeMeasurementPlanQuery.data?.active ?? null
   // A bookmark outlives the group it names. Once the plan has actually loaded
   // and we can see which groups exist, a URL naming one that does not is
@@ -2086,19 +2096,6 @@ function ProjectPageContent({
   // "project not found" state (when both context and /projects list have
   // resolved but neither matched the URL's identifier).
 
-  async function handleTriggerRun() {
-    try {
-      await triggerRunMutation.mutateAsync({
-        projectName,
-        projectLabel,
-        sourceAction: 'project-run',
-      })
-      void refetch()
-    } catch {
-      // Mutation hook surfaces the toast and error state.
-    }
-  }
-
   async function handleDeleteProject() {
     setDeleting(true)
     try {
@@ -2260,37 +2257,21 @@ function ProjectPageContent({
           <p className="text-sm text-muted">{model.dateRangeLabel}</p>
           {!isEmbed() && (
             <div className="flex items-center gap-3">
-              {nextSweepLabel ? (
+              {!nextSweepLabel && noSweepState ? <p className="text-sm text-secondary">{noSweepState}</p> : null}
+              {showScheduleLink ? (
                 <Link
                   to="/projects/$projectName/settings"
                   params={{ projectName }}
                   search={(previous: Record<string, unknown>) => ({
                     ...(typeof previous.runId === 'string' ? { runId: previous.runId } : {}),
-                    schedule: 'edit' as const,
+                    ...(canWrite ? { schedule: 'edit' as const } : {}),
                   })}
-                  aria-label="Edit AI visibility sweep schedule"
+                  aria-label={scheduleLinkAriaLabel}
                   className="text-sm text-link outline-none hover:underline focus-visible:ring-2 focus-visible:ring-mono-400"
                 >
-                  {nextSweepLabel}
+                  {scheduleLinkLabel}
                 </Link>
-              ) : noSweepState ? <p className="text-sm text-secondary">{noSweepState}</p> : null}
-              {/* Secondary, not primary. The schedule beside it is what actually
-                  runs the sweep; this is the override for when you can't wait
-                  for it. Deleting the project used to sit here too — an
-                  irreversible action one misclick from the page's most-used
-                  button — and now lives at the bottom of the Settings tab. */}
-              <WriteButton
-                type="button"
-                variant="outline"
-                disabled={triggerRunMutation.isPending || hasActiveVisibilitySweep}
-                onClick={asyncHandler(handleTriggerRun)}
-              >
-                {triggerRunMutation.isPending
-                  ? 'Starting…'
-                  : hasActiveVisibilitySweep
-                    ? 'AI sweep running…'
-                    : 'Run AI sweep'}
-              </WriteButton>
+              ) : null}
             </div>
           )}
         </div>
@@ -2783,9 +2764,8 @@ function ProjectPageContent({
           />
           <NotificationsSection projectName={model.project.name} />
           {/* Deleting the project lives here, at the far end of Settings, rather
-              than as an icon in the page header where it sat one misclick from
-              "Run AI sweep". It destroys every query, run and snapshot, and a
-              confirm dialog was the only thing standing between the two. */}
+              than as an icon in the page header. It destroys every query, run,
+              and snapshot, so its confirmation belongs with project settings. */}
           {canWrite && !isEmbed() ? (
             <section className="page-section-divider">
               <h2 className="text-lg font-semibold text-negative-400">Delete project</h2>

--- a/apps/web/test/app-embed.test.tsx
+++ b/apps/web/test/app-embed.test.tsx
@@ -10,6 +10,7 @@ import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 import { preloadAllLazyRoutes } from '../src/router/routes.js'
 import { getApiV1ProjectsByNameMeasurementPlanQueryKey } from '@ainyc/canonry-api-client/react-query'
 import { heyClient } from '../src/api.js'
+import { projectScheduleQueryOptions } from '../src/queries/schedule-query.js'
 
 type EmbedBlock = { enabled: boolean; views?: string[]; theme?: Record<string, string> }
 type DashboardBlock = { showResourceLinks?: boolean; showUpdateNotification?: boolean; showAgentBar?: boolean }
@@ -58,6 +59,9 @@ async function renderAt(
       getApiV1ProjectsByNameMeasurementPlanQueryKey({ client: heyClient, path: { name: entry.project.name } }),
       { active: null },
     )
+    // Resolve the schedule too: the header's operator action must be present
+    // before an embed assertion can prove that it is hidden.
+    queryClient.setQueryData(projectScheduleQueryOptions(entry.project.name).queryKey, null)
   }
   const router = createAppRouter(queryClient, { initialEntries: [pathname] })
   await router.load()
@@ -157,18 +161,17 @@ test('embed theme applies allowlisted CSS custom properties to the shell', async
 // control that would 403 on click against the read-only project-scoped key,
 // while keeping every read-only view. Not a security boundary (the API key
 // scope is) — purely UI cleanliness. See isEmbed() in src/api.ts.
-test('embed hides the page-header run action that leaks on every tab', async () => {
+test('embed hides page-header schedule management while keeping measured content', async () => {
   const embed = await renderAt('/projects/project_citypoint', { enabled: true })
   const operator = await renderAt('/projects/project_citypoint')
 
-  // Operator sees the header action… (the YAML-export button was removed in
-  // favor of the Settings-tab results downloads + `canonry export`. Deleting
-  // the project is no longer here at all — it moved to the end of the Settings
-  // tab, away from the button next to it.)
-  expect(operator).toContain('AI sweep')
-  // …the embed render does not (this renders OUTSIDE the tab switch, so it
-  // would otherwise leak on the default overview embed).
-  expect(embed).not.toContain('AI sweep')
+  // The header offers schedule management, never a one-click full sweep.
+  // Pin the real operator control so the embed assertion cannot pass vacuously.
+  const scheduleLink = 'a[aria-label="Create AI visibility sweep schedule"]'
+  expect(parseHtml(operator).querySelector(scheduleLink)).not.toBeNull()
+  expect(parseHtml(embed).querySelector(scheduleLink)).toBeNull()
+  expect(operator).not.toContain('Run AI sweep')
+  expect(embed).not.toContain('Run AI sweep')
   // Delete is absent from BOTH headers now, so its absence in the embed is no
   // longer evidence of anything — assert it left the header instead.
   expect(operator).not.toContain('Delete project')

--- a/apps/web/test/measurement-property-page.test.tsx
+++ b/apps/web/test/measurement-property-page.test.tsx
@@ -927,6 +927,7 @@ describe('Property page', () => {
     })
 
     const link = await screen.findByRole('link', { name: 'Go to measurement overview' })
+    expect(screen.getByText('Open the project overview to check the AI visibility sweep schedule for this Property.')).toBeTruthy()
     expect(link.getAttribute('href')).toMatch(/\/projects\/[^/]+$/)
   })
 

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -7,6 +7,7 @@ import { RouterProvider } from '@tanstack/react-router'
 import { createDashboardFixture } from '../src/mock-data.js'
 import { createAppRouter } from '../src/router/router.js'
 import { DashboardProvider } from '../src/contexts/dashboard-context.js'
+import { AccountProvider } from '../src/contexts/account-context.js'
 import { preloadAllLazyRoutes } from '../src/router/routes.js'
 import { heyClient } from '../src/api.js'
 import { projectScheduleQueryOptions } from '../src/queries/schedule-query.js'
@@ -50,7 +51,7 @@ async function renderAt(
    * decidable. These render one synchronous pass, so an unseeded query stays
    * pending for the whole render.
    */
-  options: { schedule?: unknown; scheduleReadFailure?: boolean; seedPlan?: boolean } = {},
+  options: { schedule?: unknown; scheduleReadFailure?: boolean; seedPlan?: boolean; accountRole?: 'admin' | 'viewer' } = {},
 ): Promise<string> {
   if (embed) window.__CANONRY_CONFIG__ = { embed }
   else delete window.__CANONRY_CONFIG__
@@ -62,6 +63,12 @@ async function renderAt(
     getApiV1ProjectsByNameQueriesQueryKey({ client: heyClient, path: { name: projectName } }),
     [],
   )
+  if (options.schedule !== undefined) {
+    queryClient.setQueryData(
+      getApiV1ProjectsByNameScheduleQueryKey({ client: heyClient, path: { name: projectName } }),
+      options.schedule,
+    )
+  }
   if (options.scheduleReadFailure) {
     const scheduleKey = getApiV1ProjectsByNameScheduleQueryKey({ client: heyClient, path: { name: projectName } })
     // Keep the captured 500 visible for the synchronous SSR assertion. The
@@ -71,12 +78,8 @@ async function renderAt(
     await queryClient.fetchQuery({
       ...projectScheduleQueryOptions(projectName),
       retry: false,
+      staleTime: 0,
     }).catch(() => undefined)
-  } else if (options.schedule !== undefined) {
-    queryClient.setQueryData(
-      getApiV1ProjectsByNameScheduleQueryKey({ client: heyClient, path: { name: projectName } }),
-      options.schedule,
-    )
   }
   if (options.seedPlan !== false) {
     queryClient.setQueryData(
@@ -141,11 +144,13 @@ async function renderAt(
   await router.load()
 
   return renderToStaticMarkup(
-    <QueryClientProvider client={queryClient}>
-      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
-        <RouterProvider router={router} />
-      </DashboardProvider>
-    </QueryClientProvider>,
+    <AccountProvider account={options.accountRole ? { name: 'Test account', role: options.accountRole } : null}>
+      <QueryClientProvider client={queryClient}>
+        <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+          <RouterProvider router={router} />
+        </DashboardProvider>
+      </QueryClientProvider>
+    </AccountProvider>,
   )
 }
 
@@ -508,7 +513,6 @@ test('the Portfolio route is an explicit non-embed project workspace', async () 
   expect(html).not.toMatch(/href="\/projects\/[^"/]+\/portfolio" class="project-subnav-link/)
   expect(html).toContain('Advanced measurement setup')
   expect(html).toContain('Loading advanced measurement setup')
-  expect(html).toContain('AI sweep running')
   expect(html).not.toContain('Portfolio setup')
   expect(html).not.toContain('Coverage and performance')
 })
@@ -517,7 +521,6 @@ test('a Simple project keeps the existing Overview without advertising advanced 
   const html = await renderAt('/projects/project_citypoint')
 
   expect(html).toContain('Where competitors are winning')
-  expect(html).toContain('AI sweep running')
   expect(html).not.toContain('Set up advanced measurement')
   expect(html).not.toContain('Republish setup')
   expect(html).not.toContain('Latest measurement')
@@ -591,7 +594,6 @@ test('an active setup replaces the Simple Overview with the advanced measurement
   expect(html).not.toContain('aria-label="Coverage"')
   expect(html).toContain('advanced-measurement-properties-title')
   expect(html).toContain('Harbor House')
-  expect(html).toContain('AI sweep running')
   expect(html).not.toContain('Where competitors are winning')
 })
 
@@ -1377,7 +1379,7 @@ test('a failed setup read blocks setup instead of looking planless', async () =>
   expect(screen.queryByRole('button', { name: 'Publish setup' })).toBeNull()
 })
 
-test('a failed setup read keeps project results and the global run action visible without exposing setup actions', async () => {
+test('a failed setup read keeps project results without exposing setup actions or a direct full-sweep trigger', async () => {
   const realFetch = globalThis.fetch
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const raw = input instanceof Request ? input.url : String(input)
@@ -1406,7 +1408,8 @@ test('a failed setup read keeps project results and the global run action visibl
 
   expect(await page.findByText('Could not check the advanced measurement setup. Existing project-wide results remain available.')).toBeTruthy()
   expect(page.getByText('Where competitors are winning')).toBeTruthy()
-  expect(page.getByRole('button', { name: 'AI sweep running…' })).toBeTruthy()
+  expect(page.queryByRole('button', { name: 'Run AI sweep' })).toBeNull()
+  expect(page.queryByRole('button', { name: 'AI sweep running…' })).toBeNull()
   expect(page.queryByRole('button', { name: 'Set up advanced measurement' })).toBeNull()
   expect(page.getByRole('button', { name: 'Retry setup check' })).toBeTruthy()
 })
@@ -1510,20 +1513,16 @@ function installSettingsScheduleApi() {
   return () => { globalThis.fetch = realFetch }
 }
 
-// On a managed instance the sweep is scheduled, so the header states when the
-// next one fires and the manual trigger beside it is the override. The button
-// is deliberately secondary: as the primary it told every reader that running
-// the sweep by hand was the normal way to operate the product.
-test('the header states when the next AI sweep fires', async () => {
+// On a managed instance the schedule is the measurement control. The header
+// should let a writer manage that schedule without giving the whole plan a
+// one-click, billable override.
+test('the header offers schedule management, not a direct AI sweep', async () => {
   const html = await renderAt('/projects/project_citypoint', undefined, undefined, { schedule: schedule() })
+  const doc = new DOMParser().parseFromString(html, 'text/html')
 
   expect(html).toContain('Next AI sweep')
-  // The fixture has a sweep in flight, so the button sits in its busy state.
-  // The point is the vocabulary: every state of this control names the sweep.
-  expect(html).toContain('AI sweep running')
-  // "Run now" said nothing about WHAT ran, and the page has six other sync
-  // kinds. The disabled state already called it a sweep, so the label only
-  // admitted what it did once you had clicked it.
+  expect(doc.querySelector('a[aria-label="Edit AI visibility sweep schedule"]')?.textContent).toContain('Next AI sweep')
+  expect(doc.querySelector('.page-header-right button')).toBeNull()
   expect(html).not.toContain('Run now')
 })
 
@@ -1549,9 +1548,15 @@ test('the header links the next sweep to the one-time Settings editor handoff an
 
 test('the header makes a missing AI sweep schedule explicit without inventing a next date', async () => {
   const html = await renderAt('/projects/project_citypoint', undefined, undefined, { schedule: null })
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const scheduleLink = doc.querySelector<HTMLAnchorElement>('a[aria-label="Create AI visibility sweep schedule"]')
 
   expect(html).toContain('No AI sweep scheduled')
   expect(html).not.toContain('Next AI sweep')
+  expect(scheduleLink?.textContent).toBe('Schedule AI sweep')
+  expect(new URL(scheduleLink!.href, 'http://localhost').pathname).toBe('/projects/Citypoint%20Dental%20NYC/settings')
+  expect(new URL(scheduleLink!.href, 'http://localhost').searchParams.get('schedule')).toBe('edit')
+  expect(html).not.toContain('Run AI sweep')
 })
 
 test('the header does not turn a failed schedule read into a false no-schedule state', async () => {
@@ -1564,6 +1569,61 @@ test('the header does not turn a failed schedule read into a false no-schedule s
   expect(html).toContain('AI sweep schedule unavailable')
   expect(html).not.toContain('No AI sweep scheduled')
   expect(html).not.toContain('Next AI sweep')
+})
+
+test.each([
+  ['missing', null],
+  ['paused', schedule({ enabled: false })],
+  ['active', schedule()],
+])('a failed schedule refetch does not offer actions from a cached %s schedule', async (_state, cachedSchedule) => {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async () => jsonResponse({ code: 'UNAVAILABLE' }, 500)) as typeof fetch
+  onTestFinished(() => { globalThis.fetch = realFetch })
+
+  const html = await renderAt('/projects/project_citypoint', undefined, undefined, {
+    schedule: cachedSchedule,
+    scheduleReadFailure: true,
+  })
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const header = doc.querySelector('.page-header-right')
+
+  expect(header?.textContent).toContain('AI sweep schedule unavailable')
+  expect(header?.textContent).not.toContain('Next AI sweep')
+  expect(header?.querySelector('a')).toBeNull()
+  expect(header?.querySelector('button')).toBeNull()
+})
+
+test('a viewer sees a missing schedule without an unusable creation action', async () => {
+  const html = await renderAt('/projects/project_citypoint', undefined, undefined, {
+    schedule: null,
+    accountRole: 'viewer',
+  })
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const header = doc.querySelector('.page-header-right')
+
+  expect(header?.textContent).toContain('No AI sweep scheduled')
+  expect(header?.querySelector('a')).toBeNull()
+  expect(header?.querySelector('button')).toBeNull()
+})
+
+test.each([
+  ['active', schedule()],
+  ['paused', schedule({ enabled: false })],
+  ['without a next run', schedule({ nextRunAt: null })],
+])('a viewer can view a schedule that is %s without an edit handoff', async (_state, existingSchedule) => {
+  const html = await renderAt('/projects/project_citypoint?runId=run-header', undefined, undefined, {
+    schedule: existingSchedule,
+    accountRole: 'viewer',
+  })
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const link = doc.querySelector<HTMLAnchorElement>('a[aria-label="View AI visibility sweep schedule"]')
+
+  expect(link).not.toBeNull()
+  const destination = new URL(link!.href, 'http://localhost')
+  expect(destination.pathname).toBe('/projects/Citypoint%20Dental%20NYC/settings')
+  expect(destination.searchParams.get('schedule')).toBeNull()
+  expect(destination.searchParams.get('runId')).toBe('run-header')
+  expect(doc.querySelector('.page-header-right button')).toBeNull()
 })
 
 test('the Settings schedule deep link opens once, clears with replace on cancel, and does not reopen on Back', async () => {
@@ -1606,11 +1666,12 @@ test('the Settings schedule deep link clears its marker after save and remove', 
 
 test('a DISABLED schedule promises no next sweep, even though the row still carries a stale nextRunAt', async () => {
   const html = await renderAt('/projects/project_citypoint', undefined, undefined, { schedule: schedule({ enabled: false }) })
+  const doc = new DOMParser().parseFromString(html, 'text/html')
 
   expect(html).not.toContain('Next AI sweep')
-  // The override is still offered — a paused schedule is exactly when someone
-  // needs to run one by hand.
-  expect(html).toContain('AI sweep')
+  expect(html).toContain('AI sweep schedule is paused')
+  expect(doc.querySelector('a[aria-label="Manage AI visibility sweep schedule"]')?.textContent).toBe('Manage AI sweep schedule')
+  expect(doc.querySelector('.page-header-right button')).toBeNull()
 })
 
 // Deleting a project destroys every query, run and snapshot. It used to be an
@@ -1618,8 +1679,9 @@ test('a DISABLED schedule promises no next sweep, even though the row still carr
 // most-clicked button on the page.
 test('deleting the project is not reachable from the page header', async () => {
   const html = await renderAt('/projects/project_citypoint')
+  const doc = new DOMParser().parseFromString(html, 'text/html')
 
-  expect(html).toContain('AI sweep')
+  expect(doc.querySelector('.page-header-right button')).toBeNull()
   expect(html).not.toContain('Delete project')
 })
 

--- a/apps/web/test/viewer-write-controls.test.tsx
+++ b/apps/web/test/viewer-write-controls.test.tsx
@@ -33,7 +33,6 @@ function renderAs(role: 'admin' | 'viewer' | null, ui: React.ReactNode) {
  */
 describe('project write controls', () => {
   const controls = [
-    'Run AI sweep',
     'Delete project',
     'Add competitor',
     'Add queries',

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -219,7 +219,7 @@ test('shows an empty state when there are no buckets yet', async () => {
   renderSection()
 
   await waitFor(() => {
-    expect(screen.getByText(/Run a sweep to start tracking/)).toBeTruthy()
+    expect(screen.getByText('No measured citation or mention data in this window.')).toBeTruthy()
   })
 })
 
@@ -234,7 +234,7 @@ test('carries pooled classification-unavailable scope through an empty response'
   onTestFinished(restore)
 
   renderSection(['competitor.com'])
-  await screen.findByText('Run a sweep to start tracking citations and mentions over time.')
+  await screen.findByText('No measured citation or mention data in this window.')
   act(() => { fireEvent.click(screen.getByRole('button', { name: 'Mention share' })) })
 
   expect(screen.getByText(/pooled queries.*classification unavailable/i)).toBeTruthy()

--- a/docs/mockups/advanced-measurement/portfolio-scale-flows.html
+++ b/docs/mockups/advanced-measurement/portfolio-scale-flows.html
@@ -878,8 +878,7 @@
           <div class="project-header-right">
             <p class="project-period">Last 30 days</p>
             <div class="project-header-actions">
-              <button type="button" class="schedule-summary" data-project-section="settings">Next AI sweep · Wednesday at 9:00 AM UTC</button>
-              <button type="button" class="button" data-run-sweep>Run AI sweep</button>
+              <button type="button" class="schedule-summary" data-project-section="settings" aria-label="Manage scheduled official run">Next scheduled official run: Wednesday at 9:00 AM UTC</button>
             </div>
           </div>
         </header>
@@ -939,6 +938,13 @@
       return { section: 'visibility', queryView: 'tracked', pulseGroup: null, pulseProperty: null }
     }
     const initialRoute = routeFromHash()
+    const TEST_BATCH_LIMIT = 10
+    const DEFAULT_TEST_QUERIES = [
+      'What are the best luxury apartments in Metro Golf?',
+      'Which Metro Golf apartments have coworking spaces?',
+      'Where can I find pet-friendly apartments near central Metro Golf?',
+    ]
+    const DEFAULT_TEST_QUERY_TEXT = DEFAULT_TEST_QUERIES.join('\n')
     const state = {
       section: initialRoute.section,
       queryView: initialRoute.queryView,
@@ -948,11 +954,18 @@
       trendMetric: 'mentioned',
       trendMode: 'byEngine',
       queryComposer: false,
-      researchComplete: true,
       promotionStep: 0,
       promotionQuery: '',
       publishedQuery: '',
       scheduleEditing: false,
+      testQueryText: DEFAULT_TEST_QUERY_TEXT,
+      testProvider: 'OpenAI',
+      testLocation: 'Metro Golf',
+      testResult: {
+        queries: [...DEFAULT_TEST_QUERIES],
+        provider: 'OpenAI',
+        location: 'Metro Golf',
+      },
     }
 
     function clamp(value, min, max) { return Math.max(min, Math.min(max, value)) }
@@ -961,6 +974,42 @@
       return String(value).replace(/[&<>"']/g, character => ({
         '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;',
       })[character])
+    }
+    function testBatch() {
+      const allQueries = state.testQueryText
+        .split(/\r?\n/)
+        .map(query => query.trim())
+        .filter(Boolean)
+      const exceedsLimit = allQueries.length > TEST_BATCH_LIMIT
+      return { allQueries, queries: exceedsLimit ? [] : allQueries, exceedsLimit }
+    }
+    function testCallCountLabel(batch) {
+      const total = batch.allQueries.length
+      if (!total) return 'Add at least one nonempty query before running a test.'
+      if (batch.exceedsLimit) {
+        const removeCount = total - TEST_BATCH_LIMIT
+        return `${total} ${total === 1 ? 'query' : 'queries'} exceed the ${TEST_BATCH_LIMIT}-query test limit. Remove ${removeCount} ${removeCount === 1 ? 'query' : 'queries'} to continue.`
+      }
+      const count = batch.queries.length
+      const queryLabel = count === 1 ? 'query' : 'queries'
+      const callLabel = count === 1 ? 'provider call' : 'provider calls'
+      return `${count} ${queryLabel} × 1 provider = ${count} ${callLabel}.`
+    }
+    function testRunLabel(batch) {
+      if (!batch.allQueries.length) return 'Add test query'
+      if (batch.exceedsLimit) return 'Fix test queries'
+      const count = batch.queries.length
+      return `Run ${count} test ${count === 1 ? 'query' : 'queries'}`
+    }
+    function updateTestPreflight() {
+      const batch = testBatch()
+      const callCount = document.getElementById('test-call-count')
+      const runButton = document.querySelector('[data-run-research]')
+      if (callCount) callCount.textContent = testCallCountLabel(batch)
+      if (runButton) {
+        runButton.textContent = testRunLabel(batch)
+        runButton.disabled = batch.queries.length === 0 || batch.exceedsLimit
+      }
     }
     function slug(value) { return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') }
     function allocate(total, count) {
@@ -1154,7 +1203,6 @@
         <div class="page-head">
           <div><h1>${escapeHtml(title)}</h1>${context ? `<p>${escapeHtml(context)}</p>` : ''}</div>
           <div class="head-actions">
-            ${group || property ? `<button type="button" class="button" data-spot-check="${property ? 'Property' : 'Group'}">Spot check ${property ? 'Property' : 'Group'}</button>` : ''}
             <button type="button" class="button" data-open-query-view="test">Test queries</button>
             <button type="button" class="button ghost" data-project-section="settings">Measurement setup</button>
           </div>
@@ -1165,7 +1213,7 @@
     function projectQueryTrendHtml(rows, classKey) {
       const summary = aggregate(rows, classKey)
       if (summary.measured === 0) {
-        return `<section class="scope-trend" aria-labelledby="project-trend-title"><div class="trend-head"><div><h2 id="project-trend-title">Visibility over time</h2><p>Run a full AI sweep to start the project trend.</p></div></div></section>`
+        return `<section class="scope-trend" aria-labelledby="project-trend-title"><div class="trend-head"><div><h2 id="project-trend-title">Visibility over time</h2><p>Scheduled official runs will populate the project trend.</p></div></div></section>`
       }
       const metricLabels = { mentioned: 'Mentioned', cited: 'Cited', mentionShare: 'Mention share' }
       const metric = state.trendMetric
@@ -1386,7 +1434,9 @@
       const query = state.promotionQuery || 'What are the best luxury apartments in Metro Golf?'
       const step = state.promotionStep
       const source = state.queryView === 'discover' ? 'Discovery candidate' : 'Saved test'
-      const sourceDetail = state.queryView === 'discover' ? 'Portfolio discovery · sample candidates' : 'OpenAI · Metro Golf · sample run'
+      const sourceDetail = state.queryView === 'discover'
+        ? 'Portfolio discovery · sample candidates'
+        : `${state.testResult.provider} · ${state.testResult.location} · saved test`
       if (step === 1) {
         return `<section class="promotion-panel" aria-labelledby="promotion-title">
           <div class="section-head"><div><span class="eyebrow">Measurement draft</span><h2 id="promotion-title" tabindex="-1">Add to measurement</h2><p>Choose the published scope without leaving this workspace.</p></div><button type="button" class="button small ghost" data-promotion-cancel>Cancel</button></div>
@@ -1416,7 +1466,7 @@
               <div class="review-row"><dt>Query</dt><dd class="property-name">${escapeHtml(query)}</dd></div>
               <div class="review-row"><dt>Query type</dt><dd>Non-brand</dd></div>
               <div class="review-row"><dt>Assigned Properties</dt><dd>Metro Golf selection · 15 Properties</dd></div>
-              <div class="review-row"><dt>First official measurement</dt><dd>Next full AI sweep · Wednesday at 9:00 AM UTC</dd></div>
+              <div class="review-row"><dt>First official measurement</dt><dd>Next scheduled official run: Wednesday at 9:00 AM UTC</dd></div>
             </dl>
             <div class="review-impact"><span><strong>1</strong> query added</span><span><strong>15</strong> Property assignments</span><span><strong>0</strong> runs started</span></div>
             <p class="section-note">Publishing changes the long-term plan. It does not count the saved test as official evidence or start a sweep.</p>
@@ -1440,7 +1490,7 @@
             <div class="field"><label for="new-query-class">Query type</label><select id="new-query-class" class="control"><option>Non-brand</option><option>Branded</option></select></div>
             <div class="field"><label for="new-query-scope">Assign to</label><select id="new-query-scope" class="control"><option>Choose Properties…</option><option>All 225 Properties</option><option>Metro Golf · 15 Properties</option><option>Specific Properties…</option></select></div>
           </div>
-          <div class="head-actions" style="margin-top:14px"><button type="button" class="button ghost" data-toggle-query-composer>Cancel</button><button type="button" class="button primary" data-toast="Added to the measurement draft. Publish the draft before the next full sweep.">Add to draft</button></div>
+          <div class="head-actions" style="margin-top:14px"><button type="button" class="button ghost" data-toggle-query-composer>Cancel</button><button type="button" class="button primary" data-toast="Added to the measurement draft. Publish the draft before the next scheduled official run.">Add to draft</button></div>
         </section>` : ''}
         <div class="table-wrap"><table><caption class="sr-only">Tracked project queries</caption><thead><tr><th>Query</th><th>Type</th><th>Assigned Properties</th><th>Last measured</th><th>Mention</th><th>Citation</th><th><span class="sr-only">Actions</span></th></tr></thead><tbody>
           ${rows.map(trackedQueryRowHtml).join('')}
@@ -1468,29 +1518,30 @@
     }
 
     function renderTestQueries() {
-      const testQueries = [
-        'What are the best luxury apartments in Metro Golf?',
-        'Which Metro Golf apartments have coworking spaces?',
-        'Where can I find pet-friendly apartments near central Metro Golf?',
-      ]
+      const batch = testBatch()
+      const testQueries = batch.queries
+      const savedTest = state.testResult
+      const savedQueryLabel = savedTest.queries.length === 1 ? 'query' : 'queries'
       return `${queryWorkspaceHeader('Test queries', 'Run saved checks without changing the official measurement.')}
         <div class="query-notice"><span class="badge info">Test</span><strong>Saved separately</strong><span>Does not change tracked queries, Portfolio Pulse, trends, or the AI sweep schedule.</span></div>
         <div class="test-layout">
           <section class="test-pane"><h2>New test</h2><p>Use arbitrary prompts with one API model and location.</p>
             <div class="form-stack">
-              <div class="field"><label for="test-query-text">Queries</label><textarea id="test-query-text" class="control">${testQueries.join('\n')}</textarea></div>
-              <div class="form-grid"><div class="field"><label for="test-provider">API provider</label><select id="test-provider" class="control"><option>Project default</option><option>OpenAI</option><option>Gemini</option></select></div><div class="field"><label for="test-location">Location</label><select id="test-location" class="control"><option>Metro Golf</option><option>Project default</option><option>No location</option></select></div></div>
-              <div><button type="button" class="button primary" data-run-research>Run 3 test queries</button></div>
+              <div class="field"><label for="test-query-text">Queries</label><textarea id="test-query-text" class="control">${escapeHtml(state.testQueryText)}</textarea></div>
+              <div class="form-grid"><div class="field"><label for="test-provider">API provider</label><select id="test-provider" class="control"><option${state.testProvider === 'OpenAI' ? ' selected' : ''}>OpenAI</option><option${state.testProvider === 'Gemini' ? ' selected' : ''}>Gemini</option></select></div><div class="field"><label for="test-location">Location</label><select id="test-location" class="control"><option${state.testLocation === 'Metro Golf' ? ' selected' : ''}>Metro Golf</option><option${state.testLocation === 'Project default' ? ' selected' : ''}>Project default</option><option${state.testLocation === 'No location' ? ' selected' : ''}>No location</option></select></div></div>
+              <p id="test-batch-limit" class="section-note">Prototype limit: 10 queries. This limit applies only to this mockup.</p>
+              <p id="test-call-count" class="section-note">${testCallCountLabel(batch)}</p>
+              <div><button type="button" class="button primary" data-run-research aria-describedby="test-call-count" ${testQueries.length && !batch.exceedsLimit ? '' : 'disabled'}>${testRunLabel(batch)}</button></div>
             </div>
-            <div class="settings-section" style="margin-top:20px"><h2>Spot check published measurement</h2><p class="section-note">Run assigned questions for one Group or Property. The probe stays out of official reporting.</p><div class="form-grid" style="margin-top:12px"><div class="field"><label for="spot-check-scope">Scope</label><select id="spot-check-scope" class="control"><option>Metro Golf Group</option><option>Northstar Demo Station</option><option>All published queries</option></select></div><div class="field" style="align-self:end"><button type="button" class="button" data-spot-check="Selected scope">Run spot check</button></div></div></div>
+            <div class="settings-section" style="margin-top:20px"><h2>Spot check published measurement</h2><p class="section-note">Probe one Property with one provider. It stays out of official reporting.</p><div class="settings-row"><div class="settings-facts"><strong id="spot-check-property">Property: Northstar Demo Station</strong><span id="spot-check-provider">Provider: OpenAI</span></div><div class="settings-actions"><p id="spot-check-call-count" class="section-note">4 assigned queries × 1 provider = 4 provider calls.</p><button type="button" class="button" data-spot-check aria-describedby="spot-check-call-count">Run bounded spot check</button></div></div></div>
           </section>
           <section class="test-pane"><h2>Saved tests</h2><p>Standalone answer and source evidence.</p><div class="test-batches">
-            <button type="button" class="test-batch active"><span>3 Metro Golf queries</span><span>OpenAI</span><span class="badge positive">Complete</span></button>
+            <button type="button" class="test-batch active"><span>${savedTest.queries.length} ${escapeHtml(savedTest.location)} ${savedQueryLabel}</span><span>${escapeHtml(savedTest.provider)}</span><span class="badge positive">Complete</span></button>
             <button type="button" class="test-batch"><span>5 apartment comparison queries</span><span>Gemini</span><span class="badge positive">Complete</span></button>
             <button type="button" class="test-batch"><span>2 brand recall queries</span><span>OpenAI</span><span class="badge caution">Partial</span></button>
           </div></section>
         </div>
-        ${state.researchComplete ? `<section class="test-result" aria-labelledby="test-results-title"><div class="section-head"><div><h2 id="test-results-title">Test results</h2><p>OpenAI · Metro Golf · sample run</p></div></div><div class="table-wrap"><table><thead><tr><th>Query</th><th>Mention</th><th>Citation</th><th>Sources</th><th></th></tr></thead><tbody>${testQueries.map((query, index) => `<tr><td class="property-name">${escapeHtml(query)}</td><td>${index === 1 ? badge('Not mentioned', '') : badge('Mentioned', 'positive')}</td><td>${index === 0 ? badge('Cited', 'positive') : badge('Not cited', '')}</td><td>${index === 0 ? 'northstar.example · marketplace-a.example' : index === 1 ? 'marketplace-a.example · marketplace-b.example' : 'marketplace-c.example'}</td><td><button type="button" class="scope-link" data-add-to-measurement data-promotion-query="${escapeHtml(query)}">Add to measurement&nbsp;→</button></td></tr>`).join('')}</tbody></table></div></section>` : ''}
+        ${savedTest.queries.length ? `<section class="test-result" aria-labelledby="test-results-title"><div class="section-head"><div><h2 id="test-results-title">Test results</h2><p>${escapeHtml(savedTest.provider)} · ${escapeHtml(savedTest.location)} · saved test</p></div></div><div class="table-wrap"><table><thead><tr><th>Query</th><th>Mention</th><th>Citation</th><th>Sources</th><th></th></tr></thead><tbody>${savedTest.queries.map((query, index) => `<tr><td class="property-name">${escapeHtml(query)}</td><td>${index === 1 ? badge('Not mentioned', '') : badge('Mentioned', 'positive')}</td><td>${index === 0 ? badge('Cited', 'positive') : badge('Not cited', '')}</td><td>${index === 0 ? 'northstar.example · marketplace-a.example' : index === 1 ? 'marketplace-a.example · marketplace-b.example' : 'marketplace-c.example'}</td><td><button type="button" class="scope-link" data-add-to-measurement data-promotion-query="${escapeHtml(query)}">Add to measurement&nbsp;→</button></td></tr>`).join('')}</tbody></table></div></section>` : ''}
         ${renderPromotionPanel()}`
     }
 
@@ -1600,9 +1651,18 @@
         return
       }
       if (target.dataset.runResearch !== undefined) {
-        state.researchComplete = true
+        const batch = testBatch()
+        if (!batch.queries.length || batch.exceedsLimit) {
+          updateTestPreflight()
+          return
+        }
+        state.testResult = {
+          queries: [...batch.queries],
+          provider: state.testProvider,
+          location: state.testLocation,
+        }
         render()
-        showToast('Test complete. Saved separately from official measurement.')
+        showToast(`Test probe complete, ${batch.queries.length} ${batch.queries.length === 1 ? 'provider call' : 'provider calls'}. Saved separately from official measurement.`)
         return
       }
       if (target.dataset.addToMeasurement !== undefined) {
@@ -1633,7 +1693,7 @@
         history.pushState(null, '', '#queries/tracked')
         render()
         focusQueryWorkspace()
-        showToast('Published new revision. The query is awaiting its first sweep.')
+        showToast('Published new revision. 0 provider calls started. It will wait for the next scheduled official run.')
         return
       }
       if (target.dataset.promotionCancel !== undefined) {
@@ -1642,12 +1702,8 @@
         focusQueryWorkspace()
         return
       }
-      if (target.dataset.spotCheck) {
-        showToast(`${target.dataset.spotCheck} probe queued. It will not affect Portfolio Pulse or trends.`)
-        return
-      }
-      if (target.dataset.runSweep !== undefined) {
-        showToast('Full project AI sweep queued for the published measurement plan.')
+      if (target.dataset.spotCheck !== undefined) {
+        showToast('Probe queued for Northstar Demo Station, 4 provider calls. Excluded from Portfolio Pulse and trends.')
         return
       }
       if (target.dataset.editSchedule !== undefined) {
@@ -1704,6 +1760,22 @@
         window.scrollTo({ top: 0, behavior: 'smooth' })
         return
       }
+    })
+
+    document.addEventListener('input', event => {
+      const target = event.target
+      if (!target || target.id !== 'test-query-text') return
+      state.testQueryText = target.value
+      updateTestPreflight()
+    })
+
+    document.addEventListener('change', event => {
+      const target = event.target
+      if (!target) return
+      if (target.id === 'test-provider') state.testProvider = target.value
+      else if (target.id === 'test-location') state.testLocation = target.value
+      else return
+      render()
     })
 
     function syncRouteFromLocation() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.179.6",
+  "version": "4.179.7",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.179.6",
+  "version": "4.179.7",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.179.6",
+  "version": "4.179.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.179.6",
+  "version": "4.179.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.179.6",
+  "version": "4.179.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/test/advanced-measurement-mockup.test.ts
+++ b/test/advanced-measurement-mockup.test.ts
@@ -10,12 +10,12 @@ const { JSDOM } = require('jsdom') as {
     url: string
     runScripts: 'dangerously'
     beforeParse: (window: Window) => void
-  }) => { window: Window }
+  }) => { window: Window & { Event: typeof Event } }
 }
 
-function openMockup() {
+function openMockup(hash = '#queries/test') {
   return new JSDOM(readFileSync(mockupPath, 'utf8'), {
-    url: 'https://mockup.test/#queries/test',
+    url: `https://mockup.test/${hash}`,
     runScripts: 'dangerously',
     beforeParse(window) {
       window.scrollTo = () => undefined
@@ -85,7 +85,170 @@ describe('advanced measurement query mockup', () => {
       expect(firstTrackedRow?.textContent).toContain('Awaiting first sweep')
       expect(firstTrackedRow?.textContent?.match(/Not measured/g)).toHaveLength(2)
       expect(document.querySelector('.table-footer')?.textContent).toContain('Showing 12 of 37 tracked queries')
+      expect(document.querySelector('#toast')?.textContent).toBe(
+        'Published new revision. 0 provider calls started. It will wait for the next scheduled official run.',
+      )
       expect(document.activeElement).toBe(document.querySelector('[data-query-view="tracked"]'))
+    } finally {
+      dom.window.close()
+    }
+  })
+
+  it('keeps official measurement scheduled and makes every diagnostic probe explicitly bounded', () => {
+    const source = readFileSync(mockupPath, 'utf8')
+    const dom = openMockup()
+    const { document } = dom.window
+
+    try {
+      expect(source).not.toContain('data-run-sweep')
+      expect(source).not.toContain('target.dataset.runSweep')
+      expect(source).not.toContain('Run a full AI sweep')
+
+      const scheduledRun = document.querySelector<HTMLButtonElement>('[data-project-section="settings"]')
+      expect(scheduledRun?.getAttribute('aria-label')).toBe('Manage scheduled official run')
+      expect(scheduledRun?.textContent).toContain('Next scheduled official run')
+
+      const testCallCount = document.getElementById('test-call-count')
+      const testButton = document.querySelector<HTMLButtonElement>('[data-run-research]')
+      expect(testCallCount?.textContent).toContain('3 queries × 1 provider = 3 provider calls.')
+      expect(document.getElementById('test-batch-limit')?.textContent).toContain('Prototype limit: 10 queries.')
+      expect(testButton?.getAttribute('aria-describedby')).toBe('test-call-count')
+      expect(testButton?.textContent).toBe('Run 3 test queries')
+
+      expect(document.querySelector('#spot-check-scope')).toBeNull()
+      expect(document.getElementById('spot-check-property')?.textContent).toContain('Property: Northstar Demo Station')
+      expect(document.getElementById('spot-check-provider')?.textContent).toContain('Provider: OpenAI')
+      const spotCheckCallCount = document.getElementById('spot-check-call-count')
+      const spotCheckButton = document.querySelector<HTMLButtonElement>('[data-spot-check]')
+      expect(spotCheckCallCount?.textContent).toContain('4 assigned queries × 1 provider = 4 provider calls.')
+      expect(spotCheckButton?.getAttribute('aria-describedby')).toBe('spot-check-call-count')
+      expect(spotCheckButton?.textContent).toBe('Run bounded spot check')
+
+      spotCheckButton?.click()
+      expect(document.querySelector('#toast')?.textContent).toBe(
+        'Probe queued for Northstar Demo Station, 4 provider calls. Excluded from Portfolio Pulse and trends.',
+      )
+    } finally {
+      dom.window.close()
+    }
+  })
+
+  it('rejects empty and over-limit test batches without omitting queries', () => {
+    const dom = openMockup()
+    const { document } = dom.window
+
+    try {
+      const textarea = document.querySelector<HTMLTextAreaElement>('#test-query-text')
+      const callCount = document.getElementById('test-call-count')
+      const runButton = document.querySelector<HTMLButtonElement>('[data-run-research]')
+      expect(textarea).toBeTruthy()
+
+      textarea!.value = Array.from({ length: 11 }, (_, index) => `Test query ${index + 1}`).join('\n')
+      textarea!.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+
+      expect(callCount?.textContent).toBe('11 queries exceed the 10-query test limit. Remove 1 query to continue.')
+      expect(runButton?.textContent).toBe('Fix test queries')
+      expect(runButton?.disabled).toBe(true)
+
+      textarea!.value = '\n  \n'
+      textarea!.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+
+      expect(callCount?.textContent).toBe('Add at least one nonempty query before running a test.')
+      expect(runButton?.textContent).toBe('Add test query')
+      expect(runButton?.disabled).toBe(true)
+    } finally {
+      dom.window.close()
+    }
+  })
+
+  it('shows an exact singular preflight and saves one bounded test probe', () => {
+    const dom = openMockup()
+    const { document } = dom.window
+
+    try {
+      const textarea = document.querySelector<HTMLTextAreaElement>('#test-query-text')
+      const callCount = document.getElementById('test-call-count')
+      const runButton = document.querySelector<HTMLButtonElement>('[data-run-research]')
+      expect(textarea).toBeTruthy()
+
+      textarea!.value = 'Which apartments have a rooftop garden?'
+      textarea!.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+
+      expect(callCount?.textContent).toBe('1 query × 1 provider = 1 provider call.')
+      expect(runButton?.textContent).toBe('Run 1 test query')
+      expect(runButton?.disabled).toBe(false)
+
+      runButton?.click()
+
+      expect(document.querySelector('#toast')?.textContent).toBe(
+        'Test probe complete, 1 provider call. Saved separately from official measurement.',
+      )
+    } finally {
+      dom.window.close()
+    }
+  })
+
+  it('keeps saved test evidence stable while draft provider and location change, then snapshots the new test on run', () => {
+    const dom = openMockup()
+    const { document } = dom.window
+
+    try {
+      const draftQuery = 'Which apartments have a quiet workspace?'
+      const textarea = document.querySelector<HTMLTextAreaElement>('#test-query-text')
+      expect(document.querySelector('.test-result .section-head p')?.textContent).toBe('OpenAI · Metro Golf · saved test')
+      expect(textarea).toBeTruthy()
+
+      textarea!.value = draftQuery
+      textarea!.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+
+      const provider = document.querySelector<HTMLSelectElement>('#test-provider')
+      provider!.value = 'Gemini'
+      provider!.dispatchEvent(new dom.window.Event('change', { bubbles: true }))
+
+      const location = document.querySelector<HTMLSelectElement>('#test-location')
+      location!.value = 'No location'
+      location!.dispatchEvent(new dom.window.Event('change', { bubbles: true }))
+
+      expect(document.querySelector<HTMLSelectElement>('#test-provider')?.value).toBe('Gemini')
+      expect(document.querySelector<HTMLSelectElement>('#test-location')?.value).toBe('No location')
+      expect(document.querySelector('.test-result .section-head p')?.textContent).toBe('OpenAI · Metro Golf · saved test')
+      expect(document.querySelector('.test-result tbody tr')?.textContent).toContain('What are the best luxury apartments in Metro Golf?')
+      expect(document.querySelector('.test-result tbody')?.textContent).not.toContain(draftQuery)
+
+      click(document, '[data-run-research]')
+
+      expect(document.querySelector('.test-result .section-head p')?.textContent).toBe('Gemini · No location · saved test')
+      expect(document.querySelector('.test-result tbody tr')?.textContent).toContain(draftQuery)
+
+      click(document, '[data-add-to-measurement]')
+
+      expect(document.querySelector('.promotion-origin')?.textContent).toContain('Gemini · No location · saved test')
+    } finally {
+      dom.window.close()
+    }
+  })
+
+  it.each([
+    ['Group', '#pulse/group/metro-alpha', 'Metro Alpha', 'Group · 15 Properties'],
+    ['Property', '#pulse/property/property-1', 'Northstar Demo Arden', 'Property · Metro Alpha · 1 URL'],
+  ])('opens Test queries instead of queuing a %s spot check', (_scope, hash, title, context) => {
+    const source = readFileSync(mockupPath, 'utf8')
+    const dom = openMockup(hash)
+    const { document, location } = dom.window
+
+    try {
+      expect(document.querySelector('.page-head h1')?.textContent).toBe(title)
+      expect(document.querySelector('.page-head p')?.textContent).toBe(context)
+      expect(source).not.toContain(`data-spot-check="${_scope}"`)
+      expect(document.querySelector(`[data-spot-check="${_scope}"]`)).toBeNull()
+      const testQueries = document.querySelector<HTMLButtonElement>('[data-open-query-view="test"]')
+      expect(testQueries?.textContent).toBe('Test queries')
+
+      testQueries?.click()
+
+      expect(location.hash).toBe('#queries/test')
+      expect(document.querySelector('.page-head h1')?.textContent).toBe('Test queries')
+      expect(document.querySelector('#toast')?.textContent).toBe('')
     } finally {
       dom.window.close()
     }


### PR DESCRIPTION
Stacked on #1064.

- Remove the project-header one-click full sweep; keep truthful, role-aware schedule navigation.
- Update the Portfolio Pulse mockup with explicit query/provider call counts, fail-closed test limits, and zero-run promotion.
- Preserve saved test scope and update measurement empty-state language.
- Cover schedule visibility for operators, viewers, embeds, and failed refreshes.
- Bump release and plugin manifests to 4.179.7.

Validation: rebased onto main `ccd7affe` (4.179.0). Full-stack `pnpm verify` passed at #1069: generated-client drift, plugin parity, typecheck, lint, and 9,531 tests. No new matches in the known-client added-line scan. Browser visual recheck pending; newer query-workspace usability changes are a separate follow-up.

Scope: the 10-query limit and bounded-probe preflight are prototype behavior. CLI/API manual-run semantics are unchanged. An official manual-run UI needs a server-bound preflight before it returns.