### PR TITLE
fix(traffic): keep Vercel sources healthy after retention backfill

### DIFF
--- a/apps/web/src/components/server-traffic/ConnectSourceDrawer.tsx
+++ b/apps/web/src/components/server-traffic/ConnectSourceDrawer.tsx
@@ -161,22 +161,26 @@ function WizardHeader({
 }
 
 /**
- * After a source connects, hand off to its detail page: kick off a backfill
- * so the source has historical data without a manual sync, then close the
- * drawer and route to the source detail page where the run is visible.
- * Backfill, not an incremental sync, is the first-load primitive: a sync's
- * default window can overrun an adapter's per-sync page budget.
+ * After a source connects, hand off to its detail page. Adapters with a safe
+ * initial history window can kick off a backfill before navigation; adapters
+ * with retention-limited history capture forward traffic and leave history as
+ * an explicit operator action.
  *
- * Rejects if the backfill kickoff fails. A failed kickoff creates no run
+ * Rejects if a requested backfill kickoff fails. A failed kickoff creates no run
  * row, so the caller keeps the drawer open and shows the error instead of
- * routing to a detail page with nothing on it. `afterBackfillStarted` runs
- * only once the kickoff has succeeded.
+ * routing to a detail page with nothing on it. `afterConnected` runs only
+ * once the optional kickoff has succeeded.
  */
 function useConnectedSourceHandoff(projectName: string, onClose: () => void) {
   const navigate = useNavigate()
-  return async (sourceId: string, afterBackfillStarted?: () => void) => {
-    await triggerServerTrafficBackfill(projectName, sourceId)
-    afterBackfillStarted?.()
+  return async (
+    sourceId: string,
+    options: { startInitialBackfill: boolean; afterConnected?: () => void },
+  ) => {
+    if (options.startInitialBackfill) {
+      await triggerServerTrafficBackfill(projectName, sourceId)
+    }
+    options.afterConnected?.()
     onClose()
     void navigate({
       to: '/traffic/$projectName/$sourceId',
@@ -200,7 +204,9 @@ function useConnectFlow(projectName: string, onClose: () => void) {
     validate: () => string | null
     /** Fire the typed connect mutation and resolve with the created source. */
     mutate: () => Promise<{ id: string }>
-    /** Runs once connect and the backfill kickoff both succeed, e.g. to clear the secret field. */
+    /** Whether this adapter can safely start an implicit history backfill. */
+    startInitialBackfill?: boolean
+    /** Runs once connect and any requested backfill kickoff succeed. */
     onConnected?: () => void
   }) => {
     setError(null)
@@ -218,12 +224,14 @@ function useConnectFlow(projectName: string, onClose: () => void) {
       return
     }
 
-    // The source row exists now. Kick off the backfill and route to its
-    // detail page. A backfill kickoff failure (bad credentials, 5xx,
-    // network) creates no run row, so keep the drawer open and surface the
-    // error rather than routing to a detail page with nothing to show.
+    // The source row exists now. Start history only for adapters that can do
+    // so safely, then route to its detail page. A requested backfill kickoff
+    // failure creates no run row, so keep the drawer open and surface it.
     try {
-      await handoff(source.id, steps.onConnected)
+      await handoff(source.id, {
+        startInitialBackfill: steps.startInitialBackfill ?? true,
+        afterConnected: steps.onConnected,
+      })
     } catch (e) {
       setError(`Source connected, but starting the initial backfill failed: ${extractErrorMessage(e)}`)
     }
@@ -592,6 +600,9 @@ function VercelSourceForm({
           environment,
           displayName: displayName.trim() || undefined,
         }),
+      // New Vercel sources start at NOW so regular sync stays inside upstream
+      // retention. Historical recovery is explicit and user-sized.
+      startInitialBackfill: false,
       // Don't keep the token around in memory after submit.
       onConnected: () => setToken(''),
     })

--- a/apps/web/test/connect-source-drawer.test.tsx
+++ b/apps/web/test/connect-source-drawer.test.tsx
@@ -84,9 +84,8 @@ test('choosing a different source returns to the picker without closing the draw
   expect(screen.queryByText('Connect a Cloud Run service')).toBeNull()
 })
 
-test('connecting a Vercel source closes the drawer and kicks off a backfill', async () => {
+test('connecting a Vercel source closes the drawer without implicitly backfilling history', async () => {
   connectVercelMock.mockResolvedValue({ id: 'src_vercel_1' })
-  backfillMock.mockResolvedValue({ sourceId: 'src_vercel_1', runId: 'run_1', status: 'running' })
 
   renderDrawer()
 
@@ -99,17 +98,14 @@ test('connecting a Vercel source closes the drawer and kicks off a backfill', as
 
   fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
 
-  // A backfill is auto-started for the freshly-connected source.
-  await waitFor(() => {
-    expect(backfillMock).toHaveBeenCalledWith('test-project', 'src_vercel_1')
-  })
-
-  // The drawer closes on success.
+  // The drawer closes on success without starting a retention-limited history
+  // pull. Vercel captures forward traffic until an operator requests history.
   await waitFor(() => {
     expect(screen.queryByText('Connect a Vercel project')).toBeNull()
   })
+  expect(backfillMock).not.toHaveBeenCalled()
 
-  // And routes to the new source's detail page so the backfill is visible.
+  // And routes to the new source's detail page.
   expect(navigateMock).toHaveBeenCalledWith({
     to: '/traffic/$projectName/$sourceId',
     params: { projectName: 'test-project', sourceId: 'src_vercel_1' },
@@ -244,15 +240,18 @@ test('a whitespace-only team ID is caught by the validation chain', async () => 
 })
 
 test('a backfill kickoff failure keeps the drawer open and surfaces the error', async () => {
-  connectVercelMock.mockResolvedValue({ id: 'src_vercel_1' })
+  connectCloudRunMock.mockResolvedValue({ id: 'src_cr_1' })
   backfillMock.mockRejectedValue(new Error('500 internal'))
 
   renderDrawer()
 
-  fireEvent.click(screen.getByText('Vercel'))
-  fireEvent.change(screen.getByPlaceholderText(/prj_/i), { target: { value: 'prj_abc' } })
-  fireEvent.change(screen.getByLabelText(/team \/ account id/i), { target: { value: 'org_xyz' } })
-  fireEvent.change(screen.getByLabelText(/personal access token/i), { target: { value: 'vcp_secret' } })
+  fireEvent.click(screen.getByText('Google Cloud Run'))
+  fireEvent.change(screen.getByLabelText(/^GCP project ID/i), {
+    target: { value: 'my-prod-foo' },
+  })
+  fireEvent.change(screen.getByPlaceholderText(/service_account/i), {
+    target: { value: '{"type":"service_account"}' },
+  })
 
   fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
 
@@ -262,6 +261,6 @@ test('a backfill kickoff failure keeps the drawer open and surfaces the error', 
   await waitFor(() => {
     expect(screen.getByText(/starting the initial backfill failed: 500 internal/i)).toBeTruthy()
   })
-  expect(screen.getByText('Connect a Vercel project')).toBeTruthy()
+  expect(screen.getByText('Connect a Cloud Run service')).toBeTruthy()
   expect(navigateMock).not.toHaveBeenCalled()
 })

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -3957,13 +3957,13 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
 
     const windowEnd = new Date()
     const requestedWindowStartMs = windowEnd.getTime() - appliedDays * 86_400_000
-    // Backfill rollups are hourly, so use a whole-hour lower bound. Round
-    // forward rather than back: the previous floor reached up to 59 minutes
-    // *before* the operator's requested lookback, which could turn an
-    // otherwise supported Vercel retention window into a 400. Starting at the
-    // next hour also keeps replacement inserts disjoint from the partial
-    // boundary bucket that remains outside the delete range.
-    const windowStart = new Date(Math.ceil(requestedWindowStartMs / 3_600_000) * 3_600_000)
+    // Backfill rollups are hourly, so replace the full lower-bound bucket.
+    // Rounding forward would silently omit up to 59 minutes while still
+    // reporting the requested number of days. A retention-limited adapter must
+    // reject the full-bucket pull instead; the failed run preserves both the
+    // existing rollups and the connected source state.
+    const windowStart = new Date(requestedWindowStartMs)
+    windowStart.setUTCMinutes(0, 0, 0)
 
     // Build the per-source-type window pull closure. Credential and config
     // validation happens up-front (synchronously throws validationError on

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -1015,12 +1015,22 @@ function bindTrafficSyncSchedule(
   return { changed: true, created: true }
 }
 
-function vercelRetentionClampError(requestedStartMs: number, effectiveStartMs: number): Error {
-  return new Error(
-    `Vercel request-logs retention starts at ${new Date(effectiveStartMs).toISOString()}, `
-      + `after requested start ${new Date(requestedStartMs).toISOString()}; refusing to advance `
-      + 'because historical traffic would be skipped',
-  )
+class VercelRetentionClampError extends Error {
+  constructor(requestedStartMs: number, effectiveStartMs: number) {
+    super(
+      `Vercel request-logs retention starts at ${new Date(effectiveStartMs).toISOString()}, `
+        + `after requested start ${new Date(requestedStartMs).toISOString()}; refusing to advance `
+        + 'because historical traffic would be skipped',
+    )
+    this.name = 'VercelRetentionClampError'
+  }
+}
+
+function vercelRetentionClampError(
+  requestedStartMs: number,
+  effectiveStartMs: number,
+): VercelRetentionClampError {
+  return new VercelRetentionClampError(requestedStartMs, effectiveStartMs)
 }
 
 interface RunBackfillTaskOptions {
@@ -1056,7 +1066,7 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
     pullErrorPrefix,
   } = options
 
-  const markFailed = (msg: string) => {
+  const markFailed = (msg: string, preserveSourceState = false) => {
     const failedAt = new Date().toISOString()
     try {
       app.db.transaction((tx) => {
@@ -1067,7 +1077,8 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
           .run()
         const latestSource = tx.select().from(trafficSources)
           .where(eq(trafficSources.id, sourceRow.id)).get()
-        if (latestSource
+        if (!preserveSourceState
+          && latestSource
           && isAuthoritativeTrafficSource(tx, latestSource)
           && isSameTrafficSourceGeneration(latestSource, sourceRow)) {
           tx
@@ -1097,7 +1108,14 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
   try {
     allEvents = await pullForBackfill()
   } catch (e) {
-    markFailed(`${pullErrorPrefix}: ${describeError(e)}`)
+    // A Vercel retention miss is a rejected optional historical recovery, not
+    // a problem with the already-connected source. The failed run records the
+    // exact range, while the existing source state is left intact so its
+    // regular forward sync remains healthy.
+    markFailed(
+      `${pullErrorPrefix}: ${describeError(e)}`,
+      e instanceof VercelRetentionClampError,
+    )
     return
   }
 
@@ -3938,14 +3956,14 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     const appliedDays = Math.min(requestedDays, MAX_BACKFILL_DAYS)
 
     const windowEnd = new Date()
-    const windowStart = new Date(windowEnd.getTime() - appliedDays * 86_400_000)
-    // Floor windowStart to the hour boundary so the boundary hour is fully
-    // replaced. Rollup `tsHour` is hour-truncated, so a raw mid-hour
-    // windowStart would leave an existing bucket at floor(windowStart, hour)
-    // outside the delete range while the new pull re-emits a bucket at the
-    // same tsHour, tripping the composite primary key on (projectId,
-    // sourceId, tsHour, botId, verificationStatus, pathNormalized, status).
-    windowStart.setUTCMinutes(0, 0, 0)
+    const requestedWindowStartMs = windowEnd.getTime() - appliedDays * 86_400_000
+    // Backfill rollups are hourly, so use a whole-hour lower bound. Round
+    // forward rather than back: the previous floor reached up to 59 minutes
+    // *before* the operator's requested lookback, which could turn an
+    // otherwise supported Vercel retention window into a 400. Starting at the
+    // next hour also keeps replacement inserts disjoint from the partial
+    // boundary bucket that remains outside the delete range.
+    const windowStart = new Date(Math.ceil(requestedWindowStartMs / 3_600_000) * 3_600_000)
 
     // Build the per-source-type window pull closure. Credential and config
     // validation happens up-front (synchronously throws validationError on

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -3376,6 +3376,10 @@ describe('POST /traffic/sources/:id/sync — WordPress', () => {
 })
 
 describe('POST /traffic/sources/:id/backfill', () => {
+  // The boundary-hour case below pins Date. Restore it even if harness setup
+  // fails before that test reaches its local cleanup.
+  afterEach(() => { vi.useRealTimers() })
+
   // Helper that polls the run row until status moves off 'running' or
   // the timeout trips, so async tests don't depend on internal scheduling.
   async function waitForRunComplete(
@@ -3838,49 +3842,35 @@ describe('POST /traffic/sources/:id/backfill', () => {
     }
   })
 
-  it('uses the next full hour so a Vercel retention boundary is never rounded backward', async () => {
-    // Fake only Date so the retention boundary and submitted window are exact
-    // while Fastify and the polling helper keep using real timers.
+  it('replaces the full boundary hour without shortening the requested lookback', async () => {
+    // Fake only Date so the submitted window is exact while Fastify and the
+    // polling helper keep using real timers.
     vi.useFakeTimers({ toFake: ['Date'] })
     vi.setSystemTime(new Date('2026-05-08T12:30:00.000Z'))
 
     const rawWindowStart = new Date(Date.now() - 86_400_000) // matches days=1
     const boundaryHour = new Date(rawWindowStart)
     boundaryHour.setUTCMinutes(0, 0, 0)
-    boundaryHour.setUTCHours(boundaryHour.getUTCHours() + 1)
     const boundaryHourIso = boundaryHour.toISOString()
-    // New event sits inside the first fully-covered hour. An existing bucket
-    // at that hour must be replaced rather than causing a composite-key clash.
-    const eventInBoundaryHour = new Date(boundaryHour.getTime() + 35 * 60_000).toISOString()
+    // This event is inside the requested lookback and its lower boundary hour.
+    // A forward-rounded start would skip it and leave the stale seeded bucket
+    // behind.
+    const eventInBoundaryHour = new Date(boundaryHour.getTime() + 45 * 60_000).toISOString()
 
     const events: NormalizedTrafficRequest[] = [
-      buildVercelEvent({
+      buildEvent({
         userAgent: 'GPTBot/1.0',
         path: '/blog/foo',
         status: 200,
         observedAt: eventInBoundaryHour,
       }),
     ]
-    const h = await buildHarness([], {
-      vercelPullPages: ({ startDate, endDate }) => {
-        const eventsInWindow = events.filter((event) => {
-          const observedMs = new Date(event.observedAt).getTime()
-          return observedMs >= startDate && observedMs < endDate
-        })
-        return {
-          events: eventsInWindow,
-          rawEntryCount: eventsInWindow.length,
-          skippedEntryCount: 0,
-          hasMore: false,
-          endpoint: '',
-        }
-      },
-    })
+    const h = await buildHarness(events)
     try {
       const connectRes = await h.app.inject({
         method: 'POST',
-        url: '/api/v1/projects/test-project/traffic/connect/vercel',
-        payload: { projectId: 'prj_hour_ceiling', teamId: 'team_hour_ceiling', token: 'vercel-secret' },
+        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
+        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
       })
       const source = JSON.parse(connectRes.payload)
 
@@ -3919,7 +3909,6 @@ describe('POST /traffic/sources/:id/backfill', () => {
       // Replaced (1), not the seeded 5 nor the additive 6.
       expect(buckets[0].hits).toBe(1)
     } finally {
-      vi.useRealTimers()
       await h.close()
     }
   })

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -1702,8 +1702,8 @@ describe('POST /traffic/sources/:id/backfill — Vercel', () => {
     runId: string,
     timeoutMs = 2000,
   ): Promise<typeof runs.$inferSelect> {
-    const deadline = Date.now() + timeoutMs
-    while (Date.now() < deadline) {
+    const deadline = performance.now() + timeoutMs
+    while (performance.now() < deadline) {
       const row = db.select().from(runs).where(eq(runs.id, runId)).get()
       if (row && row.status !== RunStatuses.running) return row
       await new Promise<void>((resolve) => setTimeout(resolve, 25))
@@ -1912,7 +1912,11 @@ describe('POST /traffic/sources/:id/backfill — Vercel', () => {
       expect(finalRun.error).toMatch(/refusing to advance/)
 
       const sourceRow = h.db.select().from(trafficSources).where(eq(trafficSources.id, sourceId)).get()!
-      expect(sourceRow.status).toBe(TrafficSourceStatuses.error)
+      // Retention is a limit on this optional historical recovery, not a
+      // broken Vercel connection. The run records the failed range while the
+      // source remains ready for forward sync.
+      expect(sourceRow.status).toBe(TrafficSourceStatuses.connected)
+      expect(sourceRow.lastError).toBeNull()
       // The failed backfill must not advance lastSyncedAt past the connect-time value.
       expect(sourceRow.lastSyncedAt).toBe(connectSyncedAt)
       expect(h.db.select().from(crawlerEventsHourly).all()).toEqual([])
@@ -3379,8 +3383,8 @@ describe('POST /traffic/sources/:id/backfill', () => {
     runId: string,
     timeoutMs = 2000,
   ): Promise<typeof runs.$inferSelect> {
-    const deadline = Date.now() + timeoutMs
-    while (Date.now() < deadline) {
+    const deadline = performance.now() + timeoutMs
+    while (performance.now() < deadline) {
       const row = db.select().from(runs).where(eq(runs.id, runId)).get()
       if (row && row.status !== RunStatuses.running) return row
       await new Promise<void>((resolve) => setTimeout(resolve, 25))
@@ -3834,33 +3838,49 @@ describe('POST /traffic/sources/:id/backfill', () => {
     }
   })
 
-  it('replaces the boundary-hour bucket cleanly when windowStart falls mid-hour', async () => {
-    // Without hour-flooring, an existing bucket at floor(windowStart, hour)
-    // has tsHour < raw windowStart so the delete misses it, but the new pull
-    // re-emits a bucket at the same tsHour — the plain insert then trips the
-    // composite primary key and rolls the whole transaction back.
-    const now = Date.now()
-    const rawWindowStart = new Date(now - 86_400_000) // matches days=1
+  it('uses the next full hour so a Vercel retention boundary is never rounded backward', async () => {
+    // Fake only Date so the retention boundary and submitted window are exact
+    // while Fastify and the polling helper keep using real timers.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-05-08T12:30:00.000Z'))
+
+    const rawWindowStart = new Date(Date.now() - 86_400_000) // matches days=1
     const boundaryHour = new Date(rawWindowStart)
     boundaryHour.setUTCMinutes(0, 0, 0)
+    boundaryHour.setUTCHours(boundaryHour.getUTCHours() + 1)
     const boundaryHourIso = boundaryHour.toISOString()
-    // New event sits inside the boundary hour, after raw windowStart.
+    // New event sits inside the first fully-covered hour. An existing bucket
+    // at that hour must be replaced rather than causing a composite-key clash.
     const eventInBoundaryHour = new Date(boundaryHour.getTime() + 35 * 60_000).toISOString()
 
     const events: NormalizedTrafficRequest[] = [
-      buildEvent({
+      buildVercelEvent({
         userAgent: 'GPTBot/1.0',
         path: '/blog/foo',
         status: 200,
         observedAt: eventInBoundaryHour,
       }),
     ]
-    const h = await buildHarness(events, { bypassTimeFilter: true })
+    const h = await buildHarness([], {
+      vercelPullPages: ({ startDate, endDate }) => {
+        const eventsInWindow = events.filter((event) => {
+          const observedMs = new Date(event.observedAt).getTime()
+          return observedMs >= startDate && observedMs < endDate
+        })
+        return {
+          events: eventsInWindow,
+          rawEntryCount: eventsInWindow.length,
+          skippedEntryCount: 0,
+          hasMore: false,
+          endpoint: '',
+        }
+      },
+    })
     try {
       const connectRes = await h.app.inject({
         method: 'POST',
-        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
-        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
+        url: '/api/v1/projects/test-project/traffic/connect/vercel',
+        payload: { projectId: 'prj_hour_ceiling', teamId: 'team_hour_ceiling', token: 'vercel-secret' },
       })
       const source = JSON.parse(connectRes.payload)
 
@@ -3889,6 +3909,7 @@ describe('POST /traffic/sources/:id/backfill', () => {
         payload: { days: 1 },
       })
       const submitted = JSON.parse(submitRes.payload)
+      expect(submitted.windowStart).toBe(boundaryHourIso)
       const finalRun = await waitForRunComplete(h.db, submitted.runId)
       expect(finalRun.status).toBe(RunStatuses.completed)
 
@@ -3898,6 +3919,7 @@ describe('POST /traffic/sources/:id/backfill', () => {
       // Replaced (1), not the seeded 5 nor the additive 6.
       expect(buckets[0].hits).toBe(1)
     } finally {
+      vi.useRealTimers()
       await h.close()
     }
   })


### PR DESCRIPTION
## Summary
- round replace-mode backfill starts forward to the next complete hour so a requested lookback never expands before Vercel request-log retention
- keep an already-connected Vercel source connected when only its optional historical recovery is retention-limited; the failed run retains the exact error
- add regression coverage for both behaviors

## Validation
- `pnpm verify` (716 test files, 9,425 tests)

No API parameters or output fields changed.