### PR TITLE
fix(ci): reinstall after the version bump so the IP-range refresh can run

### DIFF
--- a/.github/workflows/refresh-crawler-ip-ranges.yml
+++ b/.github/workflows/refresh-crawler-ip-ranges.yml
@@ -55,6 +55,18 @@ jobs:
           next="$major.$minor.$((patch + 1))"
           npm pkg set "version=$next"
           npm pkg set "version=$next" --prefix packages/canonry
+          # `verifyDepsBeforeRun: error` (pnpm-workspace.yaml) checks every
+          # workspace manifest's name+version against the name+version recorded
+          # in node_modules/.pnpm-workspace-state-v1.json at install time. The
+          # two `npm pkg set` calls above make that snapshot stale, so the very
+          # next `pnpm <script>` — plugin:sync here, then verify and build —
+          # dies with ERR_PNPM_VERIFY_DEPS_BEFORE_RUN. Nothing is actually out
+          # of sync: a workspace version bump cannot move the lockfile, which
+          # records workspace links as `link:` targets, so `--frozen-lockfile`
+          # is a no-op resolution that only rewrites the state file. Keep this
+          # between the bump and the first pnpm script, matching the
+          # bump → install → gates order in bump-aeo-audit.yml.
+          pnpm install --frozen-lockfile
           pnpm plugin:sync
           echo "from=$current" >> "$GITHUB_OUTPUT"
           echo "to=$next" >> "$GITHUB_OUTPUT"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,14 @@ packages:
 #
 # Costs a few hundredths of a second when in sync — the check short-circuits on
 # manifest mtimes and only reads the lockfile when one is newer than the last
-# install. It cannot fire spuriously in CI, where every job installs before it
-# runs anything (.github/actions/setup), and it never blocks `pnpm install`
-# itself, so the remedy it names always works.
+# install. It never blocks `pnpm install` itself, so the remedy it names always
+# works.
+#
+# One CI caveat, learned the hard way: the recorded state includes every
+# workspace project's name AND version, so a job that REWRITES a manifest after
+# .github/actions/setup has installed — `npm pkg set version=…` in
+# refresh-crawler-ip-ranges.yml — invalidates the snapshot even though nothing
+# about the dependency graph moved, and every later `pnpm <script>` in that job
+# dies. Re-run `pnpm install --frozen-lockfile` between the rewrite and the next
+# pnpm script; it is a no-op resolution that just refreshes the state file.
 verifyDepsBeforeRun: error


### PR DESCRIPTION
The crawler IP-range refresh has failed on both scheduled runs since it shipped in #1029, so it has never opened a PR — the fetch works (22 manifests, 0 failed) but the job then dies at `pnpm plugin:sync` with `ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`, because `verifyDepsBeforeRun: error` compares each workspace project's name and version against the install-time snapshot and the bump step's `npm pkg set version=` calls stale it. Adding `pnpm install --frozen-lockfile` between the bump and the first pnpm script fixes it: a workspace version bump cannot move the lockfile (workspace deps are recorded as `link:` targets), so it is a no-op resolution that only rewrites the state file, restoring the bump → install → gates order `bump-aeo-audit.yml` already uses. This also corrects the `pnpm-workspace.yaml` comment that claimed the check could not fire spuriously in CI. Verified by reproducing the failure on a clean tree, then running the exact fixed step body and a full `pnpm verify`.

Two publisher updates blocked by this are still pending — `anthropic.json` 23 → 26 prefixes and `ccbot.json` 6 → 5 — and will land on the next run, which can be triggered via `workflow_dispatch` once this merges.