### PR TITLE
fix(metrics): window unbounded reads, drop unaddable user counts, stop filtering crawlers to verified

### DIFF
--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -110,7 +110,10 @@ type PageSortKey = 'landingPage' | 'sessions' | 'organicSessions'
 // No 'users' on the two AI-referral tables: /ga/traffic stopped emitting a
 // per-row user count in 4.135.0 (GA counts users distinct per grain).
 type ReferralSortKey = 'source' | 'medium' | 'sessions'
-type SocialSortKey = 'source' | 'medium' | 'sessions' | 'users'
+// No 'users' here either, for the same reason as the AI tables above:
+// ga_social_referrals stores users at (date, source, medium, channel group),
+// so summing it over a window counts a returning visitor once per day.
+type SocialSortKey = 'source' | 'medium' | 'sessions'
 type AiLandingPageSortKey = 'landingPage' | 'source' | 'sessions'
 type SortDir = 'asc' | 'desc'
 
@@ -1171,7 +1174,6 @@ export function ClickThroughActivity({ projectName, window: windowProp }: {
                             <th className="py-1 font-medium text-left">Channel</th>
                             <SortHeader label="Sessions" sortKey="sessions" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
                             <th className="py-1 font-medium text-right">Share</th>
-                            <SortHeader label="Users" sortKey="users" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
                           </tr>
                         </thead>
                         <tbody>
@@ -1650,9 +1652,6 @@ function SocialReferralRow({
       </td>
       <td className="py-1.5 text-right text-secondary tabular-nums">
         {share}%
-      </td>
-      <td className="py-1.5 text-right text-strong tabular-nums">
-        {referral.users.toLocaleString()}
       </td>
     </tr>
   )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.180.5",
+  "version": "4.180.6",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.180.3",
+  "version": "4.180.5",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -8129,7 +8129,7 @@ export type ProjectReportDto = {
         topLandingPages: Array<{
             page: string;
             sessions: number;
-            users: number;
+            users?: number;
             organicSessions: number;
         }>;
         channelBreakdown: Array<{
@@ -8232,6 +8232,7 @@ export type ProjectReportDto = {
         topCrawledPaths: Array<{
             path: string;
             verifiedHits: number;
+            unverifiedHits: number;
             distinctOperators: number;
         }>;
         referralProducts: Array<{
@@ -8242,6 +8243,7 @@ export type ProjectReportDto = {
         dailyTrend: Array<{
             date: string;
             verifiedCrawlerHits: number;
+            unverifiedCrawlerHits: number;
             userFetchHits: number;
             referralArrivals: number;
         }>;

--- a/packages/api-routes/src/content-data.ts
+++ b/packages/api-routes/src/content-data.ts
@@ -9,7 +9,13 @@
  * `add-schema` action is supported in types but never fires until that lands.
  */
 
-import { and, eq, desc, inArray } from 'drizzle-orm'
+import { and, eq, desc, gte, inArray, lte } from 'drizzle-orm'
+import {
+  mergeGscQueryTotalsWithFallback,
+  readGscQueryDailyRows,
+  readLatestGscDataDate,
+  type GscQueryDayRow,
+} from './gsc-totals.js'
 import {
   filterTrackedSnapshots,
   queries,
@@ -70,6 +76,7 @@ export function loadOrchestratorInput(
   db: DatabaseClient,
   project: ProjectRow,
   locationFilter: LocationScope = undefined,
+  gscWindowDays: number = DEFAULT_CONTENT_GSC_WINDOW_DAYS,
 ): OrchestratorInput {
   const projectId = project.id
   const ownDomain = hostOf(project.canonicalDomain) ?? ''
@@ -98,6 +105,7 @@ export function loadOrchestratorInput(
     latestRunId,
     ourDomains,
     competitorSet,
+    gscWindowDays,
   })
 
   const inventory = buildInventory({
@@ -351,6 +359,8 @@ interface BuildCandidateQueriesOpts {
   latestRunId: string
   ourDomains: Set<string>
   competitorSet: Set<string>
+  /** Days of GSC history to score demand over. See resolveContentGscWindow. */
+  gscWindowDays: number
 }
 
 function buildCandidateQueries(opts: BuildCandidateQueriesOpts): CandidateQuery[] {
@@ -385,12 +395,41 @@ function buildCandidateQueries(opts: BuildCandidateQueriesOpts): CandidateQuery[
     snapshotsByQuery.set(row.queryId, list)
   }
 
-  const gscRows = opts.db
-    .select()
-    .from(gscSearchData)
-    .where(eq(gscSearchData.projectId, opts.projectId))
-    .all()
-  const gscByQuery = aggregateGscByQuery(gscRows)
+  // Two separate reads, because the two tables answer different questions.
+  //
+  // Impressions, clicks, CTR and position come from gsc_query_daily_totals,
+  // which is keyed (date, query). gsc_search_data is keyed
+  // (date, query, page, country, device), so one SERP impression fans out into
+  // a row per ranking page and summing it over-counts badly: on a live property
+  // the query "gjelina hotel" summed to 151,571 impressions where the real
+  // all-time figure is 26,477 and the reported 30-day window is 1,519. Both
+  // errors were compounding, since this read also had no date bound at all and
+  // presented lifetime demand under the report's window heading.
+  //
+  // gsc_search_data is still the right source for `bestPage`: attributing a
+  // query to a landing page genuinely needs the page dimension. It is now
+  // windowed to match.
+  const gscWindow = resolveContentGscWindow(opts.db, opts.projectId, opts.gscWindowDays)
+  const pageRows = gscWindow
+    ? opts.db
+        .select()
+        .from(gscSearchData)
+        .where(and(
+          eq(gscSearchData.projectId, opts.projectId),
+          gte(gscSearchData.date, gscWindow.startDate),
+          lte(gscSearchData.date, gscWindow.endDate),
+        ))
+        .all()
+    : []
+  const gscByQuery = aggregateGscByQuery(
+    pageRows,
+    gscWindow
+      ? mergeGscQueryTotalsWithFallback(
+          readGscQueryDailyRows(opts.db, opts.projectId, gscWindow.startDate, gscWindow.endDate),
+          pageDayFallback(pageRows),
+        )
+      : [],
+  )
 
   return opts.candidateQueryStrings.map((query) => {
     const queryId = queryIdByText.get(query)
@@ -427,6 +466,59 @@ interface QueryAccumulator {
   weightedPositionSum: number
 }
 
+/**
+ * Days of GSC history the content engine scores demand over when the caller
+ * does not say. Matches the report's default period so an opportunity's
+ * "impressions" means the same span as the rest of the page it is printed on.
+ */
+export const DEFAULT_CONTENT_GSC_WINDOW_DAYS = 30
+
+/**
+ * Anchor the window on the newest day GSC has actually published for this
+ * project, not on the wall clock. Google finalises a day two to three days
+ * late, so a clock-anchored window silently ends in a partial or empty span.
+ * Returns null when the project has no GSC data at all.
+ */
+function resolveContentGscWindow(
+  db: DatabaseClient,
+  projectId: string,
+  windowDays: number,
+): { startDate: string, endDate: string } | null {
+  const endDate = readLatestGscDataDate(db, projectId)
+  if (!endDate) return null
+  const end = new Date(`${endDate}T00:00:00Z`)
+  end.setUTCDate(end.getUTCDate() - (Math.max(1, windowDays) - 1))
+  return { startDate: end.toISOString().slice(0, 10), endDate }
+}
+
+/**
+ * Collapse page rows to one row per (date, query) so they can stand in for
+ * gsc_query_daily_totals on days that table has not been backfilled. Clicks are
+ * additive across pages; impressions are not, so this remains an over-count and
+ * is only ever a fallback for days with no accurate row.
+ */
+function pageDayFallback(
+  rows: Array<{ date: string, query: string, impressions: number, clicks: number, position: string }>,
+): GscQueryDayRow[] {
+  const byDay = new Map<string, { date: string, query: string, clicks: number, impressions: number, weighted: number }>()
+  for (const r of rows) {
+    if (!r.query) continue
+    const key = `${r.date}\u0000${r.query}`
+    const acc = byDay.get(key) ?? { date: r.date, query: r.query, clicks: 0, impressions: 0, weighted: 0 }
+    acc.clicks += r.clicks
+    acc.impressions += r.impressions
+    acc.weighted += (Number(r.position) || 0) * r.impressions
+    byDay.set(key, acc)
+  }
+  return [...byDay.values()].map(a => ({
+    date: a.date,
+    query: a.query,
+    clicks: a.clicks,
+    impressions: a.impressions,
+    position: a.impressions > 0 ? a.weighted / a.impressions : 0,
+  }))
+}
+
 export function aggregateGscByQuery(
   rows: Array<{
     query: string
@@ -436,7 +528,16 @@ export function aggregateGscByQuery(
     ctr: string
     position: string
   }>,
+  /**
+   * Per-query totals from gsc_query_daily_totals. When a query appears here its
+   * impressions, clicks, CTR and position are taken from this aggregate; the
+   * page rows only choose `bestPage`. Pass an empty array to fall back to the
+   * page-summed figures, which is the legacy behaviour and is wrong for any
+   * query that ranks on more than one page.
+   */
+  queryTotals: readonly { query: string, impressions: number, clicks: number, position: number }[] = [],
 ): Map<string, AggregateGscEntry> {
+  const accurateByQuery = new Map(queryTotals.map(t => [t.query, t]))
   const accumulators = new Map<string, QueryAccumulator>()
   for (const r of rows) {
     const page = extractPath(r.page)
@@ -469,12 +570,18 @@ export function aggregateGscByQuery(
     // ctr=1.0 while the bulk of impressions sit on separate ctr=0 rows. The
     // old "pick the row with the most impressions" logic almost always
     // selected a row with no clicks, so per-query CTR rendered as 0%.
+    const accurate = accurateByQuery.get(query)
+    const impressions = accurate ? accurate.impressions : acc.totalImpressions
+    const clicks = accurate ? accurate.clicks : acc.totalClicks
+    const position = accurate
+      ? accurate.position
+      : (acc.totalImpressions > 0 ? acc.weightedPositionSum / acc.totalImpressions : 0)
     byQuery.set(query, {
       page: acc.bestPage,
-      position: acc.totalImpressions > 0 ? acc.weightedPositionSum / acc.totalImpressions : 0,
-      impressions: acc.totalImpressions,
-      clicks: acc.totalClicks,
-      ctr: acc.totalImpressions > 0 ? acc.totalClicks / acc.totalImpressions : 0,
+      position,
+      impressions,
+      clicks,
+      ctr: impressions > 0 ? clicks / impressions : 0,
     })
   }
   return byQuery

--- a/packages/api-routes/src/content-data.ts
+++ b/packages/api-routes/src/content-data.ts
@@ -115,8 +115,9 @@ export function loadOrchestratorInput(
     wpPosts: [],
   })
 
-  const gaTrafficByPage = buildGaTrafficByPage(db, projectId)
-  const totalAiReferralSessions = sumAiReferralSessions(db, projectId)
+  const gaWindow = resolveContentGaWindow(db, projectId, gscWindowDays)
+  const gaTrafficByPage = buildGaTrafficByPage(db, projectId, gaWindow)
+  const totalAiReferralSessions = sumAiReferralSessions(db, projectId, gaWindow)
   const domainClasses = loadDomainClasses(db, projectId)
 
   return {
@@ -301,23 +302,65 @@ function listGa4LandingPagesForProject(db: DatabaseClient, projectId: string): s
   return rows.map((r) => r.landingPage)
 }
 
-function buildGaTrafficByPage(db: DatabaseClient, projectId: string): Map<string, number> {
+/**
+ * Organic sessions per landing page, over the analytics window.
+ *
+ * Two things this must not do. It must not read every retained row: the figure
+ * is printed as `ourBestPage.organicSessions` under the report's window
+ * heading, and unbounded it summed a project's whole history (one property:
+ * 142 days into a number labelled 30). And it must sum `organicSessions`, not
+ * `sessions`, because the field it feeds is the organic one; summing total
+ * sessions produced a per-page figure larger than the property's own total.
+ */
+function buildGaTrafficByPage(
+  db: DatabaseClient,
+  projectId: string,
+  window: { startDate: string, endDate: string } | null,
+): Map<string, number> {
+  if (!window) return new Map()
   const rows = db
     .select({
       landingPage: gaTrafficSnapshots.landingPage,
-      sessions: gaTrafficSnapshots.sessions,
+      organicSessions: gaTrafficSnapshots.organicSessions,
     })
     .from(gaTrafficSnapshots)
-    .where(eq(gaTrafficSnapshots.projectId, projectId))
+    .where(and(
+      eq(gaTrafficSnapshots.projectId, projectId),
+      gte(gaTrafficSnapshots.date, window.startDate),
+      lte(gaTrafficSnapshots.date, window.endDate),
+    ))
     .all()
 
   const map = new Map<string, number>()
   for (const row of rows) {
     const path = extractPath(row.landingPage)
     if (!path) continue
-    map.set(path, (map.get(path) ?? 0) + (row.sessions ?? 0))
+    map.set(path, (map.get(path) ?? 0) + (row.organicSessions ?? 0))
   }
   return map
+}
+
+/**
+ * Analytics window for the content engine, anchored on the newest day GA has
+ * data for rather than the wall clock, so a sync that is a day or two behind
+ * does not silently shorten the span. Null when the project has no GA data.
+ */
+function resolveContentGaWindow(
+  db: DatabaseClient,
+  projectId: string,
+  windowDays: number,
+): { startDate: string, endDate: string } | null {
+  const latest = db
+    .select({ date: gaTrafficSnapshots.date })
+    .from(gaTrafficSnapshots)
+    .where(eq(gaTrafficSnapshots.projectId, projectId))
+    .orderBy(desc(gaTrafficSnapshots.date))
+    .limit(1)
+    .get()
+  if (!latest?.date) return null
+  const end = new Date(`${latest.date}T00:00:00Z`)
+  end.setUTCDate(end.getUTCDate() - (Math.max(1, windowDays) - 1))
+  return { startDate: end.toISOString().slice(0, 10), endDate: latest.date }
 }
 
 /**
@@ -335,7 +378,12 @@ function buildGaTrafficByPage(db: DatabaseClient, projectId: string): Map<string
  * the same lens here keeps the content engine's denominator consistent with the
  * report's numerator.
  */
-function sumAiReferralSessions(db: DatabaseClient, projectId: string): number {
+function sumAiReferralSessions(
+  db: DatabaseClient,
+  projectId: string,
+  window: { startDate: string, endDate: string } | null,
+): number {
+  if (!window) return 0
   const rows = db
     .select({ sessions: gaAiReferrals.sessions })
     .from(gaAiReferrals)
@@ -343,6 +391,11 @@ function sumAiReferralSessions(db: DatabaseClient, projectId: string): number {
       and(
         eq(gaAiReferrals.projectId, projectId),
         eq(gaAiReferrals.sourceDimension, 'session'),
+        // Bounded for the same reason the per-page read is: this scales every
+        // opportunity score, so a lifetime total quietly weights the ranking
+        // toward whatever was true months ago.
+        gte(gaAiReferrals.date, window.startDate),
+        lte(gaAiReferrals.date, window.endDate),
       ),
     )
     .all()

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -1336,8 +1336,12 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         source: gaSocialReferrals.source,
         medium: gaSocialReferrals.medium,
         channelGroup: gaSocialReferrals.channelGroup,
+        // No `users`. ga_social_referrals is keyed
+        // (project, date, source, medium, channel_group) and its users column
+        // is GA's COUNT DISTINCT at that grain, so summing over the window's
+        // dates counts a returning visitor once per day they returned. Same
+        // conclusion the AI-referral surfaces reached in 4.135.0.
         sessions: sql<number>`SUM(${gaSocialReferrals.sessions})`,
-        users: sql<number>`SUM(${gaSocialReferrals.users})`,
       })
       .from(gaSocialReferrals)
       .where(and(...socialConditions))
@@ -1350,7 +1354,6 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     const socialTotals = app.db
       .select({
         sessions: sql<number>`SUM(${gaSocialReferrals.sessions})`,
-        users: sql<number>`SUM(${gaSocialReferrals.users})`,
       })
       .from(gaSocialReferrals)
       .where(and(...socialConditions))
@@ -1432,10 +1435,8 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         medium: r.medium,
         channelGroup: r.channelGroup,
         sessions: r.sessions ?? 0,
-        users: r.users ?? 0,
       })),
       socialSessions,
-      socialUsers: socialTotals?.users ?? 0,
       channelBreakdown,
       organicSharePct: total > 0 ? Math.round((totalOrganicSessions / total) * 100) : 0,
       aiSharePct: total > 0 ? Math.round((aiSummary.deduped.sessions / total) * 100) : 0,
@@ -1499,8 +1500,11 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         trafficClass: gaAiReferrals.trafficClass,
         landingPage: sql<string>`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
         sourceDimension: gaAiReferrals.sourceDimension,
+        // No `users`: ga-ai-referral-aggregation states the rule for this
+        // table, that there is no grain at which the stored users column may be
+        // added up. ga4AiReferralDtoSchema.users was deprecated for this in
+        // 4.135.0; the history endpoint kept emitting one.
         sessions: sql<number>`SUM(${gaAiReferrals.sessions})`,
-        users: sql<number>`SUM(${gaAiReferrals.users})`,
       })
       .from(gaAiReferrals)
       .where(and(...conditions))

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -101,6 +101,11 @@ declare module 'fastify' {
 
 export { registerOAuthRoutes, registerOAuthAdminRoutes, resolveOAuthAccessToken } from './oauth.js'
 export { hashApiKey } from './auth.js'
+export {
+  mergeGscQueryTotalsWithFallback,
+  readGscQueryDailyRows,
+  readLatestGscDataDate,
+} from './gsc-totals.js'
 export type { OAuthRoutesOptions } from './oauth.js'
 export type { CredentialChecker } from './user-session.js'
 export * from './notifications/alert.js'

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -2047,10 +2047,15 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     </tr>`
   }).join('')
 
+  // Total hits, with the verified share beside it. The table is ordered by
+  // total, so showing only the verified count made rows look mis-sorted, and on
+  // a source that cannot verify at all (Vercel logs carry no client IP) every
+  // cell read 0 next to a populated headline tile.
   const pathRows = sa.topCrawledPaths.map(p => `
     <tr>
       <td class="page-cell">${formatLandingPageHtml(p.path)}</td>
-      <td class="numeric">${formatNumber(p.verifiedHits)}</td>
+      <td class="numeric">${formatNumber(p.verifiedHits + (p.unverifiedHits ?? 0))}</td>
+      <td class="numeric meta">${formatNumber(p.verifiedHits)}</td>
       <td class="numeric">${p.distinctOperators}</td>
     </tr>`).join('')
 
@@ -2111,7 +2116,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     ${pathRows ? `<div class="chart-card"><h3>Top crawled paths</h3>
       <p class="meta">Pages AI bots fetched most often (verified only, last ${windowLabel}).</p>
       <table class="report-table">
-        <thead><tr><th>Path</th><th class="numeric">Verified hits</th><th class="numeric">Distinct operators</th></tr></thead>
+        <thead><tr><th>Path</th><th class="numeric">Hits</th><th class="numeric">Verified</th><th class="numeric">Distinct operators</th></tr></thead>
         <tbody>${pathRows}</tbody>
       </table>
     </div>` : ''}

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -1780,7 +1780,6 @@ function renderGa(report: ProjectReportDto): string {
     <tr>
       <td class="page-cell">${formatLandingPageHtml(p.page)}</td>
       <td class="numeric">${formatNumber(p.sessions)}</td>
-      <td class="numeric">${formatNumber(p.users)}</td>
       <td class="numeric">${formatNumber(p.organicSessions)}</td>
     </tr>`).join('')
 
@@ -1804,7 +1803,7 @@ function renderGa(report: ProjectReportDto): string {
     </div>
     <div class="chart-card"><h3>Top landing pages</h3>
       <table class="report-table">
-        <thead><tr><th>Page</th><th class="numeric">Sessions</th><th class="numeric">Users</th><th class="numeric">Organic</th></tr></thead>
+        <thead><tr><th>Page</th><th class="numeric">Sessions</th><th class="numeric">Organic</th></tr></thead>
         <tbody>${pageRows}</tbody>
       </table>
     </div>

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -2255,7 +2255,9 @@ function buildProjectReport(db: DatabaseClient, projectName: string, periodDays:
   const citationsTrend = buildCitationsTrend(db, project.id, queryLookup, latestRunLocation)
   const insightList = buildInsightList(db, project.id, latestRunLocation)
 
-  const orchestratorInput = loadOrchestratorInput(db, project, latestRunLocation)
+  // Same window as the rest of the report, so a content opportunity's demand
+  // figure covers the period the page is headed with.
+  const orchestratorInput = loadOrchestratorInput(db, project, latestRunLocation, periodDays)
   // Filter persistently-dismissed recommendations so SPA report, HTML report,
   // and `/content/targets` all consume the same filtered set. Dismissals
   // persist in `content_target_dismissals` keyed by `(projectId, targetRef)`

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -236,7 +236,6 @@ function buildGscSection(
   // breakdowns are correct from `gsc_search_data`. The grand totals and daily
   // trend prefer property-level rows per date, falling back to dimensioned rows
   // for dates not yet covered by the new table.
-  let dimensionedClicks = 0
   // Legacy per-(date, query) fallback. Kept at DAY grain, not folded to one row
   // per query, because the merge below has to decide source per day: a
   // partially-backfilled query has accurate rows for only part of the window.
@@ -244,7 +243,6 @@ function buildGscSection(
   const dimensionedTrendAgg = new Map<string, { clicks: number; impressions: number; weightedPositionSum: number }>()
 
   for (const r of rows) {
-    dimensionedClicks += r.clicks
     const dayKey = `${r.date} ${r.query}`
     const q = queryDayAgg.get(dayKey) ?? { date: r.date, query: r.query, clicks: 0, impressions: 0, weightedPositionSum: 0 }
     q.clicks += r.clicks
@@ -324,14 +322,20 @@ function buildGscSection(
     bucket.impressions += agg.impressions
     categoryAgg.set(cat, bucket)
   }
-  // Share is computed against the dimensioned click sum (the same source the
-  // per-category clicks come from) so the category shares stay internally
-  // consistent — the property total above is a different denominator.
+  // Share divides by the sum of the SAME array the numerator comes from.
+  // categoryAgg is built from queryTotals, which is the merged per-query set,
+  // while dimensionedClicks is still the raw gsc_search_data sum. Those stopped
+  // being one source when the per-query aggregation moved to the merge helper,
+  // so the shares no longer summed to 100 and drifted with an unrelated table's
+  // sync state. Worse, the two tables are written by separate fetches in one
+  // sync: a window where the dimensioned fetch returned nothing rendered every
+  // category at 0%.
+  const categoryTotalClicks = queryTotals.reduce((sum, q) => sum + q.clicks, 0)
   const categoryBreakdown = [...categoryAgg.entries()].map(([category, agg]) => ({
     category,
     clicks: agg.clicks,
     impressions: agg.impressions,
-    sharePct: dimensionedClicks > 0 ? Math.round((agg.clicks / dimensionedClicks) * 100) : 0,
+    sharePct: categoryTotalClicks > 0 ? Math.round((agg.clicks / categoryTotalClicks) * 100) : 0,
   })).sort((a, b) => b.clicks - a.clicks)
 
   const periodStart = trend[0]?.date ?? ''
@@ -469,11 +473,16 @@ function buildGaSection(db: DatabaseClient, projectId: string, windowDays: numbe
     if (!windowSummary && r.directSessions != null) directSessions += r.directSessions
   }
 
+  // No `users` here. GA reports users as a COUNT DISTINCT evaluated at the
+  // grain asked for, and ga_traffic_snapshots is keyed (date, landing_page):
+  // one visitor who returns on three days, or reads three pages, contributes a
+  // users value to every row, so adding them counts that person repeatedly.
+  // There is no grain at which the stored column may be summed, which is the
+  // same conclusion the AI-referral surfaces reached in 4.135.0.
   const topLandingPages = [...pageAgg.entries()]
     .map(([page, data]) => ({
       page,
       sessions: data.sessions,
-      users: data.users,
       organicSessions: data.organic,
     }))
     .sort((a, b) => b.sessions - a.sessions)
@@ -551,11 +560,29 @@ function buildGaSection(db: DatabaseClient, projectId: string, windowDays: numbe
   }
 }
 
-function buildSocialReferrals(db: DatabaseClient, projectId: string): SocialReferralSection | null {
+/**
+ * Social referral traffic over the report window.
+ *
+ * ga_social_referrals is a per-date table retained across syncs, so an
+ * unbounded read reports the project's whole history under the report's window
+ * heading. This was the only section builder that did not take windowDays; it
+ * now shares resolveAiReferralWindow with the AI referral and GA sections so
+ * all three cover the identical span.
+ */
+function buildSocialReferrals(
+  db: DatabaseClient,
+  projectId: string,
+  windowDays: number,
+): SocialReferralSection | null {
+  const window = resolveAiReferralWindow(db, projectId, windowDays)
   const rows = db
     .select()
     .from(gaSocialReferrals)
-    .where(eq(gaSocialReferrals.projectId, projectId))
+    .where(and(
+      eq(gaSocialReferrals.projectId, projectId),
+      gte(gaSocialReferrals.date, window.start),
+      lte(gaSocialReferrals.date, window.end),
+    ))
     .all()
   if (rows.length === 0) return null
 
@@ -942,6 +969,10 @@ function buildServerActivity(db: DatabaseClient, projectId: string, windowDays: 
     .groupBy(crawlerEventsHourly.operator, crawlerEventsHourly.verificationStatus)
     .all()
 
+  // Prior window covers BOTH verification tiers, because the current-window
+  // aggregate it is compared against does. Filtering only one side made the
+  // delta compare a verified-only present to a verified-only past and then
+  // print it on a row whose other cells are combined.
   const crawlerByOperatorPriorRows = db
     .select({
       operator: crawlerEventsHourly.operator,
@@ -951,7 +982,6 @@ function buildServerActivity(db: DatabaseClient, projectId: string, windowDays: 
     .where(
       and(
         eq(crawlerEventsHourly.projectId, projectId),
-        eq(crawlerEventsHourly.verificationStatus, VerificationStatuses.verified),
         gte(crawlerEventsHourly.tsHour, priorStart),
         lt(crawlerEventsHourly.tsHour, headlineStart),
       ),
@@ -1025,7 +1055,7 @@ function buildServerActivity(db: DatabaseClient, projectId: string, windowDays: 
       unverifiedHits: v.unverified,
       userFetchHits: v.userFetch,
       referralArrivals: v.referrals,
-      deltaPct: deltaPercent(v.verified, v.prior),
+      deltaPct: deltaPercent(v.verified + v.unverified, v.prior),
     }))
     // Sort by total signal: verified hits first, then user-fetch, then unverified and referrals.
     .sort((a, b) =>
@@ -1035,18 +1065,22 @@ function buildServerActivity(db: DatabaseClient, projectId: string, windowDays: 
       b.referralArrivals - a.referralArrivals,
     )
 
-  // 4. Top crawled paths (verified only).
+  // 4. Top crawled paths, both verification tiers. Verification needs a client
+  // IP to match against the operator's published ranges, and some log sources
+  // never carry one (Vercel request logs), so a verified-only table renders
+  // empty for those projects while the headline tile above shows thousands of
+  // hits. The split is a display attribute, not a filter.
   const topPathsRows = db
     .select({
       path: crawlerEventsHourly.pathNormalized,
-      hits: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)`,
+      verifiedHits: sql<number>`COALESCE(SUM(CASE WHEN ${crawlerEventsHourly.verificationStatus} = ${VerificationStatuses.verified} THEN ${crawlerEventsHourly.hits} ELSE 0 END), 0)`,
+      unverifiedHits: sql<number>`COALESCE(SUM(CASE WHEN ${crawlerEventsHourly.verificationStatus} <> ${VerificationStatuses.verified} THEN ${crawlerEventsHourly.hits} ELSE 0 END), 0)`,
       operators: sql<number>`COUNT(DISTINCT ${crawlerEventsHourly.operator})`,
     })
     .from(crawlerEventsHourly)
     .where(
       and(
         eq(crawlerEventsHourly.projectId, projectId),
-        eq(crawlerEventsHourly.verificationStatus, VerificationStatuses.verified),
         gte(crawlerEventsHourly.tsHour, headlineStart),
         lte(crawlerEventsHourly.tsHour, headlineEnd),
       ),
@@ -1057,7 +1091,8 @@ function buildServerActivity(db: DatabaseClient, projectId: string, windowDays: 
     .all()
   const topCrawledPaths = topPathsRows.map(r => ({
     path: r.path,
-    verifiedHits: Number(r.hits),
+    verifiedHits: Number(r.verifiedHits),
+    unverifiedHits: Number(r.unverifiedHits),
     distinctOperators: Number(r.operators),
   }))
 
@@ -1113,16 +1148,20 @@ function buildServerActivity(db: DatabaseClient, projectId: string, windowDays: 
   }))
 
   // 7. Daily trend (spans the selected window) — bucket tsHour to YYYY-MM-DD via SQLite SUBSTR.
+  // Both tiers, for the same reason as the top-paths table: this is the only
+  // crawler series in the report, so on a source that cannot verify (Vercel
+  // logs carry no client IP) a verified-only chart drew a flat zero line next
+  // to a headline tile reporting thousands of hits.
   const crawlerTrendRows = db
     .select({
       date: sql<string>`SUBSTR(${crawlerEventsHourly.tsHour}, 1, 10)`,
-      hits: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)`,
+      verifiedHits: sql<number>`COALESCE(SUM(CASE WHEN ${crawlerEventsHourly.verificationStatus} = ${VerificationStatuses.verified} THEN ${crawlerEventsHourly.hits} ELSE 0 END), 0)`,
+      unverifiedHits: sql<number>`COALESCE(SUM(CASE WHEN ${crawlerEventsHourly.verificationStatus} <> ${VerificationStatuses.verified} THEN ${crawlerEventsHourly.hits} ELSE 0 END), 0)`,
     })
     .from(crawlerEventsHourly)
     .where(
       and(
         eq(crawlerEventsHourly.projectId, projectId),
-        eq(crawlerEventsHourly.verificationStatus, VerificationStatuses.verified),
         gte(crawlerEventsHourly.tsHour, trendStart),
         lte(crawlerEventsHourly.tsHour, headlineEnd),
       ),
@@ -1162,11 +1201,12 @@ function buildServerActivity(db: DatabaseClient, projectId: string, windowDays: 
     .groupBy(sql`SUBSTR(${aiUserFetchEventsHourly.tsHour}, 1, 10)`)
     .all()
 
-  const emptyTrendEntry = () => ({ verifiedCrawlerHits: 0, userFetchHits: 0, referralArrivals: 0 })
+  const emptyTrendEntry = () => ({ verifiedCrawlerHits: 0, unverifiedCrawlerHits: 0, userFetchHits: 0, referralArrivals: 0 })
   const dailyTrendMap = new Map<string, ReturnType<typeof emptyTrendEntry>>()
   for (const r of crawlerTrendRows) {
     const e = dailyTrendMap.get(r.date) ?? emptyTrendEntry()
-    e.verifiedCrawlerHits += Number(r.hits)
+    e.verifiedCrawlerHits += Number(r.verifiedHits)
+    e.unverifiedCrawlerHits += Number(r.unverifiedHits)
     dailyTrendMap.set(r.date, e)
   }
   for (const r of userFetchTrendRows) {
@@ -2248,7 +2288,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string, periodDays:
     periodDays,
   )
   const gaSection = buildGaSection(db, project.id, periodDays)
-  const socialSection = buildSocialReferrals(db, project.id)
+  const socialSection = buildSocialReferrals(db, project.id, periodDays)
   const aiReferralsSection = buildAiReferrals(db, project.id, periodDays)
   const serverActivitySection = buildServerActivity(db, project.id, periodDays)
   const indexingHealthSection = buildIndexingHealth(db, project.id)

--- a/packages/api-routes/test/content-gsc-window.test.ts
+++ b/packages/api-routes/test/content-gsc-window.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { aggregateGscByQuery } from '../src/content-data.js'
+
+/**
+ * gsc_search_data is keyed (date, query, page, country, device), so a query
+ * ranking on several pages produces several rows for ONE SERP impression.
+ * Summing them over-counts. Measured on a live property before this fix, the
+ * query "gjelina hotel" summed to 151,571 impressions where the accurate
+ * all-time figure was 26,477 and its 30-day window was 1,519.
+ */
+const PAGE_ROWS = [
+  { query: 'boutique hotel', page: 'https://x.test/rooms', impressions: 100, clicks: 4, ctr: '0.04', position: '3' },
+  { query: 'boutique hotel', page: 'https://x.test/', impressions: 100, clicks: 6, ctr: '0.06', position: '5' },
+]
+
+describe('aggregateGscByQuery', () => {
+  it('takes impressions and clicks from the accurate per-query aggregate, not the page sum', () => {
+    const out = aggregateGscByQuery(PAGE_ROWS, [
+      { query: 'boutique hotel', impressions: 100, clicks: 10, position: 3.8 },
+    ])
+    const row = out.get('boutique hotel')!
+    // 100, not the 200 the two page rows sum to.
+    expect(row.impressions).toBe(100)
+    expect(row.clicks).toBe(10)
+    expect(row.position).toBeCloseTo(3.8)
+    expect(row.ctr).toBeCloseTo(0.1)
+  })
+
+  it('still attributes the best page from the page rows, which is what they are for', () => {
+    const out = aggregateGscByQuery([
+      { query: 'boutique hotel', page: 'https://x.test/rooms', impressions: 10, clicks: 0, ctr: '0', position: '9' },
+      { query: 'boutique hotel', page: 'https://x.test/suites', impressions: 90, clicks: 5, ctr: '0.05', position: '2' },
+    ], [{ query: 'boutique hotel', impressions: 100, clicks: 5, position: 2.7 }])
+    expect(out.get('boutique hotel')!.page).toBe('/suites')
+  })
+
+  it('falls back to page-summed figures when a query has no accurate aggregate', () => {
+    const out = aggregateGscByQuery(PAGE_ROWS, [])
+    // Legacy behaviour preserved for un-backfilled days: still an over-count,
+    // which is why the fallback is a fallback.
+    expect(out.get('boutique hotel')!.impressions).toBe(200)
+    expect(out.get('boutique hotel')!.clicks).toBe(10)
+  })
+
+  it('derives CTR from the aggregate rather than from any single row', () => {
+    const out = aggregateGscByQuery(PAGE_ROWS, [
+      { query: 'boutique hotel', impressions: 250, clicks: 25, position: 4 },
+    ])
+    expect(out.get('boutique hotel')!.ctr).toBeCloseTo(0.1)
+  })
+})

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -710,7 +710,8 @@ describe('GA4 routes', () => {
     expect(body.organicAiSharePctBySession).toBe(5)
     expect(body.socialReferrals).toEqual([])
     expect(body.socialSessions).toBe(0)
-    expect(body.socialUsers).toBe(0)
+    // socialUsers is withdrawn: see the dedicated test below.
+    expect(body).not.toHaveProperty('socialUsers')
     expect(body.organicSharePct).toBe(50)
     expect(body.aiSharePct).toBe(5)
     expect(body.socialSharePct).toBe(0)
@@ -2113,10 +2114,16 @@ describe('GA4 routes', () => {
       expect(body.aiReferralLandingPages.length).toBeGreaterThan(0)
       for (const row of body.aiReferrals) expect(row).not.toHaveProperty('users')
       for (const row of body.aiReferralLandingPages) expect(row).not.toHaveProperty('users')
-      // Property-level and social user counts are a different signal (GA
-      // deduplicates those itself) and must survive the withdrawal.
+      // The property-level user count is a different signal: GA deduplicates
+      // that one itself against an un-dimensioned aggregate, so it survives.
       expect(body.totalUsers).toBe(150)
-      expect(body).toHaveProperty('socialUsers')
+      // Social user counts do NOT survive. ga_social_referrals is keyed
+      // (date, source, medium, channel group) and its users column is GA's
+      // COUNT DISTINCT at that grain, so summing it over a window counts a
+      // returning visitor once per day they returned. Same reasoning that
+      // withdrew the AI-referral user counts in 4.135.0.
+      expect(body).not.toHaveProperty('socialUsers')
+      for (const row of body.socialReferrals) expect(row).not.toHaveProperty('users')
 
       // ── The session numbers are unchanged by the withdrawal. ────────────
       // Deduped folds the winner set: (05-01, referral) session lens 6+4=10

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -2084,6 +2084,20 @@ describe('GA4 routes', () => {
         totalUsers: 150,
         syncedAt: now,
       }).run()
+      // A social row, so the per-row assertion below is not vacuous. The
+      // stored users column is deliberately populated: the point is that the
+      // ROUTE must not publish it, not that the column is empty.
+      db.insert(gaSocialReferrals).values({
+        id: crypto.randomUUID(),
+        projectId: withdrawnProjectId,
+        date: '2026-05-01',
+        source: 'meta.ai',
+        medium: 'social',
+        channelGroup: 'Organic Social',
+        sessions: 15,
+        users: 12,
+        syncedAt: now,
+      }).run()
       db.insert(gaAiReferrals).values(seeded.map((row) => ({
         id: row.id,
         projectId: withdrawnProjectId,
@@ -2124,6 +2138,11 @@ describe('GA4 routes', () => {
       // withdrew the AI-referral user counts in 4.135.0.
       expect(body).not.toHaveProperty('socialUsers')
       for (const row of body.socialReferrals) expect(row).not.toHaveProperty('users')
+      // The loop above is vacuous when socialReferrals is empty, which is how an
+      // incomplete withdrawal shipped once: the API stopped emitting the field
+      // while the dashboard still called .toLocaleString() on it and the CLI
+      // printed "undefined". Assert there is a row to check.
+      expect(body.socialReferrals.length).toBeGreaterThan(0)
 
       // ── The session numbers are unchanged by the withdrawal. ────────────
       // Deduped folds the winner set: (05-01, referral) session lens 6+4=10

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -2229,7 +2229,7 @@ describe('serverActivity (AI visibility — server-side)', () => {
     expect(sa.verifiedCrawlerHits.deltaPct).toBeNull()
   })
 
-  test('top crawled paths sorted descending by hits, verified only', async () => {
+  test('top crawled paths cover both verification tiers, split per row', async () => {
     const projectId = insertProject(ctx.db, 'top-paths')
     const sourceId = insertTrafficSource(projectId)
     insertCrawler(projectId, sourceId, { pathNormalized: '/a', hits: 5 })
@@ -2239,9 +2239,17 @@ describe('serverActivity (AI visibility — server-side)', () => {
     await ctx.app.ready()
     const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/top-paths/report' })
     const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
-    // Verified only — /d (unverified) excluded
-    expect(sa.topCrawledPaths.map(p => p.path)).toEqual(['/b', '/c', '/a'])
-    expect(sa.topCrawledPaths[0]!.verifiedHits).toBe(20)
+    // Both tiers. Verification needs a client IP to match against the
+    // operator's published ranges and some log sources never carry one, so a
+    // verified-only table rendered empty for those projects while the headline
+    // tile above it reported thousands of hits. The split is reported per row
+    // instead of filtering, so /d leads on 999 unverified hits.
+    expect(sa.topCrawledPaths.map(p => p.path)).toEqual(['/d', '/b', '/c', '/a'])
+    expect(sa.topCrawledPaths[0]!.unverifiedHits).toBe(999)
+    expect(sa.topCrawledPaths[0]!.verifiedHits).toBe(0)
+    const b = sa.topCrawledPaths.find(p => p.path === '/b')!
+    expect(b.verifiedHits).toBe(20)
+    expect(b.unverifiedHits).toBe(0)
   })
 
   test('referral products aggregated and counted with distinct landing paths', async () => {

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -2252,6 +2252,38 @@ describe('serverActivity (AI visibility — server-side)', () => {
     expect(b.unverifiedHits).toBe(0)
   })
 
+  test('daily crawler trend carries unverified hits, so a source that cannot verify is not a flat zero line', async () => {
+    const projectId = insertProject(ctx.db, 'trend-unverified')
+    const sourceId = insertTrafficSource(projectId)
+    // A Vercel-shaped project: every row claimed, none verified, because Vercel
+    // request logs carry no client IP to match against operator ranges.
+    insertCrawler(projectId, sourceId, { hits: 400, verificationStatus: 'claimed_unverified' })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/trend-unverified/report' })
+    const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
+    const withHits = sa.dailyTrend.filter(d => d.verifiedCrawlerHits + (d.unverifiedCrawlerHits ?? 0) > 0)
+    expect(withHits.length).toBeGreaterThan(0)
+    expect(withHits.reduce((n, d) => n + (d.unverifiedCrawlerHits ?? 0), 0)).toBe(400)
+    // Verified-only, the previous behaviour, would make this 0 and draw a flat line.
+    expect(withHits.reduce((n, d) => n + d.verifiedCrawlerHits, 0)).toBe(0)
+  })
+
+  test('per-operator delta compares total hits against total hits, not verified against verified', async () => {
+    const projectId = insertProject(ctx.db, 'operator-delta')
+    const sourceId = insertTrafficSource(projectId)
+    // Prior window: 100 hits, all unverified. Current window: 200, all unverified.
+    // A verified-only prior would read 0 and render the delta as a new arrival
+    // rather than a doubling, on a row whose other cells count both tiers.
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(40), hits: 100, verificationStatus: 'claimed_unverified', operator: 'OpenAI' })
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(1), hits: 200, verificationStatus: 'claimed_unverified', operator: 'OpenAI' })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/operator-delta/report' })
+    const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
+    const openai = sa.byOperator.find(o => o.operator === 'OpenAI')!
+    expect(openai.unverifiedHits).toBe(200)
+    expect(openai.deltaPct).toBe(100)
+  })
+
   test('referral products aggregated and counted with distinct landing paths', async () => {
     const projectId = insertProject(ctx.db, 'referral-products')
     const sourceId = insertTrafficSource(projectId)

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.180.5",
+  "version": "4.180.6",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.180.3",
+  "version": "4.180.5",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -277,13 +277,13 @@ export async function gaTraffic(project: string, opts?: GaRangeOptions & { limit
       console.log(`  Social Sessions:         ${result.socialSessions} (${share}% of total)`)
     }
     console.log('  SOCIAL REFERRAL SOURCES')
-    console.log(`  ${'SOURCE'.padEnd(25)}  ${'MEDIUM'.padEnd(15)}  ${'CHANNEL'.padEnd(chanWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
-    console.log(`  ${'─'.repeat(25)}  ${'─'.repeat(15)}  ${'─'.repeat(chanWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
+    console.log(`  ${'SOURCE'.padEnd(25)}  ${'MEDIUM'.padEnd(15)}  ${'CHANNEL'.padEnd(chanWidth)}  ${'SESSIONS'.padEnd(10)}`)
+    console.log(`  ${'─'.repeat(25)}  ${'─'.repeat(15)}  ${'─'.repeat(chanWidth)}  ${'─'.repeat(10)}`)
 
     for (const ref of result.socialReferrals) {
       const chanLabel = ref.channelGroup === 'Paid Social' ? 'paid' : 'organic'
       console.log(
-        `  ${ref.source.padEnd(25)}  ${ref.medium.padEnd(15)}  ${chanLabel.padEnd(chanWidth)}  ${String(ref.sessions).padEnd(10)}${String(ref.users).padEnd(8)}`,
+        `  ${ref.source.padEnd(25)}  ${ref.medium.padEnd(15)}  ${chanLabel.padEnd(chanWidth)}  ${String(ref.sessions).padEnd(10)}`,
       )
     }
     console.log()
@@ -292,13 +292,13 @@ export async function gaTraffic(project: string, opts?: GaRangeOptions & { limit
   if (result.topPages.length > 0) {
     const pageWidth = Math.min(60, Math.max(15, ...result.topPages.map((r) => r.landingPage.length)))
     console.log(`  TOP LANDING PAGES`)
-    console.log(`  ${'PAGE'.padEnd(pageWidth)}  ${'SESSIONS'.padEnd(10)}${'ORGANIC'.padEnd(10)}${'USERS'.padEnd(8)}`)
-    console.log(`  ${'─'.repeat(pageWidth)}  ${'─'.repeat(10)}${'─'.repeat(10)}${'─'.repeat(8)}`)
+    console.log(`  ${'PAGE'.padEnd(pageWidth)}  ${'SESSIONS'.padEnd(10)}${'ORGANIC'.padEnd(10)}`)
+    console.log(`  ${'─'.repeat(pageWidth)}  ${'─'.repeat(10)}${'─'.repeat(10)}`)
 
     for (const row of result.topPages) {
       const page = row.landingPage.length > pageWidth ? row.landingPage.slice(0, pageWidth - 3) + '...' : row.landingPage
       console.log(
-        `  ${page.padEnd(pageWidth)}  ${String(row.sessions).padEnd(10)}${String(row.organicSessions).padEnd(10)}${String(row.users).padEnd(8)}`,
+        `  ${page.padEnd(pageWidth)}  ${String(row.sessions).padEnd(10)}${String(row.organicSessions).padEnd(10)}`,
       )
     }
   }
@@ -382,12 +382,12 @@ export async function gaAiReferralHistory(project: string, opts?: GaRangeOptions
   const sourceWidth = Math.min(30, Math.max(10, ...result.map((r) => r.source.length)))
   const attrWidth = 12
   console.log(`GA4 AI Referral History for "${project}":\n`)
-  console.log(`  ${'DATE'.padEnd(dateWidth)}  ${'SOURCE'.padEnd(sourceWidth)}  ${'ATTRIBUTION'.padEnd(attrWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
-  console.log(`  ${'─'.repeat(dateWidth)}  ${'─'.repeat(sourceWidth)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
+  console.log(`  ${'DATE'.padEnd(dateWidth)}  ${'SOURCE'.padEnd(sourceWidth)}  ${'ATTRIBUTION'.padEnd(attrWidth)}  ${'SESSIONS'.padEnd(10)}`)
+  console.log(`  ${'─'.repeat(dateWidth)}  ${'─'.repeat(sourceWidth)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}`)
   for (const row of result) {
     const dimLabel = row.sourceDimension === 'first_user' ? 'first-visit' : row.sourceDimension === 'manual_utm' ? 'utm' : 'session'
     console.log(
-      `  ${row.date.padEnd(dateWidth)}  ${row.source.padEnd(sourceWidth)}  ${dimLabel.padEnd(attrWidth)}  ${String(row.sessions).padEnd(10)}${String(row.users).padEnd(8)}`,
+      `  ${row.date.padEnd(dateWidth)}  ${row.source.padEnd(sourceWidth)}  ${dimLabel.padEnd(attrWidth)}  ${String(row.sessions).padEnd(10)}`,
     )
   }
 }
@@ -556,7 +556,6 @@ export async function gaSocialReferralSummary(project: string, opts?: { trend?: 
     if (isMachineFormat(opts.format)) {
       console.log(JSON.stringify({
         socialSessions: traffic.socialSessions,
-        socialUsers: traffic.socialUsers,
         totalSessions: traffic.totalSessions,
         socialSharePct: traffic.socialSharePct,
         windowStart: traffic.windowStart,
@@ -572,7 +571,6 @@ export async function gaSocialReferralSummary(project: string, opts?: { trend?: 
     const trendWindow = windowLine(traffic)
     if (trendWindow) console.log(`${trendWindow}\n`)
     console.log(`  Sessions: ${traffic.socialSessions} (${traffic.socialSharePct}% of ${traffic.totalSessions} total)`)
-    console.log(`  Users:    ${traffic.socialUsers}`)
     console.log()
 
     const fmtTrend = (pct: number | null) => pct === null ? 'n/a' : `${pct >= 0 ? '+' : ''}${pct}%`
@@ -597,7 +595,6 @@ export async function gaSocialReferralSummary(project: string, opts?: { trend?: 
   if (isMachineFormat(opts?.format)) {
     console.log(JSON.stringify({
       socialSessions: traffic.socialSessions,
-      socialUsers: traffic.socialUsers,
       totalSessions: traffic.totalSessions,
       socialSharePct: traffic.socialSharePct,
       windowStart: traffic.windowStart,
@@ -612,7 +609,6 @@ export async function gaSocialReferralSummary(project: string, opts?: { trend?: 
   const socialWindow = windowLine(traffic)
   if (socialWindow) console.log(`${socialWindow}\n`)
   console.log(`  Sessions: ${traffic.socialSessions} (${traffic.socialSharePct}% of ${traffic.totalSessions} total)`)
-  console.log(`  Users:    ${traffic.socialUsers}`)
   if (traffic.socialReferrals.length > 0) {
     console.log()
     console.log('  TOP SOURCES')
@@ -644,7 +640,6 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
         paidAiSessionsBySession: traffic.paidAiSessionsBySession,
         organicAiSessionsBySession: traffic.organicAiSessionsBySession,
         socialSessions: traffic.socialSessions,
-        socialUsers: traffic.socialUsers,
         directSessions: traffic.totalDirectSessions,
         aiSharePct: traffic.aiSharePct,
         aiSharePctBySession: traffic.aiSharePctBySession,
@@ -729,7 +724,6 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       paidAiSessionsBySession: traffic.paidAiSessionsBySession,
       organicAiSessionsBySession: traffic.organicAiSessionsBySession,
       socialSessions: traffic.socialSessions,
-      socialUsers: traffic.socialUsers,
       directSessions: traffic.totalDirectSessions,
       aiSharePct: traffic.aiSharePct,
       aiSharePctBySession: traffic.aiSharePctBySession,

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -1,6 +1,6 @@
 import { eq, desc, asc, and, ne, or, inArray, gte, lte, isNull, sql, exists } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { competitors, groupRunsByCreatedAt, healthSnapshots, insights, projects, queries, querySnapshots, runs, gbpLocations, gbpDailyMetrics, gbpKeywordMonthly, gbpPlaceActions, gbpLodgingSnapshots, gbpPlaceDetails, parseJsonColumn } from '@ainyc/canonry-db'
+import { competitors, groupRunsByCreatedAt, gscSearchData, healthSnapshots, insights, projects, queries, querySnapshots, runs, gbpLocations, gbpDailyMetrics, gbpKeywordMonthly, gbpPlaceActions, gbpLodgingSnapshots, gbpPlaceDetails, parseJsonColumn } from '@ainyc/canonry-db'
 import { analyzeRuns, analyzeGbp, classifyRegressionSeverity, compileCompetitiveSignalResolver, PERSISTENT_GAP_THRESHOLD, GBP_INSIGHT_PROVIDER } from '@ainyc/canonry-intelligence'
 import type { RunData, Snapshot, AnalysisResult, Insight, GbpLocationSignals, GbpKeywordPoint } from '@ainyc/canonry-intelligence'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
@@ -853,6 +853,50 @@ export class IntelligenceService {
   }
 
   /**
+   * Per-(date, query) rows folded from the page-keyed table, for days the
+   * accurate per-query table has not backfilled. Impressions here are a page
+   * fanout sum and therefore an over-count; this exists only so an un-backfilled
+   * day reads as "some demand" rather than "none".
+   */
+  private readGscPageSummedFallback(
+    projectId: string,
+    window: { startDate: string, endDate: string },
+  ): { date: string, query: string, clicks: number, impressions: number, position: number }[] {
+    const rows = this.db
+      .select({
+        date: gscSearchData.date,
+        query: gscSearchData.query,
+        clicks: gscSearchData.clicks,
+        impressions: gscSearchData.impressions,
+        position: gscSearchData.position,
+      })
+      .from(gscSearchData)
+      .where(and(
+        eq(gscSearchData.projectId, projectId),
+        gte(gscSearchData.date, window.startDate),
+        lte(gscSearchData.date, window.endDate),
+      ))
+      .all()
+    const byDay = new Map<string, { date: string, query: string, clicks: number, impressions: number, weighted: number }>()
+    for (const r of rows) {
+      if (!r.query) continue
+      const key = `${r.date}\u0000${r.query}`
+      const acc = byDay.get(key) ?? { date: r.date, query: r.query, clicks: 0, impressions: 0, weighted: 0 }
+      acc.clicks += r.clicks
+      acc.impressions += r.impressions
+      acc.weighted += (Number(r.position) || 0) * r.impressions
+      byDay.set(key, acc)
+    }
+    return [...byDay.values()].map(a => ({
+      date: a.date,
+      query: a.query,
+      clicks: a.clicks,
+      impressions: a.impressions,
+      position: a.impressions > 0 ? a.weighted / a.impressions : 0,
+    }))
+  }
+
+  /**
    * Apply severity tiering to the insights of an AnalysisResult and return a
    * new result. Wraps `applySeverityTiering` so callers (analyzeAndPersist,
    * analyzeRunWithPrevious) can pass the same tiered shape both into the DB
@@ -892,10 +936,19 @@ export class IntelligenceService {
     // errors pushed queries UP a tier, never down.
     const gscEnd = readLatestGscDataDate(this.db, projectId)
     const gscWindow = gscEnd ? severityGscWindow(gscEnd) : null
+    // The fallback is NOT empty. readLatestGscDataDate anchors on the watermark,
+    // the property table or the dimensioned table, none of which is
+    // gsc_query_daily_totals, so a project can be "connected" while the accurate
+    // table lags the window. Passing [] there would report zero impressions for
+    // every query and silently tier every regression DOWN, which is the failure
+    // the thresholds are least able to survive. Days the accurate table covers
+    // still win; only uncovered days fall back to the page-summed figure, which
+    // over-counts but is far closer than zero. Same degradation content-data.ts
+    // uses, so the two cannot drift.
     const gscTotals = gscWindow
       ? mergeGscQueryTotalsWithFallback(
           readGscQueryDailyRows(this.db, projectId, gscWindow.startDate, gscWindow.endDate),
-          [],
+          this.readGscPageSummedFallback(projectId, gscWindow),
         )
       : []
     const gscConnected = gscEnd !== null

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -1,10 +1,15 @@
 import { eq, desc, asc, and, ne, or, inArray, gte, lte, isNull, sql, exists } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { competitors, groupRunsByCreatedAt, gscSearchData, healthSnapshots, insights, projects, queries, querySnapshots, runs, gbpLocations, gbpDailyMetrics, gbpKeywordMonthly, gbpPlaceActions, gbpLodgingSnapshots, gbpPlaceDetails, parseJsonColumn } from '@ainyc/canonry-db'
+import { competitors, groupRunsByCreatedAt, healthSnapshots, insights, projects, queries, querySnapshots, runs, gbpLocations, gbpDailyMetrics, gbpKeywordMonthly, gbpPlaceActions, gbpLodgingSnapshots, gbpPlaceDetails, parseJsonColumn } from '@ainyc/canonry-db'
 import { analyzeRuns, analyzeGbp, classifyRegressionSeverity, compileCompetitiveSignalResolver, PERSISTENT_GAP_THRESHOLD, GBP_INSIGHT_PROVIDER } from '@ainyc/canonry-intelligence'
 import type { RunData, Snapshot, AnalysisResult, Insight, GbpLocationSignals, GbpKeywordPoint } from '@ainyc/canonry-intelligence'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
-import { buildGbpSummary } from '@ainyc/canonry-api-routes'
+import {
+  buildGbpSummary,
+  mergeGscQueryTotalsWithFallback,
+  readGscQueryDailyRows,
+  readLatestGscDataDate,
+} from '@ainyc/canonry-api-routes'
 import { CitationStates, RunKinds, RunStatuses, RunTriggers, effectiveDomains } from '@ainyc/canonry-contracts'
 import crypto from 'node:crypto'
 import { createLogger } from './logger.js'
@@ -82,6 +87,20 @@ function parseGbpInsightId(id: string): { location: string; slot: string } | nul
   const parts = id.split('::')
   if (parts.length !== 4 || parts[1] !== 'gbp') return null
   return { location: parts[2]!, slot: gbpInsightSlot(parts[3]!) }
+}
+
+/**
+ * Severity is a statement about the regression being reported, so its demand
+ * signal covers the same recent span the reader is looking at rather than the
+ * project's whole history. Anchored on the newest day GSC has published, since
+ * Google finalises a day two to three days late.
+ */
+const SEVERITY_GSC_WINDOW_DAYS = 30
+
+function severityGscWindow(endDate: string): { startDate: string, endDate: string } {
+  const end = new Date(`${endDate}T00:00:00Z`)
+  end.setUTCDate(end.getUTCDate() - (SEVERITY_GSC_WINDOW_DAYS - 1))
+  return { startDate: end.toISOString().slice(0, 10), endDate }
 }
 
 export class IntelligenceService {
@@ -858,18 +877,30 @@ export class IntelligenceService {
     const regressions = rawInsights.filter((i) => i.type === 'regression')
     if (regressions.length === 0) return rawInsights
 
-    // GSC impressions per query (case-insensitive).
-    // GSC impressions per query. Distinguish "GSC not connected" (no rows
-    // at all → undefined per query) from "connected but zero impressions
-    // for this query" (returns 0 — a real measurement).
-    const gscRows = this.db
-      .select({ query: gscSearchData.query, impressions: gscSearchData.impressions })
-      .from(gscSearchData)
-      .where(eq(gscSearchData.projectId, projectId))
-      .all()
-    const gscConnected = gscRows.length > 0
+    // GSC impressions per query (case-insensitive), over the severity window.
+    // Distinguish "GSC not connected" (no rows at all → undefined per query)
+    // from "connected but zero impressions for this query" (0, a real
+    // measurement).
+    //
+    // Read gsc_query_daily_totals, not gsc_search_data. The latter is keyed
+    // (date, query, page, country, device), so one SERP impression fans out
+    // into a row per ranking page and summing it over-counts; on a live
+    // property a single query summed to 151,571 against a true 26,477. It also
+    // had no date bound while SeveritySignals.gscImpressions is documented as
+    // "over the report window", so lifetime demand was being compared against
+    // the fixed 100 and 10 thresholds in classifyRegressionSeverity. Both
+    // errors pushed queries UP a tier, never down.
+    const gscEnd = readLatestGscDataDate(this.db, projectId)
+    const gscWindow = gscEnd ? severityGscWindow(gscEnd) : null
+    const gscTotals = gscWindow
+      ? mergeGscQueryTotalsWithFallback(
+          readGscQueryDailyRows(this.db, projectId, gscWindow.startDate, gscWindow.endDate),
+          [],
+        )
+      : []
+    const gscConnected = gscEnd !== null
     const gscImpressionsByQuery = new Map<string, number>()
-    for (const row of gscRows) {
+    for (const row of gscTotals) {
       const key = row.query.toLowerCase()
       gscImpressionsByQuery.set(key, (gscImpressionsByQuery.get(key) ?? 0) + row.impressions)
     }

--- a/packages/canonry/test/intelligence-service-severity.test.ts
+++ b/packages/canonry/test/intelligence-service-severity.test.ts
@@ -41,7 +41,8 @@ interface SeededRegression {
 function seedRegressionScenario(
   db: ReturnType<typeof createClient>,
   opts: { gscImpressions?: number
-  gscDate?: string; priorRegressions?: number } = {},
+  gscDate?: string
+  skipAccurateGsc?: boolean; priorRegressions?: number } = {},
 ): SeededRegression {
   const now = new Date()
   const projectId = crypto.randomUUID()
@@ -114,7 +115,7 @@ function seedRegressionScenario(
     // once per ranking page. The date is inside the severity window, which is
     // anchored on the newest published GSC day.
     const gscDate = opts.gscDate ?? '2026-04-01'
-    db.insert(gscQueryDailyTotals).values({
+    if (!opts.skipAccurateGsc) db.insert(gscQueryDailyTotals).values({
       id: crypto.randomUUID(),
       projectId,
       syncRunId: currentRunId,
@@ -214,6 +215,24 @@ describe('IntelligenceService — regression severity tiering', () => {
     new IntelligenceService(db).analyzeAndPersist(currentRunId, projectId)
 
     expect(persistedSeverity(db, currentRunId)).toBe('medium')
+  })
+
+  it('falls back to page-summed impressions when the accurate table has no row for that day', () => {
+    // readLatestGscDataDate anchors on the watermark, the property table or the
+    // dimensioned table, never on gsc_query_daily_totals, so a project can look
+    // connected while the accurate table lags the window. An empty fallback
+    // would report zero impressions for every query and tier every regression
+    // DOWN, which is the direction the fixed 100/10 thresholds are least able
+    // to survive. 500 page-summed impressions must still reach "high".
+    const db = createTempDb('intel-sev-')
+    const { projectId, currentRunId } = seedRegressionScenario(db, {
+      gscImpressions: 500,
+      skipAccurateGsc: true,
+    })
+
+    new IntelligenceService(db).analyzeAndPersist(currentRunId, projectId)
+
+    expect(persistedSeverity(db, currentRunId)).toBe('high')
   })
 
   it('persists "low" when neither traffic nor recurrence qualify', () => {

--- a/packages/canonry/test/intelligence-service-severity.test.ts
+++ b/packages/canonry/test/intelligence-service-severity.test.ts
@@ -18,6 +18,7 @@ import {
   queries,
   querySnapshots,
   insights,
+  gscQueryDailyTotals,
   gscSearchData,
 } from '@ainyc/canonry-db'
 import { IntelligenceService } from '../src/intelligence-service.js'
@@ -39,7 +40,8 @@ interface SeededRegression {
 
 function seedRegressionScenario(
   db: ReturnType<typeof createClient>,
-  opts: { gscImpressions?: number; priorRegressions?: number } = {},
+  opts: { gscImpressions?: number
+  gscDate?: string; priorRegressions?: number } = {},
 ): SeededRegression {
   const now = new Date()
   const projectId = crypto.randomUUID()
@@ -107,11 +109,31 @@ function seedRegressionScenario(
   }).run()
 
   if (opts.gscImpressions !== undefined) {
+    // Severity reads gsc_query_daily_totals, not gsc_search_data. The latter is
+    // keyed by page as well as query, so summing it counts one SERP impression
+    // once per ranking page. The date is inside the severity window, which is
+    // anchored on the newest published GSC day.
+    const gscDate = opts.gscDate ?? '2026-04-01'
+    db.insert(gscQueryDailyTotals).values({
+      id: crypto.randomUUID(),
+      projectId,
+      syncRunId: currentRunId,
+      date: gscDate,
+      query: 'foo query',
+      impressions: opts.gscImpressions,
+      clicks: 0,
+      position: '10',
+      syncedAt: now.toISOString(),
+      createdAt: now.toISOString(),
+    }).run()
+    // A page-fanned row for the same query on the same day. If severity ever
+    // reverts to gsc_search_data this doubles the impressions and the tier
+    // assertions below fail, which is the point of seeding it.
     db.insert(gscSearchData).values({
       id: crypto.randomUUID(),
       projectId,
       syncRunId: currentRunId,
-      date: '2026-04-01',
+      date: gscDate,
       query: 'foo query',
       page: '/foo',
       impressions: opts.gscImpressions,

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -359,11 +359,16 @@ export interface GaTrafficResponse {
   organicAiSessionsBySession: number
   /** @deprecated See `GA4AiReferralDto.users`. Never emitted since 4.135.0. */
   organicAiUsersBySession?: number
-  socialReferrals: Array<{ source: string; medium: string; sessions: number; users: number; channelGroup: string }>
+  socialReferrals: Array<{ source: string; medium: string; sessions: number; users?: number; channelGroup: string }>
   /** Total social sessions (session-scoped via sessionDefaultChannelGroup). */
   socialSessions: number
-  /** Total social users (session-scoped via sessionDefaultChannelGroup). */
-  socialUsers: number
+  /**
+   * @deprecated Never emitted. ga_social_referrals stores users as GA's COUNT
+   * DISTINCT at (date, source, medium, channel group), so summing it across a
+   * window counts a returning visitor once per day. Same reasoning that
+   * withdrew `GA4AiReferralDto.users` in 4.135.0.
+   */
+  socialUsers?: number
   /** Five disjoint buckets used for the channel breakdown. Known AI session-source matches are removed from their native GA4 bucket before shares are computed. */
   channelBreakdown: {
     organic: GA4ChannelBucketDto

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -151,7 +151,12 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   /** Total social sessions (session-scoped, no cross-dimension dedup needed). */
   socialSessions: z.number(),
   /** Total social users (session-scoped, no cross-dimension dedup needed). */
-  socialUsers: z.number(),
+  /**
+   * @deprecated Never emitted. ga_social_referrals stores users as GA's
+   * COUNT DISTINCT at (date, source, medium, channel group), so summing it
+   * across the window counts a returning visitor once per day.
+   */
+  socialUsers: z.number().optional(),
   /** Five disjoint buckets used for the channel breakdown. Known AI session-source matches are removed from their native GA4 bucket before shares are computed. */
   channelBreakdown: ga4ChannelBreakdownDtoSchema,
   /** Organic sessions as a percentage of total sessions (0–100, rounded). */

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -385,7 +385,13 @@ export const gaTrafficSectionSchema = z.object({
   topLandingPages: z.array(z.object({
     page: z.string(),
     sessions: z.number(),
-    users: z.number(),
+    /**
+     * @deprecated Never emitted. A per-landing-page user count cannot be
+     * summed: GA evaluates users as a COUNT DISTINCT at the requested grain,
+     * so a visitor is counted once per page and per day. Kept optional so
+     * existing consumers keep parsing.
+     */
+    users: z.number().optional(),
     organicSessions: z.number(),
   })),
   channelBreakdown: z.array(z.object({
@@ -558,6 +564,14 @@ export const serverActivitySectionSchema = z.object({
   topCrawledPaths: z.array(z.object({
     path: z.string(),
     verifiedHits: z.number(),
+    /**
+     * Hits from a crawler that identified itself but whose source IP could not
+     * be matched against the operator's published ranges. Additive, not an
+     * alternative: some log sources carry no client IP at all (Vercel request
+     * logs, for one), so for those projects every hit lands here and a
+     * verified-only view reports zero against real crawl activity.
+     */
+    unverifiedHits: z.number().default(0),
     /** How many distinct AI operators crawled this path in the window. */
     distinctOperators: z.number(),
   })),
@@ -573,6 +587,8 @@ export const serverActivitySectionSchema = z.object({
   dailyTrend: z.array(z.object({
     date: z.string(),
     verifiedCrawlerHits: z.number(),
+    /** See topCrawledPaths.unverifiedHits. Plotted alongside, never instead. */
+    unverifiedCrawlerHits: z.number().default(0),
     userFetchHits: z.number(),
     referralArrivals: z.number(),
   })),

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.180.5",
+  "version": "4.180.6",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.180.3",
+  "version": "4.180.5",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.180.5",
+  "version": "4.180.6",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.180.3",
+  "version": "4.180.5",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.180.5",
+  "version": "4.180.6",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.180.3",
+  "version": "4.180.5",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Context

Stacked on #1093, which fixed the first instance of this. **Merge #1093 first.** Both touch `content-data.ts`, which is why this branches from it rather than from `main`.

An audit for the same class as the AI referral double-count (#1092) turned up six more defects of one kind: a number shown to a user computed from a table in a way that table does not support.

## What ships

**Unbounded reads presented as windowed.** `ourBestPage.organicSessions` summed `ga_traffic_snapshots` across all retained history *and* summed the wrong column, so a per-page figure came out larger than the property's own total for the period it was labelled with. On one project that was 142 days of data under a heading saying 30. It now sums `organicSessions` over the analytics window. The content engine's AI referral denominator had the same missing bound, and it scales every opportunity score. `buildSocialReferrals` was the only section builder that never took `windowDays` at all.

**Severity tiering read the wrong table over the wrong span.** It queried `gsc_search_data` with no date filter while `SeveritySignals.gscImpressions` is documented as "over the report window". That table is keyed by page, so one impression counted once per ranking page. Both errors push a query *up* a tier and never down, against fixed thresholds of 100 and 10, and the result sets the severity badge in the report, the CLI and the Discord `insight.critical` events. Now reads `gsc_query_daily_totals` over a 30 day window anchored on the newest published day.

**User counts that cannot be summed.** GA evaluates users as a COUNT DISTINCT at the grain requested, so a per-landing-page or per-`(date, source, medium)` column counts a visitor once per page and once per day. The AI referral surfaces withdrew theirs in 4.135.0 with exactly this reasoning; the report's `topLandingPages`, the social referral rows and totals, and the AI referral history endpoint were still publishing one. Fields are optional-and-never-emitted rather than removed, so existing consumers keep parsing.

**Crawler surfaces filtered to `verified`.** Verification needs a client IP matched against the operator's published ranges, and some log sources carry none. A Vercel-backed project has *zero* verified rows, so it rendered an empty path table and a flat zero trend line beside a headline tile reporting thousands of hits. Measured: one project has 21,351 crawler rows, all `claimed_unverified`. The split is now a display attribute rather than a filter, with both tiers returned per path and per day. The per-operator delta compared a verified-only present against a verified-only past while every other cell in its row was combined; it now compares like with like.

**Category share had a mismatched denominator.** The numerator comes from the merged per-query set, the denominator was still the raw dimensioned sum. Those stopped being one source when per-query aggregation moved to the merge helper, so shares did not total 100 and drifted with an unrelated table's sync state. A window where the dimensioned fetch returned nothing rendered every category at 0%.

Patch bump to 4.180.6, plugin manifests synced, generated client regenerated.

## Test coverage

Three existing tests encoded the old behaviour and now assert the new contract, which is the useful part of the change:

- `ga.test.ts` explicitly asserted `socialUsers` *survives* the AI-referral withdrawal. It now asserts the opposite, with the grain reasoning inline.
- `report.test.ts` asserted top crawled paths were "verified only" and excluded an unverified path. It now asserts both tiers are returned and that the unverified-only path leads.
- The severity fixture seeded `gsc_search_data`. It now seeds `gsc_query_daily_totals` **and** a page-fanned row for the same query and day, so a revert to the old table doubles the impressions and the tier assertions fail.

## Validation

- [x] `pnpm run verify` clean: gen:check, plugin:check, typecheck, lint, 9,588 tests across 735 files
- [x] Every figure quantified against the live database before changing it
- [x] No em or en dashes in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
