### PR TITLE
fix(vals): pin the real deployment targets, and stop vt rewriting the lock it ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main]
     paths:
-      - '.github/workflows/ci.yml'
+      # Every workflow, not just this one: a change to a deploy workflow is a
+      # change to how something reaches production, and it went unvalidated
+      # while only `ci.yml` was listed.
+      - '.github/workflows/**'
       - '.github/actions/setup/action.yml'
       - '.dockerignore'
       - 'Dockerfile'
@@ -17,6 +20,11 @@ on:
       - 'tsconfig.base.json'
       - 'eslint.config.js'
       - 'scripts/**'
+      # Workspace-level guards live here and belong to no single package.
+      # Without this, a PR that changes only a guard never runs it.
+      - 'test/**'
+      - 'test-setup/**'
+      - 'vitest.config.ts'
       - 'skills/**'
       - 'plugins/**'
       - '.agents/**'
@@ -30,7 +38,10 @@ on:
     # targeting feature branches. This keeps each step of a stack green
     # without waiting until rebase-to-main.
     paths:
-      - '.github/workflows/ci.yml'
+      # Every workflow, not just this one: a change to a deploy workflow is a
+      # change to how something reaches production, and it went unvalidated
+      # while only `ci.yml` was listed.
+      - '.github/workflows/**'
       - '.github/actions/setup/action.yml'
       - '.dockerignore'
       - 'Dockerfile'
@@ -43,6 +54,11 @@ on:
       - 'tsconfig.base.json'
       - 'eslint.config.js'
       - 'scripts/**'
+      # Workspace-level guards live here and belong to no single package.
+      # Without this, a PR that changes only a guard never runs it.
+      - 'test/**'
+      - 'test-setup/**'
+      - 'vitest.config.ts'
       - 'skills/**'
       - 'plugins/**'
       - '.agents/**'

--- a/.github/workflows/deploy-ai-visibility-check.yml
+++ b/.github/workflows/deploy-ai-visibility-check.yml
@@ -28,6 +28,9 @@ jobs:
       # where this Val deploys means editing this reviewed workflow.
       VAL_TOWN_EXPECTED_VAL_ID: b1194860-7c77-41d7-b0b7-f3529a80e15b
       VAL_TOWN_EXPECTED_BRANCH_ID: a4524491-dcb3-470a-a361-437a88df6a63
+      # The name this Val lives under. Pinned so the preflight can refuse a
+      # correctly-formed id that points at some other Val.
+      VAL_TOWN_EXPECTED_VAL_NAME: AI-Visibility-Check
       VAL_TOWN_API_KEY: ${{ secrets.VAL_TOWN_API_KEY }}
       VAL_TOWN_HEALTH_URL: ${{ vars.VAL_TOWN_HEALTH_URL }}
     steps:
@@ -145,9 +148,14 @@ jobs:
           deno lint --config deno.json main.http.tsx src test
           deno test --allow-env --allow-net --allow-import --frozen --config deno.json test
 
+      # `--no-lock` is load-bearing, not tidiness. These run with the Val as the
+      # working directory, so without it Deno resolves vt's OWN dependency graph
+      # (cliffy, @std, ...) into the Val's `deno.lock` — the same file the frozen
+      # check above just validated. The push then ships a lockfile nobody
+      # checked: observed once, 373 lines became 718.
       - name: Preview Val Town file changes
         working-directory: apps/vals/ai-visibility-check
-        run: deno run -A jsr:@valtown/vt@0.1.59 push --dry-run
+        run: deno run --no-lock -A jsr:@valtown/vt@0.1.59 push --dry-run
 
       # vt applies a multi-file mirror rather than an atomic bundle. Retry the
       # same desired state so a transient partial push converges before health
@@ -160,7 +168,7 @@ jobs:
           set -euo pipefail
 
           for attempt in 1 2 3; do
-            if deno run -A jsr:@valtown/vt@0.1.59 push; then
+            if deno run --no-lock -A jsr:@valtown/vt@0.1.59 push; then
               exit 0
             fi
 

--- a/.github/workflows/deploy-brand-perception-check.yml
+++ b/.github/workflows/deploy-brand-perception-check.yml
@@ -26,16 +26,11 @@ jobs:
       # Public, fixed deployment identity, and the ONLY source of it: the state
       # file `vt push` reads is generated from these two ids below, so changing
       # where this Val deploys means editing this reviewed workflow.
-      #
-      # PLACEHOLDERS. This Val does not exist in Val Town yet, and this workflow
-      # must never invent a deployment target — pushing at a Val chosen by
-      # accident is not recoverable from here. Create the Val, then paste its
-      # real IDs in. The first step below refuses to run until you do.
-      VAL_TOWN_EXPECTED_VAL_ID: 00000000-0000-0000-0000-000000000000
-      VAL_TOWN_EXPECTED_BRANCH_ID: 00000000-0000-0000-0000-000000000000
-      # The name the Val is created under. Pinned so the preflight can refuse a
+      VAL_TOWN_EXPECTED_VAL_ID: 801445f4-c67d-433d-af43-92af47fb72c9
+      VAL_TOWN_EXPECTED_BRANCH_ID: 0ff5a62c-67cf-45f9-85df-c272daf0a6a9
+      # The name the Val was created under. Pinned so the preflight can refuse a
       # correctly-formed id that points at some other Val.
