### PR TITLE
build(vals): pin both production graphs against the published kit

### DIFF
--- a/apps/vals/ai-visibility-check/AGENTS.md
+++ b/apps/vals/ai-visibility-check/AGENTS.md
@@ -563,6 +563,15 @@ deployment serves reads and skills but refuses to spend.
    first request instead of at the push.
 2. Refresh the production `deno.lock` with `deno check --allow-import main.http.tsx` (plain config, no `--frozen`) and
    commit it. `deno.dev.lock` is separate and is not touched by this.
+
+> **Deno blocks a freshly published version for 24 hours.** `deno check` applies a
+> minimum dependency age policy (default 24h) to reduce supply-chain risk, so the
+> step above fails with "blocked by the minimum dependency age policy" if the kit
+> was published minutes ago. Pass `--min-dep-age 0` to generate the lock anyway —
+> defensible for a first-party package this repo just built and published from a
+> reviewed commit. The override is only needed to CREATE the lock: once the lock
+> pins the version with its integrity hash, `--frozen` resolves from the lock and
+> the policy does not apply, so the deploy workflow needs no flag and no config.
 3. Regenerate the skill mirror with `node scripts/sync-val-town-skills.mjs`.
 4. Run the verification commands above, including `deno task check:prod`.
 5. Run `vt push --dry-run` and review the file plan. A local push reads `.vt/state.json`; CI has none, so the deploy

--- a/apps/vals/brand-perception-check/AGENTS.md
+++ b/apps/vals/brand-perception-check/AGENTS.md
@@ -289,6 +289,15 @@ request.
    the deploy workflow fail closed.
 3. **Create the production `deno.lock`** with `deno check --allow-import main.http.tsx` (plain config, no `--frozen`)
    and commit it. This is only possible after step 2. `deno.dev.lock` is separate and is not touched by this.
+
+> **Deno blocks a freshly published version for 24 hours.** `deno check` applies a
+> minimum dependency age policy (default 24h) to reduce supply-chain risk, so the
+> step above fails with "blocked by the minimum dependency age policy" if the kit
+> was published minutes ago. Pass `--min-dep-age 0` to generate the lock anyway —
+> defensible for a first-party package this repo just built and published from a
+> reviewed commit. The override is only needed to CREATE the lock: once the lock
+> pins the version with its integrity hash, `--frozen` resolves from the lock and
+> the policy does not apply, so the deploy workflow needs no flag and no config.
 4. Regenerate the skill mirror with `node scripts/sync-val-town-skills.mjs`.
 5. Run the verification commands above, including `deno task check:prod`.
 6. Run `vt push --dry-run` and review the file plan.

--- a/apps/vals/brand-perception-check/deno.lock
+++ b/apps/vals/brand-perception-check/deno.lock
@@ -1,22 +1,11 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@canonry/aeo-audit@7.1.0": "7.1.0",
     "npm:@canonry/val-kit@0.1.0": "0.1.0",
-    "npm:@google/genai@1.46.0": "1.46.0",
     "npm:@libsql/client@0.17.2": "0.17.2",
     "npm:hono@4.12.25": "4.12.25"
   },
   "npm": {
-    "@canonry/aeo-audit@7.1.0": {
-      "integrity": "sha512-XwWEfzVqrzBkaCCAe4ficJW52LUhpxzsNF3uB3v3u2RsUHD3nRhv03jSgyTpj7hILTUNJTt8Xqn5HNMgDqX19w==",
-      "dependencies": [
-        "cheerio",
-        "ipaddr.js",
-        "undici"
-      ],
-      "bin": true
-    },
     "@canonry/val-kit@0.1.0": {
       "integrity": "sha512-BEFLIrdOLkwO4I9t1j3OHsl2LYcBP6QLNfSmaJMNo7w7IIrGoCKGmXHg6L1OBmFYFA0RwnXmI9PssRKpDLjtPw==",
       "dependencies": [
@@ -166,57 +155,14 @@
     "bignumber.js@9.3.1": {
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
     },
-    "boolbase@1.0.0": {
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
-    },
     "buffer-equal-constant-time@1.0.1": {
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
-    },
-    "cheerio-select@2.1.0": {
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dependencies": [
-        "boolbase",
-        "css-select",
-        "css-what",
-        "domelementtype",
-        "domhandler",
-        "domutils"
-      ]
-    },
-    "cheerio@1.2.0": {
-      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
-      "dependencies": [
-        "cheerio-select",
-        "dom-serializer",
-        "domhandler",
-        "domutils",
-        "encoding-sniffer",
-        "htmlparser2",
-        "parse5",
-        "parse5-htmlparser2-tree-adapter",
-        "parse5-parser-stream",
-        "undici",
-        "whatwg-mimetype"
-      ]
     },
     "cross-fetch@4.1.0": {
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "dependencies": [
         "node-fetch@2.7.0"
       ]
-    },
-    "css-select@5.2.2": {
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "dependencies": [
-        "boolbase",
-        "css-what",
-        "domhandler",
-        "domutils",
-        "nth-check"
-      ]
-    },
-    "css-what@6.2.2": {
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="
     },
     "data-uri-to-buffer@4.0.1": {
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
@@ -230,52 +176,11 @@
     "detect-libc@2.0.2": {
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
     },
-    "dom-serializer@2.0.0": {
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dependencies": [
-        "domelementtype",
-        "domhandler",
-        "entities@4.5.0"
-      ]
-    },
-    "domelementtype@2.3.0": {
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
-    },
-    "domhandler@5.0.3": {
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dependencies": [
-        "domelementtype"
-      ]
-    },
-    "domutils@3.2.2": {
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dependencies": [
-        "dom-serializer",
-        "domelementtype",
-        "domhandler"
-      ]
-    },
     "ecdsa-sig-formatter@1.0.11": {
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dependencies": [
         "safe-buffer"
       ]
