### PR TITLE
fix(web): make the whole traffic source row clickable, not just the arrow

### DIFF
--- a/apps/web/src/lib/row-navigation.ts
+++ b/apps/web/src/lib/row-navigation.ts
@@ -1,0 +1,53 @@
+/**
+ * Make a whole table row navigate, without breaking the things a row full of
+ * text needs to keep doing.
+ *
+ * A row that highlights on hover reads as clickable, so when only a small
+ * "View" link navigates, most of the target is dead. Putting a bare onClick on
+ * the row fixes that and breaks three other things, which is why this helper
+ * exists rather than an inline handler:
+ *
+ * - Selecting text by dragging across the row ends in a navigation, so the
+ *   figures in the row cannot be copied.
+ * - Cmd, Ctrl, Shift and middle clicks navigate in place instead of opening a
+ *   new tab or window, which is what those gestures mean everywhere else.
+ * - A click on a control inside the row navigates as well as acting, so a
+ *   button in a cell does two things at once.
+ *
+ * KEYBOARD AND ASSISTIVE TECH ARE NOT SERVED BY THIS. A row is not focusable
+ * and this adds no role, because announcing a whole row as a link would bury
+ * the cells it contains. Every row using this MUST still contain a real anchor
+ * (the primary cell's link), which is what keyboard users, screen readers, and
+ * "copy link address" actually use. This handler is a mouse convenience layered
+ * on top of that link, never a replacement for it.
+ */
+const INTERACTIVE = 'a, button, input, select, textarea, label, [role="button"], [role="link"], [role="checkbox"], [role="menuitem"]'
+
+export function shouldNavigateFromRowClick(event: {
+  target: EventTarget | null
+  defaultPrevented: boolean
+  button: number
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+}): boolean {
+  if (event.defaultPrevented) return false
+  // Primary button only. Auxiliary and secondary clicks have their own meaning.
+  if (event.button !== 0) return false
+  // Let the browser's own new-tab / new-window / download gestures through to
+  // the real link rather than swallowing them into a same-tab navigation.
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false
+
+  const target = event.target
+  if (target && typeof (target as Element).closest === 'function') {
+    // A control inside the row already handled this click.
+    if ((target as Element).closest(INTERACTIVE)) return false
+  }
+
+  // A drag that selected text is a copy gesture, not a click-through.
+  const selection = typeof window !== 'undefined' ? window.getSelection() : null
+  if (selection && !selection.isCollapsed && selection.toString().trim() !== '') return false
+
+  return true
+}

--- a/apps/web/src/pages/ProjectsPage.tsx
+++ b/apps/web/src/pages/ProjectsPage.tsx
@@ -3,6 +3,7 @@ import { Plus } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
 
 import { Button } from '../components/ui/button.js'
+import { shouldNavigateFromRowClick } from '../lib/row-navigation.js'
 import { Card } from '../components/ui/card.js'
 import { StatusBadge } from '../components/shared/StatusBadge.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