-      VAL_TOWN_EXPECTED_VAL_NAME: brand-perception-check
+      VAL_TOWN_EXPECTED_VAL_NAME: Brand-Perception-Check
       VAL_TOWN_API_KEY: ${{ secrets.VAL_TOWN_API_KEY }}
       VAL_TOWN_HEALTH_URL: ${{ vars.VAL_TOWN_BRAND_PERCEPTION_HEALTH_URL }}
     steps:
@@ -172,9 +167,14 @@ jobs:
           deno lint --config deno.json main.http.tsx src test
           deno test --allow-env --allow-net --allow-import --frozen --config deno.json test
 
+      # `--no-lock` is load-bearing, not tidiness. These run with the Val as the
+      # working directory, so without it Deno resolves vt's OWN dependency graph
+      # (cliffy, @std, ...) into the Val's `deno.lock` — the same file the frozen
+      # check above just validated. The push then ships a lockfile nobody
+      # checked: observed once, 373 lines became 718.
       - name: Preview Val Town file changes
         working-directory: apps/vals/brand-perception-check
-        run: deno run -A jsr:@valtown/vt@0.1.59 push --dry-run
+        run: deno run --no-lock -A jsr:@valtown/vt@0.1.59 push --dry-run
 
       # vt applies a multi-file mirror rather than an atomic bundle. Retry the
       # same desired state so a transient partial push converges before health
@@ -187,7 +187,7 @@ jobs:
           set -euo pipefail
 
           for attempt in 1 2 3; do
-            if deno run -A jsr:@valtown/vt@0.1.59 push; then
+            if deno run --no-lock -A jsr:@valtown/vt@0.1.59 push; then
               exit 0
             fi
 

--- a/test/workspace-definition.test.ts
+++ b/test/workspace-definition.test.ts
@@ -18,10 +18,13 @@ import { parse as parseYaml } from 'yaml'
  * `deno.dev.lock`. `deno check --frozen` then fails with a lockfile diff
  * hundreds of lines long, in a job that never touched the Val.
  *
- * The key is easy to commit by accident (it appears in an unrelated `git add`)
- * and expensive to diagnose from the symptom, which is exactly the shape that
- * earns a guard rather than a convention. Run `deno` from inside a Val
- * directory, where its own `deno.json` stops the walk.
+ * There is no reliable way to avoid it. Deno walks UP for npm resolution, so it
+ * finds `pnpm-workspace.yaml` even when invoked from a Val directory that has
+ * its own `deno.json`, and `--no-lock` does not stop it either — both verified.
+ * The remedy is therefore to NOTICE, which is what this guard is for: the key is
+ * easy to sweep into an unrelated `git add` and expensive to diagnose from its
+ * symptom. If `git status` shows `package.json` after any `deno` command, revert
+ * it.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')


### PR DESCRIPTION
The Brand Perception Check Val now exists (`canonry/Brand-Perception-Check`), so both deploy workflows carry real ids instead of placeholders, and both pin the Val NAME so the preflight can refuse a correctly-formed id that points somewhere else.

The preflight's three failure modes are now verified against the **live** API rather than a stub: a branch id borrowed from the sibling Val 404s, a name mismatch refuses, and an unknown val id refuses. The first of those is the unrecoverable mistake — it would have pushed this Val's code over the live AI Visibility Check.

**`--no-lock` is the real fix here, and it is not tidiness.** Both `vt` invocations run with the Val as the working directory, so Deno resolved vt's OWN dependency graph — cliffy, `@std`, the whole CLI — into the Val's `deno.lock`: the same file `deno check --frozen` had validated two steps earlier. The push then shipped a lockfile nobody had checked. Observed on the first real push: 373 lines became 718, and the deployed Val carried them until it was pushed again. A guard that validates one artifact while a different one ships is not a guard.

Also corrects the workspace-definition guard's explanation. It claimed running Deno from inside a Val directory avoids the `pnpm-workspace.yaml` migration. It does not — Deno walks up for npm resolution and rewrote root `package.json` again from within a Val, with `--no-lock` set. There is no avoidance, only noticing, which is what the guard is for.

No version bump: workflows, a test comment, and no published package source.

**Deployment state.** Brand Perception Check is pushed and healthy. It serves reads and skills but refuses to spend until its Val Town environment variables are set (`VAL_TOWN_ENV`, `GEMINI_API_KEY`, `CANONRY_QUOTA_SALT`, and the Turnstile trio, whose `TURNSTILE_ALLOWED_HOSTNAMES` needs this Val's hostname added). AI Visibility Check is still serving pre-kit code and moves onto the published kit on its next deploy.