-    },
-    "encoding-sniffer@0.2.1": {
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-      "dependencies": [
-        "iconv-lite",
-        "whatwg-encoding"
-      ]
-    },
-    "entities@4.5.0": {
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
-    },
-    "entities@6.0.1": {
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
-    },
-    "entities@7.0.1": {
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="
     },
     "extend@3.0.2": {
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
@@ -326,30 +231,12 @@
     "hono@4.12.25": {
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="
     },
-    "htmlparser2@10.1.0": {
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "dependencies": [
-        "domelementtype",
-        "domhandler",
-        "domutils",
-        "entities@7.0.1"
-      ]
-    },
     "https-proxy-agent@7.0.6": {
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dependencies": [
         "agent-base",
         "debug"
       ]
-    },
-    "iconv-lite@0.6.3": {
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": [
-        "safer-buffer"
-      ]
-    },
-    "ipaddr.js@2.5.0": {
-      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w=="
     },
     "js-base64@3.9.3": {
       "integrity": "sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g=="
@@ -419,36 +306,11 @@
         "formdata-polyfill"
       ]
     },
-    "nth-check@2.1.1": {
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dependencies": [
-        "boolbase"
-      ]
-    },
     "p-retry@4.6.2": {
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dependencies": [
         "@types/retry",
         "retry"
-      ]
-    },
-    "parse5-htmlparser2-tree-adapter@7.1.0": {
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "dependencies": [
-        "domhandler",
-        "parse5"
-      ]
-    },
-    "parse5-parser-stream@7.1.2": {
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "dependencies": [
-        "parse5"
-      ]
-    },
-    "parse5@7.3.0": {
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dependencies": [
-        "entities@6.0.1"
       ]
     },
     "promise-limit@2.7.0": {
@@ -477,33 +339,17 @@
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
-    "safer-buffer@2.1.2": {
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "tr46@0.0.3": {
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "undici-types@8.3.0": {
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
-    "undici@7.29.0": {
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="
-    },
     "web-streams-polyfill@3.3.3": {
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
     "webidl-conversions@3.0.1": {
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-encoding@3.1.1": {
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dependencies": [
-        "iconv-lite"
-      ],
-      "deprecated": true
-    },
-    "whatwg-mimetype@4.0.0": {
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
     },
     "whatwg-url@5.0.0": {
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",


### PR DESCRIPTION
`@canonry/val-kit@0.1.0` is now on public npm, so the graph each Val actually deploys can resolve for the first time.

- **Brand Perception Check had no production lock at all** — it could not be generated before the publish.
- **AI Visibility Check's predated the kit extraction.** `deno check --frozen --config deno.json` on it failed with `npm package '@canonry/val-kit' does not exist`, so the currently-deployed Val could not have been redeployed either.

Both now pin `npm:@canonry/val-kit@0.1.0` and pass the exact validation the deploy workflow runs — `deno check --frozen`, `deno lint`, and `deno test --frozen` against `deno.json`, 142 and 98 tests.

**One gotcha, now documented in both release orders.** Deno refuses a version published less than 24 hours ago as a supply-chain measure, so generating the locks needed `--min-dep-age 0` — defensible for a first-party package this repo built and published minutes earlier from a reviewed commit. It is needed only to CREATE the lock: once the lock carries the version and its integrity hash, `--frozen` resolves from the lock and the policy does not apply. Verified, so the deploy workflow needs no flag and no config change.

No version bump: lockfiles and docs.

**Still not deployed.** Brand Perception Check needs its Val Town val created and its real ids pinned in place of the placeholders; both deploys need the `VAL_TOWN_API_KEY` secret and their health-URL repository variables, none of which are set today.
