### PR TITLE
feat(health): report build commit and instance identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1142,11 +1142,23 @@ All API routes in `packages/api-routes/` are registered via a Fastify plugin wit
 
 ### Health endpoint
 
-The `/health` endpoint exposes `basePath` in its response for auto-discovery:
+`GET /health` (also served at `<basePath>health`) exposes `basePath` for auto-discovery and identifies the build and the deployment it is running as:
 ```json
-{ "status": "ok", "service": "canonry", "version": "1.26.1", "basePath": "/canonry" }
+{
+  "status": "ok",
+  "service": "canonry",
+  "version": "4.193.0",
+  "commit": "eed745d5c1f0a4b6e2d8c9a7b3f1e0d2c4b6a8f0",
+  "instance": { "name": "gjelina-demo", "role": "client-demo" },
+  "basePath": "/canonry"
+}
 ```
-When `basePath` is not configured, the `basePath` field is omitted.
+Every field after `version` is optional and is omitted rather than nulled, so consumers key on presence. Adding fields here is fine; renaming or removing one is a breaking change (see "API Stability").
+
+- `commit`: the git sha the bundle was built from. `packages/canonry/tsup.config.ts` stamps it at build time from `git rev-parse HEAD` (`packages/canonry/scripts/build-commit.ts`). A build without git omits the stamp and the server falls back to the `CANONRY_COMMIT` env var at runtime; unset as well means the field is omitted.
+- `instance`: read at boot from `CANONRY_INSTANCE` (`name`) and `CANONRY_INSTANCE_ROLE` (`role`). Omitted entirely when `CANONRY_INSTANCE` is unset; `role` is dropped when its var is unset. Role is free text, but use the convention so fleet tooling can group on it: `internal` (our own engines), `client-demo` (a prospect's demo tenant), `client-trial` (a client on trial), `preview` (a branch or PR preview).
+- `basePath`: omitted when not configured.
+- `updateAvailable`: `{ current, latest, url, upgradeCommand }` when a newer `@canonry/canonry` is on npm (`packages/canonry/src/update-check.ts`); omitted otherwise, or when the check is opted out.
 
 ### Web UI — use `window.__CANONRY_CONFIG__.basePath`
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -308,6 +308,12 @@ Example with env vars (useful for systemd units, Docker, etc.):
 CANONRY_PORT=4100 CANONRY_BASE_PATH=/canonry/ canonry serve
 ```
 
+Deployment identity is env-only and is reported by `GET /health`: `CANONRY_INSTANCE` names the instance, `CANONRY_INSTANCE_ROLE` tags what it is for (convention: `internal`, `client-demo`, `client-trial`, `preview`), and `CANONRY_COMMIT` supplies the build commit when the bundle was built without git. See "Health endpoint" in `AGENTS.md` for the response shape.
+
+```bash
+CANONRY_INSTANCE=gjelina-demo CANONRY_INSTANCE_ROLE=client-demo canonry serve
+```
+
 ---
 
 ## Tailscale

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.192.3",
+  "version": "4.193.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.192.3",
+  "version": "4.193.0",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/scripts/build-commit.ts
+++ b/packages/canonry/scripts/build-commit.ts
@@ -1,0 +1,36 @@
+/**
+ * Build-time helper: the git commit the bundle is built from.
+ *
+ * `packages/canonry/tsup.config.ts` stamps the result into the bundle as
+ * `__CANONRY_BUILD_COMMIT__` so a running engine can report it at GET /health
+ * (`commit`). Resolution must never fail the build: a machine without a git
+ * binary, a build from an npm tarball, or a vendored copy outside any
+ * repository all yield `undefined`, and the server then falls back to the
+ * `CANONRY_COMMIT` env var at runtime (see `src/instance-identity.ts`).
+ */
+import { execFileSync } from 'node:child_process'
+
+/** sha1 (40 hex) today; sha256 repositories produce 64. */
+const SHA_PATTERN = /^[0-9a-f]{40,64}$/
+
+export interface ReadGitCommitOptions {
+  /** Directory to resolve HEAD from. Defaults to the process cwd. */
+  cwd?: string
+  /** Environment for the git child process (PATH lookup included). Defaults to the process env. */
+  env?: NodeJS.ProcessEnv
+}
+
+export function readGitCommit(opts: ReadGitCommitOptions = {}): string | undefined {
+  try {
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: opts.cwd,
+      env: opts.env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000,
+    }).trim()
+    return SHA_PATTERN.test(sha) ? sha : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/packages/canonry/src/instance-identity.ts
+++ b/packages/canonry/src/instance-identity.ts
@@ -1,0 +1,43 @@
+/**
+ * Self-identification for a running engine, surfaced by GET /health.
+ *
+ * `commit`: the git sha the bundle was built from. tsup stamps it in at build
+ * time as `__CANONRY_BUILD_COMMIT__` (see `../tsup.config.ts` and
+ * `../scripts/build-commit.ts`). The identifier is undefined when the build
+ * ran without git or when the source runs unbundled (tsx, vitest); the
+ * runtime then falls back to `CANONRY_COMMIT`, and omits the field when that
+ * is unset too.
+ *
+ * `instance`: which deployment this is, purely from the runtime environment.
+ * `CANONRY_INSTANCE` names it; `CANONRY_INSTANCE_ROLE` says what kind it is.
+ * Role is free text so an operator can tag a one-off without a code change;
+ * the convention is `internal | client-demo | client-trial | preview`
+ * (documented in AGENTS.md under "Health endpoint").
+ */
+declare const __CANONRY_BUILD_COMMIT__: string | undefined
+
+export interface InstanceIdentity {
+  name: string
+  role?: string
+}
+
+function nonBlank(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+/** Build-time stamp first, `CANONRY_COMMIT` second, otherwise undefined. */
+export function resolveBuildCommit(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  // `typeof` on an undeclared global is safe; a bare read would throw when
+  // the define is absent.
+  const embedded = typeof __CANONRY_BUILD_COMMIT__ === 'string' ? __CANONRY_BUILD_COMMIT__ : undefined
+  return nonBlank(embedded) ?? nonBlank(env.CANONRY_COMMIT)
+}
+
+/** Undefined when `CANONRY_INSTANCE` is unset or blank, so /health omits the field entirely. */
+export function resolveInstanceIdentity(env: NodeJS.ProcessEnv = process.env): InstanceIdentity | undefined {
+  const name = nonBlank(env.CANONRY_INSTANCE)
+  if (!name) return undefined
+  const role = nonBlank(env.CANONRY_INSTANCE_ROLE)
+  return role ? { name, role } : { name }
+}

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -142,6 +142,7 @@ import {
   trackEvent,
 } from "./telemetry.js";
 import { checkLatestVersionForServer } from "./update-check.js";
+import { resolveBuildCommit, resolveInstanceIdentity } from "./instance-identity.js";
 import { JobRunner } from "./job-runner.js";
 import { maybeShowActivationNotice } from './activation-notice.js'
 import { executeGscSync } from "./gsc-sync.js";
@@ -3531,6 +3532,12 @@ export async function createServer(opts: {
   // /health responds in microseconds and never exceeds k8s probe budgets.
   // Opt-out via CANONRY_DISABLE_UPDATE_CHECK=1, DO_NOT_TRACK=1, CI, or
   // updateCheck: false in config.
+  // `commit` (build-time stamp, else CANONRY_COMMIT) and `instance`
+  // (CANONRY_INSTANCE / CANONRY_INSTANCE_ROLE) make a running engine
+  // self-identifying to fleet tooling. Both are fixed for the process lifetime,
+  // so resolve them once here; each is omitted, not nulled, when unknown.
+  const buildCommit = resolveBuildCommit();
+  const instance = resolveInstanceIdentity();
   const healthHandler = () => {
     const update = checkLatestVersionForServer();
     return {
@@ -3538,6 +3545,8 @@ export async function createServer(opts: {
       service: "canonry",
       version: PKG_VERSION,
       mcp: mcpHttpHealth(app, apiPrefix),
+      ...(buildCommit ? { commit: buildCommit } : {}),
+      ...(instance ? { instance } : {}),
       ...(basePath ? { basePath: basePath.replace(/\/$/, "") } : {}),
       ...(update ? { updateAvailable: update } : {}),
     };

--- a/packages/canonry/test/index.test.ts
+++ b/packages/canonry/test/index.test.ts
@@ -1342,7 +1342,10 @@ describe('canonry', () => {
     }
   })
 
-  it('health endpoint returns ok', async () => {
+  it('health endpoint returns ok and omits commit and instance when the env is unset', async () => {
+    vi.stubEnv('CANONRY_COMMIT', undefined)
+    vi.stubEnv('CANONRY_INSTANCE', undefined)
+    vi.stubEnv('CANONRY_INSTANCE_ROLE', undefined)
     const tmpDir = path.join(os.tmpdir(), `canonry-test-${crypto.randomUUID()}`)
     fs.mkdirSync(tmpDir, { recursive: true })
     const dbPath = path.join(tmpDir, 'test.db')
@@ -1378,9 +1381,72 @@ describe('canonry', () => {
         url: '/health',
       })
       expect(res.statusCode).toBe(200)
-      const body = JSON.parse(res.body) as { status: string; basePath?: string }
+      const body = JSON.parse(res.body) as {
+        status: string
+        service: string
+        version: string
+        commit?: string
+        instance?: { name: string; role?: string }
+        basePath?: string
+      }
       expect(body.status).toBe('ok')
+      expect(body.service).toBe('canonry')
+      expect(body.version).toBe(PKG_VERSION)
+      expect(body.commit).toBeUndefined()
+      expect(body.instance).toBeUndefined()
       expect(body.basePath).toBeUndefined()
+    } finally {
+      await app.close()
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('health endpoint reports commit and instance identity from the env', async () => {
+    // Unbundled source carries no tsup build stamp, so CANONRY_COMMIT is the
+    // path a test can reach; the stamp source is covered in instance-identity.test.ts.
+    vi.stubEnv('CANONRY_COMMIT', 'eed745d5c1f0a4b6e2d8c9a7b3f1e0d2c4b6a8f0')
+    vi.stubEnv('CANONRY_INSTANCE', 'gjelina-demo')
+    vi.stubEnv('CANONRY_INSTANCE_ROLE', 'client-demo')
+    const tmpDir = path.join(os.tmpdir(), `canonry-test-${crypto.randomUUID()}`)
+    fs.mkdirSync(tmpDir, { recursive: true })
+    const dbPath = path.join(tmpDir, 'test.db')
+
+    const db = createClient(dbPath)
+    migrate(db)
+
+    const rawKey = `cnry_${crypto.randomBytes(16).toString('hex')}`
+    const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex')
+    db.insert(apiKeys).values({
+      id: crypto.randomUUID(),
+      name: 'test',
+      keyHash,
+      keyPrefix: rawKey.slice(0, 9),
+      scopes: ['*'],
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const app = await createServer({
+      config: {
+        apiUrl: 'http://localhost:4100',
+        database: dbPath,
+        apiKey: rawKey,
+        geminiApiKey: 'test-key',
+      },
+      db,
+      logger: false,
+    })
+
+    try {
+      const res = await app.inject({ method: 'GET', url: '/health' })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.body) as {
+        status: string
+        commit?: string
+        instance?: { name: string; role?: string }
+      }
+      expect(body.status).toBe('ok')
+      expect(body.commit).toBe('eed745d5c1f0a4b6e2d8c9a7b3f1e0d2c4b6a8f0')
+      expect(body.instance).toEqual({ name: 'gjelina-demo', role: 'client-demo' })
     } finally {
       await app.close()
       fs.rmSync(tmpDir, { recursive: true, force: true })

--- a/packages/canonry/test/instance-identity.test.ts
+++ b/packages/canonry/test/instance-identity.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readGitCommit } from '../scripts/build-commit.js'
+import { resolveBuildCommit, resolveInstanceIdentity } from '../src/instance-identity.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+describe('readGitCommit (build-time stamp source)', () => {
+  it('returns the checkout HEAD sha', () => {
+    const expected = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: here, encoding: 'utf8' }).trim()
+    expect(expected).toMatch(/^[0-9a-f]{40,64}$/)
+    expect(readGitCommit({ cwd: here })).toBe(expected)
+  })
+
+  it('returns undefined outside a repository instead of throwing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-no-repo-'))
+    try {
+      // Ceiling at the temp root so git cannot discover a repository above it
+      // on a machine whose tmpdir happens to sit inside a checkout.
+      const env = { ...process.env, GIT_CEILING_DIRECTORIES: path.dirname(dir) }
+      delete env.GIT_DIR
+      expect(readGitCommit({ cwd: dir, env })).toBeUndefined()
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns undefined when no git binary is on PATH instead of throwing', () => {
+    const emptyBin = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-no-git-'))
+    try {
+      expect(readGitCommit({ cwd: here, env: { ...process.env, PATH: emptyBin } })).toBeUndefined()
+    } finally {
+      fs.rmSync(emptyBin, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('resolveBuildCommit', () => {
+  // Unbundled source (vitest) never carries the tsup define, so only the env
+  // fallback is reachable here; the stamp's source is covered above.
+  it('falls back to CANONRY_COMMIT when no build-time commit is stamped', () => {
+    expect(resolveBuildCommit({ CANONRY_COMMIT: 'eed745d5c1f0a4b6e2d8c9a7b3f1e0d2c4b6a8f0' })).toBe(
+      'eed745d5c1f0a4b6e2d8c9a7b3f1e0d2c4b6a8f0',
+    )
+  })
+
+  it('trims whitespace and treats blank or unset as undefined', () => {
+    expect(resolveBuildCommit({ CANONRY_COMMIT: '  abc1234  ' })).toBe('abc1234')
+    expect(resolveBuildCommit({ CANONRY_COMMIT: '   ' })).toBeUndefined()
+    expect(resolveBuildCommit({})).toBeUndefined()
+  })
+})
+
+describe('resolveInstanceIdentity', () => {
+  it('returns name and role when both env vars are set', () => {
+    expect(
+      resolveInstanceIdentity({ CANONRY_INSTANCE: 'gjelina-demo', CANONRY_INSTANCE_ROLE: 'client-demo' }),
+    ).toEqual({ name: 'gjelina-demo', role: 'client-demo' })
+  })
+
+  it('omits role when CANONRY_INSTANCE_ROLE is unset or blank', () => {
+    expect(resolveInstanceIdentity({ CANONRY_INSTANCE: 'agent-node' })).toEqual({ name: 'agent-node' })
+    expect(resolveInstanceIdentity({ CANONRY_INSTANCE: ' agent-node ', CANONRY_INSTANCE_ROLE: ' ' })).toEqual({
+      name: 'agent-node',
+    })
+  })
+
+  it('is undefined when CANONRY_INSTANCE is unset or blank, even with a role', () => {
+    expect(resolveInstanceIdentity({})).toBeUndefined()
+    expect(resolveInstanceIdentity({ CANONRY_INSTANCE_ROLE: 'internal' })).toBeUndefined()
+    expect(resolveInstanceIdentity({ CANONRY_INSTANCE: '', CANONRY_INSTANCE_ROLE: 'internal' })).toBeUndefined()
+  })
+})

--- a/packages/canonry/tsup.config.ts
+++ b/packages/canonry/tsup.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'tsup'
+import { readGitCommit } from './scripts/build-commit.js'
+
+// Stamp the build's git commit into the bundle; GET /health reports it as
+// `commit`. Omitted, never fatal, when git or the repository is absent: the
+// server then falls back to CANONRY_COMMIT at runtime.
+const buildCommit = readGitCommit()
 
 export default defineConfig({
+  define: buildCommit ? { __CANONRY_BUILD_COMMIT__: JSON.stringify(buildCommit) } : {},
   entry: {
     cli: 'src/cli.ts',
     index: 'src/index.ts',

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.192.3",
+  "version": "4.193.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.192.3",
+  "version": "4.193.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.192.3",
+  "version": "4.193.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
`GET /health` identifies the running build and deployment so deployment tooling can verify a commit and distinguish instances sharing a package version.

- Add optional `commit` from a build-time Git stamp, with `CANONRY_COMMIT` as the runtime fallback.
- Add optional `instance: { name, role? }` from `CANONRY_INSTANCE` and `CANONRY_INSTANCE_ROLE`, resolved at server creation.
- Preserve current MCP health metadata and existing response fields. Document the identity settings.
- Rebase onto main `cd66f6345`; update package and plugin versions to `4.193.0`. Merge before #1086 (`4.193.1`).

Validation: 46 health/server/identity tests passed; CLI build passed and its embedded SHA matches the rebased commit. Changed-file lint passed with existing warnings; generated-client, plugin, and Val Town mirror checks passed. Full workspace validation runs in CI.

Docker builds exclude `.git`; deployments must supply `CANONRY_COMMIT` for that fallback. This PR does not change Docker deployment wiring.