@@ -221,13 +222,19 @@ export function ProjectsPage() {
               {projects.map((p) => {
                 const latestRun = p.recentRuns[0]
                 return (
-                  <tr key={p.project.id} className="cursor-pointer" onClick={() => { void navigate({ to: '/projects/$projectName', params: { projectName: p.project.name } }) }}>
+                  <tr
+                    key={p.project.id}
+                    className="cursor-pointer"
+                    onClick={(event) => {
+                      if (!shouldNavigateFromRowClick(event)) return
+                      void navigate({ to: '/projects/$projectName', params: { projectName: p.project.name } })
+                    }}
+                  >
                     <td>
                       <Link
                         to="/projects/$projectName"
                         params={{ projectName: p.project.name }}
                         className="text-heading font-medium hover:underline"
-                        onClick={(e) => e.stopPropagation()}
                       >
                         {p.project.displayName || p.project.name}
                       </Link>

--- a/apps/web/src/pages/TrafficPage.tsx
+++ b/apps/web/src/pages/TrafficPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useQueries, useQuery } from '@tanstack/react-query'
-import { Link } from '@tanstack/react-router'
+import { Link, useNavigate } from '@tanstack/react-router'
 import { ArrowRight, Plus } from 'lucide-react'
 
 import type { TrafficSourceDto } from '@ainyc/canonry-contracts'
@@ -13,6 +13,7 @@ import {
 import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
+import { shouldNavigateFromRowClick } from '../lib/row-navigation.js'
 import { ConnectSourceDrawer } from '../components/server-traffic/ConnectSourceDrawer.js'
 import {
   toneFromTrafficSourceStatus,
@@ -132,6 +133,7 @@ export function TrafficPage() {
 }
 
 function SourcesTable({ projectName, sources }: { projectName: string; sources: TrafficSourceDto[] }) {
+  const navigate = useNavigate()
   // UI/CLI parity: this view shows last-24h totals + latest run, the same shape `canonry traffic status`
   // returns. Rather than denormalize the totals onto the list endpoint, fan out to /traffic/sources/:id.
   const detailQueries = useQueries({
@@ -167,9 +169,27 @@ function SourcesTable({ projectName, sources }: { projectName: string; sources: 
         </thead>
         <tbody className="divide-y divide-mono-800/60">
           {rows.map(({ source, detail, isLoading }) => (
-            <tr key={source.id} className="hover:bg-bg-elevated/40 transition-colors">
+            <tr
+              key={source.id}
+              className="cursor-pointer transition-colors hover:bg-bg-elevated/40 focus-within:bg-bg-elevated/40"
+              onClick={(event) => {
+                if (!shouldNavigateFromRowClick(event)) return
+                void navigate({
+                  to: '/traffic/$projectName/$sourceId',
+                  params: { projectName, sourceId: source.id },
+                })
+              }}
+            >
               <td className="px-4 py-3">
-                <div className="font-medium text-heading">{source.displayName}</div>
+                {/* The real anchor. The row's onClick is a mouse convenience on
+                    top of this; keyboard and assistive tech use the link. */}
+                <Link
+                  to="/traffic/$projectName/$sourceId"
+                  params={{ projectName, sourceId: source.id }}
+                  className="font-medium text-heading hover:underline"
+                >
+                  {source.displayName}
+                </Link>
               </td>
               <td className="px-4 py-3">
                 <ToneBadge tone={toneFromTrafficSourceStatus(source.status)}>

--- a/apps/web/test/row-navigation.test.ts
+++ b/apps/web/test/row-navigation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { shouldNavigateFromRowClick } from '../src/lib/row-navigation.js'
+
+const click = (over: Partial<Parameters<typeof shouldNavigateFromRowClick>[0]> = {}) => ({
+  target: null,
+  defaultPrevented: false,
+  button: 0,
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  ...over,
+})
+
+describe('shouldNavigateFromRowClick', () => {
+  it('navigates on a plain primary click', () => {
+    expect(shouldNavigateFromRowClick(click())).toBe(true)
+  })
+
+  it.each([
+    ['meta', { metaKey: true }],
+    ['ctrl', { ctrlKey: true }],
+    ['shift', { shiftKey: true }],
+    ['alt', { altKey: true }],
+  ])('leaves a %s click to the browser, so open-in-new-tab still works', (_label, mods) => {
+    expect(shouldNavigateFromRowClick(click(mods))).toBe(false)
+  })
+
+  it('ignores middle and right clicks', () => {
+    expect(shouldNavigateFromRowClick(click({ button: 1 }))).toBe(false)
+    expect(shouldNavigateFromRowClick(click({ button: 2 }))).toBe(false)
+  })
+
+  it('ignores a click something else already handled', () => {
+    expect(shouldNavigateFromRowClick(click({ defaultPrevented: true }))).toBe(false)
+  })
+
+  it.each(['a', 'button', 'input', 'select', 'textarea', 'label'])(
+    'does not navigate when the click came from a <%s> inside the row', tag => {
+      const row = document.createElement('tr')
+      const cell = document.createElement('td')
+      const control = document.createElement(tag)
+      cell.appendChild(control)
+      row.appendChild(cell)
+      document.body.appendChild(row)
+      expect(shouldNavigateFromRowClick(click({ target: control }))).toBe(false)
+      row.remove()
+    })
+
+  it('does not navigate when the click came from a role=button element', () => {
+    const el = document.createElement('div')
+    el.setAttribute('role', 'button')
+    document.body.appendChild(el)
+    expect(shouldNavigateFromRowClick(click({ target: el }))).toBe(false)
+    el.remove()
+  })
+
+  it('navigates when the click came from plain text in a cell', () => {
+    const cell = document.createElement('td')
+    cell.textContent = '116'
+    document.body.appendChild(cell)
+    expect(shouldNavigateFromRowClick(click({ target: cell }))).toBe(true)
+    cell.remove()
+  })
+
+  it('does not navigate when the drag selected text, so figures stay copyable', () => {
+    const cell = document.createElement('td')
+    cell.textContent = '116 content crawls'
+    document.body.appendChild(cell)
+    const range = document.createRange()
+    range.selectNodeContents(cell)
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    expect(shouldNavigateFromRowClick(click({ target: cell }))).toBe(false)
+
+    selection.removeAllRanges()
+    // With the selection cleared, the same click is a click again.
+    expect(shouldNavigateFromRowClick(click({ target: cell }))).toBe(true)
+    cell.remove()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.180.6",
+  "version": "4.180.7",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.180.6",
+  "version": "4.180.7",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.180.6",
+  "version": "4.180.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.180.6",
+  "version": "4.180.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.180.6",
+  "version": "4.180.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Context

The server traffic table highlights a row on hover, which reads as clickable, but only the small "View" link navigated. Most of the target was dead.

## What ships

The row navigates, and the source name is a real anchor rather than plain text. Keyboard users, screen readers and "copy link address" use that anchor; the row handler is a mouse convenience layered on top of it. The row deliberately gets no `role` and no `tabIndex`, because announcing a whole row as a link would bury the cells inside it.

A bare `onClick` on a row breaks three things, which is why the guard is a shared helper rather than an inline handler:

| Gesture | Without the guard |
|---|---|
| Drag to select a figure | Navigates, so the row cannot be copied |
| Cmd, Ctrl, Shift, middle click | Navigates in place instead of opening a new tab |
| Click a control in a cell | Navigates as well as acting |

`ProjectsPage` already had a clickable row with all three of those problems and now uses the same helper. Its inner link no longer needs `stopPropagation`, since the helper ignores clicks that originated on an anchor.

## Sweep for the same issue

| Surface | Finding |
|---|---|
| `TrafficPage` | The reported bug. Fixed. |
| `ProjectsPage` | Clickable already, but no guards. Fixed. |
| `OverviewPage` | Wraps the entire row in a `Link`. Better than either of the above; left alone. |
| `TrafficSourceDetailPage` | Hovering row is an event log with nowhere to navigate, so the hover is feedback, not a false affordance. |
| `EvidenceTable`, `CompetitorTable`, `GscSection`, `AdvancedMeasurementOverview` | `cursor-pointer` rows that all have handlers. |

## Test coverage

`row-navigation.test.ts` covers each guard: a plain click navigates; each of the four modifier keys does not; middle and right clicks do not; an already-handled click does not; a click originating on `a`, `button`, `input`, `select`, `textarea`, `label` or `role="button"` does not; a click on plain cell text does; and a click after a text selection does not, then does again once the selection is cleared.

## Validation

- [x] `pnpm run verify` clean: 9,619 tests across 737 files
- [x] Patch bump to 4.180.7 with plugin manifests synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
