### PR TITLE
fix(report): stop reporting absent measurements as findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.180.0",
+  "version": "4.180.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -1814,20 +1814,44 @@ function buildReportActionPlan(input: ReportActionPlanInput): ReportActionPlanIt
   }
 
   if (actions.length === 0) {
+    // An empty action list has TWO causes that read identically and mean
+    // opposite things: everything was checked and came back clean, or nothing
+    // was ever checked. The single copy below assumed the first. On a project
+    // with no snapshots it told the reader that no issues "were detected",
+    // which is a finding the evidence cannot support, and paired it with
+    // "keep monitoring" and "the NEXT check" for a project that has never had
+    // a first one. No provider snapshots means nothing could be detected
+    // either way, so say that instead.
+    const neverMeasured = input.citationScorecard.providers.length === 0
     actions.push({
       audience: 'both',
       priority: 90,
       horizon: 'short-term',
       category: 'monitoring',
-      title: 'Keep monitoring citation and mention coverage',
-      action: 'Run the next scheduled check and watch for citation gains, losses, and engine-specific misses.',
-      why: [
-        'No urgent corrective action surfaced from the current evidence.',
-        'AEO performance is directional; repeated checks are needed before overreacting to a single sample.',
+      title: neverMeasured
+        ? 'Run the first visibility check'
+        : 'Keep monitoring citation and mention coverage',
+      action: neverMeasured
+        ? 'Run an answer-visibility check to establish the first citation and mention baseline.'
+        : 'Run the next scheduled check and watch for citation gains, losses, and engine-specific misses.',
+      why: neverMeasured
+        ? [
+            'No answer-engine check has completed for this project, so there is no citation or mention evidence to act on yet.',
+            'The rest of this report can only describe what was measured, and this signal has not been measured once.',
+          ]
+        : [
+            'No urgent corrective action surfaced from the current evidence.',
+            'AEO performance is directional; repeated checks are needed before overreacting to a single sample.',
+          ],
+      evidence: [
+        neverMeasured
+          ? 'No completed answer-engine snapshots exist for this project, so nothing could be detected either way.'
+          : 'No critical insights, content gaps, indexing blockers, or provider-zero issues were detected in this report.',
       ],
-      evidence: ['No critical insights, content gaps, indexing blockers, or provider-zero issues were detected in this report.'],
-      successMetric: 'Coverage stays stable or improves across the next trend window.',
-      confidence: 'medium',
+      successMetric: neverMeasured
+        ? 'A first check completes and produces a citation and mention baseline.'
+        : 'Coverage stays stable or improves across the next trend window.',
+      confidence: neverMeasured ? 'high' : 'medium',
     })
   }
 
@@ -1927,14 +1951,33 @@ function buildAgencyDiagnostics(input: ReportActionPlanInput & {
   }
 
   if (input.indexingHealth) {
+    // `indexedPct` falls back to 0 when NOTHING was inspected, which is
+    // indistinguishable from a measured 0%. Rendered as a percentage it stated
+    // "0% of inspected URLs are indexed" at NEGATIVE severity for a project
+    // that had simply never been inspected: a red flag manufactured out of no
+    // measurement, and the first thing a new client would read. The sibling
+    // gate on this same metric already guards `total > 0`; this one did not.
+    const inspected = input.indexingHealth.total > 0
+    const provider = input.indexingHealth.provider ?? 'the connected provider'
     diagnostics.push({
       title: 'Indexing health',
-      detail: `${input.indexingHealth.indexedPct}% of inspected URLs are indexed in ${input.indexingHealth.provider ?? 'the connected provider'}.`,
-      severity: input.indexingHealth.indexedPct >= 90 ? 'positive' : input.indexingHealth.indexedPct >= 70 ? 'caution' : 'negative',
-      evidence: [
-        `${input.indexingHealth.indexed}/${input.indexingHealth.total} indexed`,
-        `${input.indexingHealth.notIndexed} not indexed`,
-      ],
+      detail: inspected
+        ? `${input.indexingHealth.indexedPct}% of inspected URLs are indexed in ${provider}.`
+        : `No URLs have been inspected in ${provider} yet, so indexing coverage is not measured.`,
+      // Not measured is not a finding, so it must not carry a finding's tone.
+      severity: !inspected
+        ? 'neutral'
+        : input.indexingHealth.indexedPct >= 90
+          ? 'positive'
+          : input.indexingHealth.indexedPct >= 70
+            ? 'caution'
+            : 'negative',
+      evidence: inspected
+        ? [
+            `${input.indexingHealth.indexed}/${input.indexingHealth.total} indexed`,
+            `${input.indexingHealth.notIndexed} not indexed`,
+          ]
+        : ['0 URLs inspected'],
     })
   }
 

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -203,6 +203,96 @@ describe('GET /api/v1/projects/:name/report', () => {
     expect(body.agencyDiagnostics.priorities.length).toBeGreaterThan(0)
   })
 
+  /**
+   * A coverage snapshot exists as soon as GSC has been synced once, so
+   * `indexingHealth` goes non-null well before any URL has been INSPECTED.
+   * With nothing inspected `indexedPct` falls back to 0, which is
+   * indistinguishable from a measured 0%, and the diagnostic stated
+   * "0% of inspected URLs are indexed" at NEGATIVE severity — a red flag
+   * manufactured out of no measurement, hitting every new client before their
+   * first inspection run.
+   */
+  test('indexing health reports nothing inspected as unmeasured, not as 0% indexed', async () => {
+    const projectId = insertProject(ctx.db, 'no-inspections')
+    ctx.db.insert(gscCoverageSnapshots).values({
+      id: crypto.randomUUID(),
+      projectId,
+      syncRunId: null,
+      date: '2026-04-30',
+      indexed: 0,
+      notIndexed: 0,
+      reasonBreakdown: {},
+      createdAt: new Date().toISOString(),
+    }).run()
+    await ctx.app.ready()
+
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/no-inspections/report' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    const diag = body.agencyDiagnostics.diagnostics.find((d) => d.title === 'Indexing health')
+    expect(diag).toBeDefined()
+    // Not measured is not a finding, so it must not carry a finding's tone.
+    expect(diag!.severity).toBe('neutral')
+    expect(diag!.detail).toMatch(/not measured/i)
+    // The exact false claim that shipped.
+    expect(diag!.detail).not.toMatch(/0% of inspected URLs are indexed/)
+    expect(diag!.evidence.join(' ')).not.toContain('0/0 indexed')
+  })
+
+  /**
+   * The counterpart, and the one that makes the fix safe: a REAL 0% indexed is
+   * a genuine emergency and must still fire at negative severity. Suppressing
+   * the zero rather than the unmeasured case would hide it.
+   */
+  test('indexing health still reports a genuine 0% indexed as negative', async () => {
+    const projectId = insertProject(ctx.db, 'really-zero')
+    ctx.db.insert(gscCoverageSnapshots).values({
+      id: crypto.randomUUID(),
+      projectId,
+      syncRunId: null,
+      date: '2026-04-30',
+      indexed: 0,
+      notIndexed: 12,
+      reasonBreakdown: {},
+      createdAt: new Date().toISOString(),
+    }).run()
+    await ctx.app.ready()
+
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/really-zero/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+    const diag = body.agencyDiagnostics.diagnostics.find((d) => d.title === 'Indexing health')
+    expect(diag).toBeDefined()
+    expect(diag!.severity).toBe('negative')
+    expect(diag!.detail).toMatch(/0% of inspected URLs are indexed/)
+    expect(diag!.evidence.join(' ')).toContain('0/12 indexed')
+  })
+
+  /**
+   * An empty action list has two causes that read identically and mean opposite
+   * things: everything was checked and came back clean, or nothing was ever
+   * checked. The fallback assumed the first, so a project with no snapshots was
+   * told no issues "were detected" — a finding the evidence cannot support —
+   * and asked to keep monitoring and run "the NEXT" check before it had a first.
+   */
+  test('a never-measured project is not given a clean bill of health', async () => {
+    insertProject(ctx.db, 'never-swept')
+    await ctx.app.ready()
+
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/never-swept/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.citationScorecard.providers).toEqual([])
+    const monitoring = body.actionPlan.find((a) => a.category === 'monitoring')
+    expect(monitoring).toBeDefined()
+    expect(monitoring!.title).toBe('Run the first visibility check')
+    // The claim that could not be supported.
+    expect(monitoring!.evidence.join(' ')).not.toMatch(/were detected in this report/)
+    expect(monitoring!.evidence.join(' ')).toMatch(/nothing could be detected/i)
+    // And it must not imply a check has already been happening.
+    expect(monitoring!.action).not.toMatch(/next scheduled check/)
+  })
+
   test('citation scorecard reflects query × provider matrix', async () => {
     const projectId = insertProject(ctx.db, 'scorecard')
     const kwA = insertQuery(ctx.db, projectId, 'aeo platform')

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.180.0",
+  "version": "4.180.1",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.180.0",
+  "version": "4.180.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.180.0",
+  "version": "4.180.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.180.0",
+  "version": "4.180.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Two places in the report stated a finding the evidence could not support when a project had simply not been measured yet. Both were found by generating a real report for a project that has no sweeps, no Search Console data, and no traffic source.

**Indexing health.** `indexedPct` falls back to `0` when nothing has been inspected, which is indistinguishable from a measured 0%. A coverage snapshot exists as soon as Search Console syncs once, well before any URL is inspected, so the diagnostic rendered "0% of inspected URLs are indexed" at **negative** severity for a project that had never been inspected, with evidence "0/0 indexed". That is a red flag manufactured out of no measurement, and it fires for any new project before its first inspection run. It now reports unmeasured at `neutral` severity. The sibling gate on this same metric already guarded `total > 0`; this one did not. A genuine 0% indexed still reports `negative` and has its own test, so the fix cannot hide a real emergency.

**Action plan fallback.** An empty action list has two causes that read identically and mean opposite things: everything was checked and came back clean, or nothing was ever checked. The copy assumed the first, so a project with no snapshots was told that no issues "were detected", and was asked to keep monitoring and run "the next" scheduled check before it had had a first one.

Both strings come from the DTO rather than either renderer, so the HTML and SPA surfaces move together and report parity is unaffected.

Tests: unmeasured vs genuine-zero indexing, and the never-measured action plan. Each was mutation-checked by reverting its fix individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)