### PR TITLE
test(web): stop clicking a DOM node captured before an await

### DIFF
--- a/apps/web/test/advanced-measurement-section.test.tsx
+++ b/apps/web/test/advanced-measurement-section.test.tsx
@@ -584,9 +584,31 @@ async function advancePropertiesToQuestions() {
   await advanceGroupsToQuestions()
 }
 
+/**
+ * Wait for an assignment button to be enabled, then click the LIVE node.
+ *
+ * The node must be re-queried after the wait. Holding a reference across an
+ * await is unsafe here because the flows these tests drive re-render the tree
+ * while waiting: after a 409 or 412 the section reloads the draft, and React may
+ * replace the button rather than reuse it. A detached node keeps whatever
+ * `disabled` value it had when it was captured, so the wait passes against a
+ * stale element and `fireEvent.click` then dispatches into a node that is no
+ * longer in the document. No handler runs, and the failure surfaces much later
+ * as "expected 2 calls, got 1", which reads like a product bug rather than a
+ * test defect.
+ *
+ * The `isConnected` check keeps that failure honest: if the node ever is
+ * detached, the test says so instead of silently clicking nothing.
+ */
 async function clickReadyAssignment(name: RegExp): Promise<void> {
+  await waitFor(() => {
+    // Strict: `.not.toHaveProperty('disabled', true)` also passes when the
+    // property is absent entirely, so it cannot tell "enabled" from "not a
+    // button".
+    expect(screen.getByRole('button', { name })).toHaveProperty('disabled', false)
+  })
   const button = screen.getByRole('button', { name })
-  await waitFor(() => expect(button).not.toHaveProperty('disabled', true))
+  expect(button.isConnected).toBe(true)
   fireEvent.click(button)
 }
 
@@ -1157,7 +1179,7 @@ describe('AdvancedMeasurementSection server draft controller', () => {
       'This setup changed in another session. The latest draft is loaded; review your changes again.',
     )).toBeTruthy()
     expect(fake.service.applyAssignments).toHaveBeenCalledTimes(1)
-    await waitFor(() => expect(screen.getByRole('button', { name: /Assign 1 query to all 1 Property/ })).not.toHaveProperty('disabled', true))
+    await waitFor(() => expect(screen.getByRole('button', { name: /Assign 1 query to all 1 Property/ })).toHaveProperty('disabled', false))
 
     await clickReadyAssignment(/Assign 1 query to all 1 Property/)
     await waitFor(() => expect(fake.service.applyAssignments).toHaveBeenCalledTimes(2))


### PR DESCRIPTION
## Context

`advanced-measurement-section.test.tsx` "reloads actionable state after a 409 assignment conflict" failed twice on the node 26 shard of an unrelated branch, then went green on a bare re-run with no code change. The symptom was `expected "vi.fn()" to be called 2 times, but got 1 times`.

The cause is in the shared helper:

```js
const button = screen.getByRole('button', { name })   // captured first
await waitFor(() => expect(button).not.toHaveProperty('disabled', true))
fireEvent.click(button)                                // may now be detached
```

The flows these tests drive re-render while waiting. After a 409 or 412 the section reloads the draft, and React may replace the button rather than reuse it. A detached node keeps whatever `disabled` value it had when captured, so the wait passes against a stale element and the click dispatches into a node that is no longer in the document. No handler runs, so the second `applyAssignments` never happens.

That explains why it is runtime dependent: whether React reuses or replaces a node comes down to scheduling.

## What ships

- The wait re-queries inside `waitFor`, and the click uses a freshly queried node.
- An `isConnected` assertion so a future occurrence fails as "the node was detached" rather than as a confusing call-count mismatch.
- The enabled check is strict. `.not.toHaveProperty('disabled', true)` also passes when the property is absent, so it could not distinguish an enabled button from an element that is not a button. It now asserts `disabled` is `false`.

Test-only, 26 lines, no version bump.

## What I could not do

**I did not reproduce the original failure.** Stating that plainly rather than claiming a verified fix:

- 10 of 10 runs pass on node 24 and on node 26 in isolation, both before and after the change.
- A faithful shard reproduction needs native modules rebuilt for node 26; locally `better-sqlite3` is built for ABI 137 and 1,080 unrelated tests fail to load.
- The local shard split does not contain this file, so `--shard=1/2` does not exercise it here.

The change is justified by the anti-pattern on its own merits: holding an element reference across an await is unsafe in Testing Library, and it produces exactly the observed symptom. If the failure recurs, the `isConnected` assertion will now say whether this was the cause.

## Validation

- [x] `pnpm run verify` clean: 9,603 tests across 736 files
- [x] 10 consecutive passes on node 24 and node 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
