### PR TITLE
fix(api): apply the status filter on run list endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.193.0",
+  "version": "4.193.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -16404,9 +16404,13 @@ export type GetApiV1ProjectsByNameRunsData = {
          */
         limit?: number;
         /**
-         * Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response.
+         * Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response. Unknown values are rejected with 400.
          */
-        kind?: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe';
+        kind?: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe' | 'gbp-sync' | 'ads-sync' | 'google-ads-sync' | 'gtm-sync';
+        /**
+         * Restrict results to a single run status, e.g. "running" to find in-flight work or "failed" to triage. Unknown values are rejected with 400 rather than returning an empty list.
+         */
+        status?: 'queued' | 'running' | 'completed' | 'partial' | 'failed' | 'cancelled';
     };
     url: '/api/v1/projects/{name}/runs';
 };
@@ -16515,9 +16519,13 @@ export type GetApiV1RunsData = {
          */
         includeProbe?: string;
         /**
-         * Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response.
+         * Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response. Unknown values are rejected with 400.
          */
-        kind?: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe';
+        kind?: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe' | 'gbp-sync' | 'ads-sync' | 'google-ads-sync' | 'gtm-sync';
+        /**
+         * Restrict results to a single run status, e.g. "running" to find in-flight work or "failed" to triage. Unknown values are rejected with 400 rather than returning an empty list.
+         */
+        status?: 'queued' | 'running' | 'completed' | 'partial' | 'failed' | 'cancelled';
     };
     url: '/api/v1/runs';
 };

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -4,6 +4,8 @@ import {
   AdsAdGroupBillingEventTypes,
   AdsCampaignBiddingTypes,
   AdsOperationStates,
+  runKindSchema,
+  runStatusSchema,
 } from '@ainyc/canonry-contracts'
 import {
   buildComponentSchemas,
@@ -335,26 +337,21 @@ const scheduleExpectedUpdatedAtQueryParameter: OpenApiParameter = {
   schema: { type: 'string', format: 'date-time' },
 }
 
+// Both list filters take their enum from the contracts schema the route
+// validates against, so the spec (and the generated SDK) cannot drift from
+// what the server accepts.
 const runsListKindQueryParameter: OpenApiParameter = {
   name: 'kind',
   in: 'query',
-  description: 'Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response.',
-  schema: {
-    type: 'string',
-    enum: [
-      'answer-visibility',
-      'site-audit',
-      'gsc-sync',
-      'inspect-sitemap',
-      'ga-sync',
-      'bing-inspect',
-      'bing-inspect-sitemap',
-      'backlink-extract',
-      'traffic-sync',
-      'aeo-discover-seed',
-      'aeo-discover-probe',
-    ],
-  },
+  description: 'Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response. Unknown values are rejected with 400.',
+  schema: { type: 'string', enum: [...runKindSchema.options] },
+}
+
+const runsListStatusQueryParameter: OpenApiParameter = {
+  name: 'status',
+  in: 'query',
+  description: 'Restrict results to a single run status, e.g. "running" to find in-flight work or "failed" to triage. Unknown values are rejected with 400 rather than returning an empty list.',
+  schema: { type: 'string', enum: [...runStatusSchema.options] },
 }
 
 const runsListSinceQueryParameter: OpenApiParameter = {
@@ -2220,7 +2217,7 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/runs',
     summary: 'List project runs',
     tags: ['runs'],
-    parameters: [nameParameter, limitQueryParameter, runsListKindQueryParameter],
+    parameters: [nameParameter, limitQueryParameter, runsListKindQueryParameter, runsListStatusQueryParameter],
     responses: {
       200: jsonArrayResponse('Runs returned.', 'RunDto'),
     },
@@ -2245,6 +2242,7 @@ const routeCatalog: OpenApiOperation[] = [
       runsListSinceQueryParameter,
       runsListIncludeProbeQueryParameter,
       runsListKindQueryParameter,
+      runsListStatusQueryParameter,
     ],
     responses: {
       200: jsonArrayResponse('Runs returned.', 'RunDto'),

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -3,13 +3,16 @@ import { and, eq, asc, desc, inArray, or, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { runs, querySnapshots, queries, projects, competitors, parseJsonColumn } from '@ainyc/canonry-db'
 import { compileCompetitiveSignalResolver } from '@ainyc/canonry-intelligence'
-import type { LocationContext, MeasurementExecutionIdentity, MeasurementRunScope } from '@ainyc/canonry-contracts'
+import type { LocationContext, MeasurementExecutionIdentity, MeasurementRunScope, RunListFilterQuery } from '@ainyc/canonry-contracts'
 import {
   AppError as AppErrorClass,
   type AppError,
   measurementRunScopeIsEmpty,
   RunKinds,
   RunTriggers,
+  runKindSchema,
+  runListFilterQuerySchema,
+  runStatusSchema,
   runTriggerRequestSchema,
   noProvider,
   noQueries,
@@ -273,7 +276,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
   // GET /projects/:name/runs — list runs for project
   app.get<{
     Params: { name: string }
-    Querystring: { limit?: string; kind?: string }
+    Querystring: { limit?: string; kind?: string; status?: string }
   }>('/projects/:name/runs', async (request, reply) => {
     const project = resolveProject(app.db, request.params.name)
 
@@ -282,11 +285,13 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
 
     // Per-URL integration runs (bing-inspect especially) can fill the limit
     // window and push answer-visibility runs out — the same footgun GET /runs
-    // guards against. ?kind= scopes the list to the one kind a caller needs.
-    const kind = parseListKind(request.query.kind)
-    const where = kind
-      ? and(eq(runs.projectId, project.id), eq(runs.kind, kind))
-      : eq(runs.projectId, project.id)
+    // guards against. ?kind= scopes the list to the one kind a caller needs;
+    // ?status= to the one status (e.g. `running` for in-flight work).
+    const { kind, status } = parseListFilters(request.query)
+    const filters = [eq(runs.projectId, project.id)]
+    if (kind) filters.push(eq(runs.kind, kind))
+    if (status) filters.push(eq(runs.status, status))
+    const where = and(...filters)
 
     const rows = limit == null
       ? app.db
@@ -364,17 +369,20 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
   //                      can easily fill the 500-row window in <1 hour,
   //                      pushing the answer-visibility runs the dashboard
   //                      actually needs off the response.
+  //   ?status=S        — restrict to a single run status (e.g. 'running' to
+  //                      find in-flight work, 'failed' to triage).
   app.get<{
-    Querystring: { limit?: string; since?: string; includeProbe?: string; kind?: string }
+    Querystring: { limit?: string; since?: string; includeProbe?: string; kind?: string; status?: string }
   }>('/runs', async (request, reply) => {
     const limit = parseListLimit(request.query.limit, 500, 5000)
     const since = parseListSince(request.query.since)
     const includeProbe = request.query.includeProbe === '1' || request.query.includeProbe === 'true'
-    const kind = parseListKind(request.query.kind)
+    const { kind, status } = parseListFilters(request.query)
 
     const filters = [gte(runs.createdAt, since)]
     if (!includeProbe) filters.push(notProbeRun())
     if (kind) filters.push(eq(runs.kind, kind))
+    if (status) filters.push(eq(runs.status, status))
     // A project-scoped key sees ONLY its own project's runs (this global list
     // is not under the /projects/:name auth gate, so filter explicitly).
     const scopedProjectId = request.apiKey?.projectId
@@ -648,18 +656,37 @@ function parseListLimit(raw: string | undefined, defaultValue: number, max: numb
 }
 
 /**
- * Parse the `?kind=` query param for `GET /runs`. Restricts the response to
- * a single run kind. Returns `null` when the param is absent (no filter
- * applied). Validates against the `RunKinds` enum so a typo produces a 400
- * instead of silently returning empty.
+ * Allowed values per list filter. Keyed on the schema's fields so adding a
+ * filter to `runListFilterQuerySchema` without an entry here is a type error.
  */
-function parseListKind(raw: string | undefined): string | null {
-  if (raw === undefined || raw === '') return null
-  const validKinds = Object.values(RunKinds)
-  if (!validKinds.includes(raw as (typeof validKinds)[number])) {
-    throw validationError(`"kind" must be one of: ${validKinds.join(', ')}`)
-  }
-  return raw
+const RUN_LIST_FILTER_OPTIONS: Record<keyof RunListFilterQuery, readonly string[]> = {
+  kind: runKindSchema.options,
+  status: runStatusSchema.options,
+}
+
+function isRunListFilterField(field: PropertyKey | undefined): field is keyof RunListFilterQuery {
+  return typeof field === 'string' && field in RUN_LIST_FILTER_OPTIONS
+}
+
+/**
+ * Parse the `?kind=` / `?status=` filters shared by `GET /runs` and
+ * `GET /projects/:name/runs`. An absent or empty param applies no filter. An
+ * unknown value is a 400 naming the param and its allowed values: a typo that
+ * silently returned `[]` would be indistinguishable from "no runs exist", and
+ * an ignored param is worse still (`?status=running` used to return completed
+ * rows).
+ */
+function parseListFilters(query: { kind?: string; status?: string }): RunListFilterQuery {
+  const parsed = runListFilterQuerySchema.safeParse({
+    kind: query.kind === '' ? undefined : query.kind,
+    status: query.status === '' ? undefined : query.status,
+  })
+  if (parsed.success) return parsed.data
+  const invalid = parsed.error.issues.map(issue => issue.path[0]).filter(isRunListFilterField)
+  const message = invalid.length > 0
+    ? invalid.map(field => `"${field}" must be one of: ${RUN_LIST_FILTER_OPTIONS[field].join(', ')}`).join('; ')
+    : 'Invalid run list filters'
+  throw validationError(message, { invalid: Object.fromEntries(invalid.map(field => [field, query[field]])) })
 }
 
 /**

--- a/packages/api-routes/test/runs-list-filters.test.ts
+++ b/packages/api-routes/test/runs-list-filters.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import Fastify from 'fastify'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createClient, migrate, projects, runs } from '@ainyc/canonry-db'
+import { RunKinds, RunStatuses, RunTriggers, type RunStatus } from '@ainyc/canonry-contracts'
 import { apiRoutes } from '../src/index.js'
 
 /**
@@ -22,6 +23,11 @@ import { apiRoutes } from '../src/index.js'
  * kind it actually consumes (`answer-visibility`), so integration syncs
  * never displace what it needs. These tests pin that the server honours
  * the filter and rejects typos rather than silently returning empty.
+ *
+ * `?status=` had the worse failure: both list routes accepted the param and
+ * ignored it, so `GET /runs?status=running&limit=20` returned 20 completed
+ * rows. The status suites below pin that the filter is applied, combines
+ * with `?kind=`, and rejects unknown values the same way.
  */
 
 interface Ctx {
@@ -31,7 +37,14 @@ interface Ctx {
   projectId: string
   bingRunIds: string[]
   answerVisibilityRunIds: string[]
+  runningRunIds: string[]
+  queuedRunId: string
+  failedRunId: string
 }
+
+/** 20 bing-inspect + 3 answer-visibility + 4 gsc-sync (2 running, 1 queued, 1 failed). */
+const SEEDED_TOTAL = 27
+const ALL_STATUSES = Object.values(RunStatuses)
 
 function buildCtx(): Ctx {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-runs-filter-'))
@@ -95,7 +108,29 @@ function buildCtx(): Ctx {
     }).run()
   }
 
-  return { app, db, tmpDir, projectId, bingRunIds, answerVisibilityRunIds }
+  // Status variety on a third kind so the kind assertions above stay exact:
+  // two in-flight syncs, one queued, one failed. All older than the
+  // answer-visibility runs so the small-limit repro still sees bing only.
+  const seedStatusRun = (status: RunStatus, offsetMs: number): string => {
+    const id = crypto.randomUUID()
+    const createdAt = new Date(now - 120_000 - offsetMs).toISOString()
+    db.insert(runs).values({
+      id,
+      projectId,
+      kind: RunKinds['gsc-sync'],
+      status,
+      trigger: RunTriggers.scheduled,
+      startedAt: status === RunStatuses.queued ? null : createdAt,
+      finishedAt: status === RunStatuses.failed ? createdAt : null,
+      createdAt,
+    }).run()
+    return id
+  }
+  const runningRunIds = [seedStatusRun(RunStatuses.running, 0), seedStatusRun(RunStatuses.running, 1_000)]
+  const queuedRunId = seedStatusRun(RunStatuses.queued, 2_000)
+  const failedRunId = seedStatusRun(RunStatuses.failed, 3_000)
+
+  return { app, db, tmpDir, projectId, bingRunIds, answerVisibilityRunIds, runningRunIds, queuedRunId, failedRunId }
 }
 
 let ctx: Ctx
@@ -187,5 +222,108 @@ describe('GET /projects/:name/runs ?kind= filter', () => {
   it('empty ?kind= behaves like no filter', async () => {
     const { body } = await get<Array<{ kind: string }>>(`/api/v1/projects/runs-filter/runs?kind=`)
     expect(new Set(body.map(r => r.kind)).size).toBeGreaterThan(1)
+  })
+})
+
+describe('GET /runs ?status= filter', () => {
+  it('?status=running&limit=20 returns only the running rows (the live repro returned 20 completed rows)', async () => {
+    const { status, body } = await get<Array<{ id: string; status: string }>>(`/api/v1/runs?status=running&limit=20`)
+    expect(status).toBe(200)
+    expect(body).toHaveLength(2)
+    expect(body.every(r => r.status === RunStatuses.running)).toBe(true)
+    expect(new Set(body.map(r => r.id))).toEqual(new Set(ctx.runningRunIds))
+  })
+
+  it('?status=queued and ?status=failed each return exactly the one seeded row', async () => {
+    const queued = await get<Array<{ id: string }>>(`/api/v1/runs?status=queued`)
+    expect(queued.body.map(r => r.id)).toEqual([ctx.queuedRunId])
+    const failed = await get<Array<{ id: string }>>(`/api/v1/runs?status=failed`)
+    expect(failed.body.map(r => r.id)).toEqual([ctx.failedRunId])
+  })
+
+  it('?status=completed returns every completed row across kinds', async () => {
+    const { body } = await get<Array<{ status: string }>>(`/api/v1/runs?status=completed`)
+    expect(body).toHaveLength(23)
+    expect(body.every(r => r.status === RunStatuses.completed)).toBe(true)
+  })
+
+  it('?status= combines with ?kind= as AND', async () => {
+    const match = await get<Array<{ id: string }>>(`/api/v1/runs?kind=gsc-sync&status=running`)
+    expect(new Set(match.body.map(r => r.id))).toEqual(new Set(ctx.runningRunIds))
+    const none = await get<Array<{ id: string }>>(`/api/v1/runs?kind=answer-visibility&status=running`)
+    expect(none.status).toBe(200)
+    expect(none.body).toEqual([])
+  })
+
+  it('?status=<unknown> returns 400 naming the param and the allowed values', async () => {
+    const { status, body } = await get<{ error: { code: string; message: string } }>(`/api/v1/runs?status=not-a-status`)
+    expect(status).toBe(400)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.message).toBe(`"status" must be one of: ${ALL_STATUSES.join(', ')}`)
+  })
+
+  it('no filter returns every seeded row, as before', async () => {
+    const { body } = await get<Array<{ status: string }>>(`/api/v1/runs`)
+    expect(body).toHaveLength(SEEDED_TOTAL)
+    expect(new Set(body.map(r => r.status))).toEqual(
+      new Set([RunStatuses.completed, RunStatuses.running, RunStatuses.queued, RunStatuses.failed]),
+    )
+  })
+
+  it('empty ?status= behaves like no filter', async () => {
+    const { body } = await get<Array<{ status: string }>>(`/api/v1/runs?status=`)
+    expect(body).toHaveLength(SEEDED_TOTAL)
+  })
+})
+
+describe('GET /projects/:name/runs ?status= filter', () => {
+  it('?status=running returns only the running rows', async () => {
+    const { status, body } = await get<Array<{ id: string; status: string }>>(
+      `/api/v1/projects/runs-filter/runs?status=running`,
+    )
+    expect(status).toBe(200)
+    expect(body).toHaveLength(2)
+    expect(body.every(r => r.status === RunStatuses.running)).toBe(true)
+    expect(new Set(body.map(r => r.id))).toEqual(new Set(ctx.runningRunIds))
+  })
+
+  it('?status=running&limit=1 applies the filter before the limit window, not to it', async () => {
+    // Unfiltered, limit=1 is the newest bing-inspect row. Filtered, it must be
+    // the newest RUNNING row even though every running row is older.
+    const { body } = await get<Array<{ id: string; status: string }>>(
+      `/api/v1/projects/runs-filter/runs?status=running&limit=1`,
+    )
+    expect(body).toHaveLength(1)
+    expect(body[0]?.status).toBe(RunStatuses.running)
+    expect(body[0]?.id).toBe(ctx.runningRunIds[0])
+  })
+
+  it('?status=<unknown> returns 400 naming the param and the allowed values', async () => {
+    const { status, body } = await get<{ error: { code: string; message: string } }>(
+      `/api/v1/projects/runs-filter/runs?status=not-a-status`,
+    )
+    expect(status).toBe(400)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.message).toBe(`"status" must be one of: ${ALL_STATUSES.join(', ')}`)
+  })
+
+  it('no filter returns every seeded row, as before', async () => {
+    const { body } = await get<Array<{ id: string }>>(`/api/v1/projects/runs-filter/runs`)
+    expect(body).toHaveLength(SEEDED_TOTAL)
+  })
+})
+
+describe('OpenAPI: runs list filter params', () => {
+  it('kind and status enums on both list routes are the contracts enums', async () => {
+    // The kind enum was a hand-copied list that had fallen behind RunKinds;
+    // both filters now derive from the schema the server validates against.
+    const { body } = await get<{
+      paths: Record<string, { get?: { parameters?: Array<{ name: string; schema?: { enum?: string[] } }> } }>
+    }>('/api/v1/openapi.json')
+    for (const path of ['/api/v1/runs', '/api/v1/projects/{name}/runs']) {
+      const params = body.paths[path]?.get?.parameters ?? []
+      expect(params.find(p => p.name === 'kind')?.schema?.enum, path).toEqual(Object.values(RunKinds))
+      expect(params.find(p => p.name === 'status')?.schema?.enum, path).toEqual(ALL_STATUSES)
+    }
   })
 })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.193.0",
+  "version": "4.193.1",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/run.ts
+++ b/packages/canonry/src/cli-commands/run.ts
@@ -5,6 +5,7 @@ import { usageError } from '../cli-error.js'
 
 const RUN_TRIGGER_USAGE = 'canonry run trigger <project> [--group <key>]... [--target <key>]... [--provider <name>] [--query <q>...] [--location <label>] [--all-locations] [--no-location] [--probe] [--wait] [--format json]'
 const RUN_USAGE = 'canonry run <project|--all> [--group <key>]... [--target <key>]... [--provider <name>] [--query <q>...] [--location <label>] [--all-locations] [--no-location] [--probe] [--wait] [--format json]'
+const RUNS_USAGE = 'canonry runs <project> [--limit <n>] [--kind <kind>] [--status <status>] [--format json]'
 
 const RUN_TRIGGER_OPTIONS = {
   provider: stringOption(),
@@ -142,21 +143,25 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['runs'],
-    usage: 'canonry runs <project> [--limit <n>] [--kind <kind>] [--format json]',
+    usage: RUNS_USAGE,
     options: {
       limit: stringOption(),
       kind: stringOption(),
+      status: stringOption(),
     },
     run: async (input) => {
-      const project = requireProject(input, 'runs', 'canonry runs <project> [--limit <n>] [--kind <kind>] [--format json]')
+      const project = requireProject(input, 'runs', RUNS_USAGE)
+      // kind/status pass through as typed; the server validates them against
+      // the run enums and its 400 names the allowed values.
       await listRuns(project, {
         format: input.format,
         limit: parseIntegerOption(input, 'limit', {
           command: 'runs',
-          usage: 'canonry runs <project> [--limit <n>] [--kind <kind>] [--format json]',
+          usage: RUNS_USAGE,
           message: '--limit must be an integer',
         }),
         kind: getString(input.values, 'kind'),
+        status: getString(input.values, 'status'),
       })
     },
   },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -2037,13 +2037,13 @@ export class ApiClient {
     )
   }
 
-  async listRuns(project: string, limit?: number, kind?: string): Promise<RunDto[]> {
+  async listRuns(project: string, limit?: number, kind?: string, status?: string): Promise<RunDto[]> {
     return this.invoke<RunDto[]>(() =>
       getApiV1ProjectsByNameRuns({
         client: this.heyClient,
         path: { name: project },
-        // kind arrives as a free CLI string; the server validates it against the enum.
-        query: { limit, kind } as GetApiV1ProjectsByNameRunsData['query'],
+        // kind/status arrive as free CLI strings; the server validates them against the enums.
+        query: { limit, kind, status } as GetApiV1ProjectsByNameRunsData['query'],
       }),
     )
   }

--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -317,9 +317,12 @@ export async function showRun(id: string, format?: string): Promise<void> {
   printRunDetail(run)
 }
 
-export async function listRuns(project: string, opts?: { format?: string; limit?: number; kind?: string }): Promise<void> {
+export async function listRuns(
+  project: string,
+  opts?: { format?: string; limit?: number; kind?: string; status?: string },
+): Promise<void> {
   const client = getClient()
-  const runs = await client.listRuns(project, opts?.limit, opts?.kind) as Array<{
+  const runs = await client.listRuns(project, opts?.limit, opts?.kind, opts?.status) as Array<{
     id: string
     status: string
     kind: string

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -72,6 +72,7 @@ import {
   canonicalizeGtmResourceSelection,
   type NotificationEvent,
   describeError,
+  runListFilterQuerySchema,
 } from '@ainyc/canonry-contracts'
 import { z } from 'zod'
 import type { ApiClient } from '../client.js'
@@ -266,6 +267,8 @@ const measurementDraftActionOpenApiOperations = [
 const runsListInputSchema = z.object({
   project: projectNameSchema,
   limit: z.number().int().positive().max(500).optional(),
+  kind: runListFilterQuerySchema.shape.kind.describe('Restrict to a single run kind (e.g. "answer-visibility"). Unknown values are rejected.'),
+  status: runListFilterQuerySchema.shape.status.describe('Restrict to a single run status (e.g. "running" for in-flight work, "failed" to triage). Unknown values are rejected.'),
 })
 
 const runGetInputSchema = z.object({
@@ -1347,13 +1350,13 @@ export const canonryMcpTools = [
   defineTool({
     name: 'canonry_runs_list',
     title: 'List project runs',
-    description: "List runs for a Canonry project. Includes both real runs (trigger='manual'/'scheduled'/'config-apply'/'backfill') AND probe runs (trigger='probe'). Probe runs are operator/agent test runs that don't influence dashboard, analytics, intelligence, or notifications — filter by `trigger !== 'probe'` if you only want runs that feed project metrics.",
+    description: "List runs for a Canonry project. Includes both real runs (trigger='manual'/'scheduled'/'config-apply'/'backfill') AND probe runs (trigger='probe'). Probe runs are operator/agent test runs that don't influence dashboard, analytics, intelligence, or notifications — filter by `trigger !== 'probe'` if you only want runs that feed project metrics. Narrow with `kind` and/or `status` (e.g. status='running' lists only in-flight work).",
     access: 'read',
     tier: 'monitoring',
     inputSchema: runsListInputSchema,
     annotations: readAnnotations(),
     openApiOperations: ['GET /api/v1/projects/{name}/runs'],
-    handler: (client, input) => client.listRuns(input.project, input.limit),
+    handler: (client, input) => client.listRuns(input.project, input.limit, input.kind, input.status),
   }),
   defineTool({
     name: 'canonry_runs_latest',

--- a/packages/canonry/test/cli-run-contract.test.ts
+++ b/packages/canonry/test/cli-run-contract.test.ts
@@ -187,6 +187,29 @@ describe('run lifecycle CLI contract', () => {
     expect(parsed[0]?.id).not.toBe(olderRunId)
   })
 
+  it('supports runs <project> --status <status> in JSON mode', async () => {
+    await insertRun({ status: 'completed' })
+    const runningRunId = await insertRun({ status: 'running' })
+    await insertRun({ status: 'queued' })
+
+    const result = await invokeCli(['runs', 'test-proj', '--status', 'running', '--format', 'json'])
+
+    expect(result.exitCode).toBe(undefined)
+    expect(result.stderr).toBe('')
+    const parsed = JSON.parse(result.stdout) as Array<{ id: string; status: string }>
+    expect(parsed.map(run => ({ id: run.id, status: run.status }))).toEqual([{ id: runningRunId, status: 'running' }])
+  })
+
+  it('surfaces the server validation error for runs <project> --status with an unknown value', async () => {
+    const result = await invokeCli(['runs', 'test-proj', '--status', 'bogus', '--format', 'json'])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toBe('')
+    const parsed = JSON.parse(result.stderr) as { error: { code: string; message: string } }
+    expect(parsed.error.code).toBe('VALIDATION_ERROR')
+    expect(parsed.error.message).toBe('"status" must be one of: queued, running, completed, partial, failed, cancelled')
+  })
+
   it('forwards repeatable --query flags as a queries[] body field', async () => {
     await client.appendQueries('test-proj', ['alpha', 'beta', 'gamma'])
 

--- a/packages/canonry/test/mcp-registry.test.ts
+++ b/packages/canonry/test/mcp-registry.test.ts
@@ -696,6 +696,11 @@ describe('MCP tool registry', () => {
       type: 'integer',
       maximum: 500,
     })
+    expect(schemaProperty(inputSchemaFor('canonry_runs_list'), 'kind')).toMatchObject({ type: 'string' })
+    expect(schemaProperty(inputSchemaFor('canonry_runs_list'), 'status')).toMatchObject({
+      type: 'string',
+      enum: ['queued', 'running', 'completed', 'partial', 'failed', 'cancelled'],
+    })
 
     const visibilityStatsSchema = inputSchemaFor('canonry_visibility_stats')
     expect(schemaProperty(visibilityStatsSchema, 'month')).toMatchObject({ type: 'string' })

--- a/packages/contracts/src/run.ts
+++ b/packages/contracts/src/run.ts
@@ -29,6 +29,18 @@ export type RunKind = z.infer<typeof runKindSchema>
 export const RunKinds = runKindSchema.enum
 
 /**
+ * Optional filters shared by `GET /runs` and `GET /projects/:name/runs`.
+ * Both validate against the run enums so an unknown value is a 400 instead
+ * of a silently empty list, and the MCP `canonry_runs_list` input reuses this
+ * shape so every surface accepts the same filters.
+ */
+export const runListFilterQuerySchema = z.object({
+  kind: runKindSchema.optional(),
+  status: runStatusSchema.optional(),
+})
+export type RunListFilterQuery = z.infer<typeof runListFilterQuerySchema>
+
+/**
  * What caused this run to be created.
  *
  * - `manual`        operator-initiated full sweep (CLI `canonry run` or the

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.193.0",
+  "version": "4.193.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.193.0",
+  "version": "4.193.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.193.0",
+  "version": "4.193.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Both run-list endpoints currently ignore `status`, so a request for running work can return completed history. Apply the filter before the result limit and expose the same filters through the API, CLI, and MCP.

- Share `kind`/`status` validation through the contracts schema; combine filters with AND and reject unknown values with `400 VALIDATION_ERROR`.
- Add `canonry runs <project> --status <status>` and MCP `canonry_runs_list` inputs for `kind` and `status`.
- Derive OpenAPI filter enums from contracts and regenerate the SDK, preserving current schedule parameters.
- Rebase onto main `6cb1a2ee1`, which includes merged #1085. Package and plugin versions advance from `4.193.0` to `4.193.1`.

Validation: 64 focused API, CLI, and MCP tests passed during review, together with API-routes and Canonry package typechecks and artifact checks. After #1085 merged, all 110 combined health, API, CLI, and MCP tests passed. The rebase changes only version-conflict context; the reviewed implementation is unchanged. Full workspace validation runs in CI.