### PR TITLE
Present Canonry as the AEO platform for your agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Run Canonry on your infrastructure with your own provider keys. Use the dashboar
 
 > Find a weak page using our site audit and search data. Propose a content update for review. After I approve it, publish through WordPress, submit the sitemap, and rerun the checks.
 
-Your agent coordinates the steps using Canonry's tools and returns the results for review. Activating ChatGPT Ads requires explicit approval of the prepared campaign tree.
+Your agent coordinates the steps using Canonry's tools and returns the results for review.
 
 ### Built-in integrations and workflows
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,23 @@
 
 [![npm version](https://img.shields.io/npm/v/@canonry/canonry)](https://www.npmjs.com/package/@canonry/canonry) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
 
-**Measure your presence in AI search. Act on the evidence.**
+**Give your agent the evidence, tools, and skills to run AEO.**
 
-Canonry is an open-source AEO operating platform. It connects AI answers and citations with search analytics, website traffic, and technical audits. Your agent can use that evidence to plan content, update WordPress pages, deploy structured data, submit sitemaps, and prepare paused ChatGPT Ads campaigns for approval.
+Canonry is an agent-first, open-source AEO operating platform. Connect the agent you already use through the [Agent Plugin](docs/plugins.md), [MCP](docs/mcp.md), CLI, or REST API. Canonry gives it the project evidence, tools, and skills to measure AI visibility, investigate problems, and carry out the work.
 
-Run it on your infrastructure with your own provider keys. Work through the CLI, REST API, or MCP, with a dashboard for reviewing evidence and recommendations.
+Your agent can combine AI answers and citations with search analytics, website traffic, and technical audits. It can plan content, update WordPress pages, deploy structured data, submit sitemaps, and prepare paused ChatGPT Ads campaigns for approval.
+
+Run Canonry on your infrastructure with your own provider keys. Use the dashboard to review the same evidence and recommendations as your agent.
 
 `npm install -g @canonry/canonry`
 
-![Canonry connects AI visibility, search analytics, and traffic evidence to content, indexing, and ChatGPT Ads actions through CLI, REST API, MCP, and webhooks. Rerun measurements to check what changed.](https://raw.githubusercontent.com/Canonry/canonry/main/docs/images/measure-act.svg)
+![Your agent uses Canonry's evidence, CLI, REST API, MCP tools, and webhooks to measure AI visibility, publish content and schema, submit sitemaps, prepare ChatGPT Ads for approval, and measure what changed.](https://raw.githubusercontent.com/Canonry/canonry/main/docs/images/measure-act.svg)
 
-**Example workflow:** Find a weak page → review a content change → publish through WordPress → submit the sitemap → rerun checks.
+**Give your agent a job:**
 
-Use the connected tools to investigate and carry out each step. Review content before publishing; activating ChatGPT Ads requires explicit approval of the prepared campaign tree.
+> Find a weak page using our site audit and search data. Propose a content update for review. After I approve it, publish through WordPress, submit the sitemap, and rerun the checks.
+
+Your agent coordinates the steps using Canonry's tools and returns the results for review. Activating ChatGPT Ads requires explicit approval of the prepared campaign tree.
 
 ### Built-in integrations and workflows
 
@@ -30,6 +34,38 @@ Use the connected tools to investigate and carry out each step. Review content b
 - **Client reporting:** Automate [scheduled checks and data syncs](skills/canonry/references/canonry-cli.md#scheduling--notifications), send webhook alerts, and generate [client-ready HTML reports](skills/canonry/references/canonry-cli.md#reports).
 
 The dashboard, CLI, and agent tools share the same project API.
+
+<a id="or-use-any-shell-capable-coding-agent"></a>
+
+## Start with your agent
+
+Connect the [Agent Plugin](docs/plugins.md) or [MCP adapter](docs/mcp.md) to your agent. For any shell-capable agent, copy the setup request below.
+
+<details>
+<summary>Copy the Site Health-first setup request</summary>
+
+<br />
+
+```text
+Help me set up Canonry for my public site.
+
+Use the official Canonry docs:
+- Agent quickstart: https://github.com/Canonry/canonry#or-use-any-shell-capable-coding-agent
+- CLI reference: https://github.com/Canonry/canonry/blob/main/skills/canonry/references/canonry-cli.md
+- Plugin setup: https://github.com/Canonry/canonry/blob/main/docs/plugins.md
+- MCP setup: https://github.com/Canonry/canonry/blob/main/docs/mcp.md
+
+If a Canonry installation or connected plugin/MCP is available, use it. Do not create a duplicate. Choose the connected tools or the shell path, not both. The `cnry` and `canonry` commands are interchangeable.
+
+1. Ask for my public domain, country, and language. Do not create or scan anything yet.
+2. If connected tools are available, use them for the remaining steps. For the shell path, make sure that `cnry` is on PATH. Then run `cnry --version`. If Canonry is missing, propose `npm install -g @canonry/canonry` and wait for approval. If configuration is missing, tell me to run `cnry bootstrap` in my private terminal and wait. Never ask me to paste passwords, API keys, OAuth credentials, or command output.
+3. Make sure that the API or connected tool is reachable. If the shell API is unavailable, propose `cnry start`. Wait for approval. List the projects with the connected project tool or `cnry project list --format json`. Reuse a project with the same domain. Make sure that the proposed name is not assigned to a different domain. If no match exists, show the exact create operation and wait for approval.
+4. Propose a bounded Site Health scan. Include `--max-pages` and the state of dead-link checking. Show the connected operation or exact `cnry technical-aeo run ... --wait --format json` command. Wait for separate approval before scanning.
+5. If the run status is `completed` or `partial`, read its score and worst pages with run-pinned connected tools. For the shell path, use `cnry technical-aeo score <project> --run-id <run-id> --format json` and `cnry technical-aeo pages <project> --run-id <run-id> --sort score-asc --limit 10 --format jsonl`. If the run failed or was cancelled, inspect the run error and stop. Summarize completed evidence and propose AI Visibility setup.
+6. Ask before you add queries, connect providers, start a provider-backed or quota-consuming run, edit files, or publish.
+```
+
+</details>
 
 ## Get a Page Health baseline
 
@@ -77,36 +113,6 @@ The dashboard, CLI, and agent tools share the same project API.
 
    `--wait` polls for up to 15 minutes. If the scan remains active, use the progress command below. If it fails or is cancelled, inspect it with `cnry run show <run-id> --format json`.
 
-## Or use any shell-capable coding agent
-
-If your client supports the [Agent Plugin](docs/plugins.md) or [MCP adapter](docs/mcp.md), use that integration. Otherwise, paste this request into any shell-capable agent.
-
-<details>
-<summary>Copy the Site Health-first setup request</summary>
-
-<br />
-
-```text
-Help me set up Canonry for my public site.
-
-Use the official Canonry docs:
-- Agent quickstart: https://github.com/Canonry/canonry#or-use-any-shell-capable-coding-agent
-- CLI reference: https://github.com/Canonry/canonry/blob/main/skills/canonry/references/canonry-cli.md
-- Plugin setup: https://github.com/Canonry/canonry/blob/main/docs/plugins.md
-- MCP setup: https://github.com/Canonry/canonry/blob/main/docs/mcp.md
-
-If a Canonry installation or connected plugin/MCP is available, use it. Do not create a duplicate. Choose the connected tools or the shell path, not both. The `cnry` and `canonry` commands are interchangeable.
-
-1. Ask for my public domain, country, and language. Do not create or scan anything yet.
-2. If connected tools are available, use them for the remaining steps. For the shell path, make sure that `cnry` is on PATH. Then run `cnry --version`. If Canonry is missing, propose `npm install -g @canonry/canonry` and wait for approval. If configuration is missing, tell me to run `cnry bootstrap` in my private terminal and wait. Never ask me to paste passwords, API keys, OAuth credentials, or command output.
-3. Make sure that the API or connected tool is reachable. If the shell API is unavailable, propose `cnry start`. Wait for approval. List the projects with the connected project tool or `cnry project list --format json`. Reuse a project with the same domain. Make sure that the proposed name is not assigned to a different domain. If no match exists, show the exact create operation and wait for approval.
-4. Propose a bounded Site Health scan. Include `--max-pages` and the state of dead-link checking. Show the connected operation or exact `cnry technical-aeo run ... --wait --format json` command. Wait for separate approval before scanning.
-5. If the run status is `completed` or `partial`, read its score and worst pages with run-pinned connected tools. For the shell path, use `cnry technical-aeo score <project> --run-id <run-id> --format json` and `cnry technical-aeo pages <project> --run-id <run-id> --sort score-asc --limit 10 --format jsonl`. If the run failed or was cancelled, inspect the run error and stop. Summarize completed evidence and propose AI Visibility setup.
-6. Ask before you add queries, connect providers, start a provider-backed or quota-consuming run, edit files, or publish.
-```
-
-</details>
-
 ## Add AI Visibility when you need it
 
 ![Canonry AI Visibility mention share trend across answer engines](https://raw.githubusercontent.com/Canonry/canonry/main/docs/images/ai-visibility-trend.png)
@@ -140,7 +146,7 @@ cnry visibility-stats my-site --by-provider
 | **CLI and REST API** | Script project measurements, diagnoses, actions, reports, and schedules. OpenAPI is available at `GET /api/v1/openapi.json`. |
 | **MCP and Agent Plugin** | Give Codex, Claude, Cursor, or a custom agent a typed, task-shaped tool surface. |
 | **Aero** | When enabled and configured, use the built-in analyst that reviews evidence and wakes after completed runs. |
-| **Dashboard** | Approve work, inspect evidence, and observe the same project record used by agents. |
+| **Dashboard** | Review recommendations, inspect evidence, and observe the same project record used by agents. |
 
 ## Deployment and trust boundary
 

--- a/README.md
+++ b/README.md
@@ -2,24 +2,19 @@
 
 [![npm version](https://img.shields.io/npm/v/@canonry/canonry)](https://www.npmjs.com/package/@canonry/canonry) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
 
-Your entire AEO/GEO/AI Visibility, technical SEO + web analytics stack. **Agent-first. Self-hosted. Local.**
+**Measure your presence in AI search. Act on the evidence.**
 
-Think PostHog, for AI search visibility. Canonry tracks what ChatGPT, Claude, Gemini, and Perplexity say about you, joins it with your search, server side traffic data and paid media, and gives your agent the tools + skills to fix what it finds.
+Canonry is an open-source AEO operating platform. It connects AI answers and citations with search analytics, website traffic, and technical audits. Your agent can use that evidence to plan content, update WordPress pages, deploy structured data, submit sitemaps, and prepare paused ChatGPT Ads campaigns for approval.
+
+Run it on your infrastructure with your own provider keys. Work through the CLI, REST API, or MCP, with a dashboard for reviewing evidence and recommendations.
 
 `npm install -g @canonry/canonry`
 
-![Canonry AI Visibility mention share trend across answer engines](https://raw.githubusercontent.com/Canonry/canonry/main/docs/images/ai-visibility-trend.png)
+![Canonry connects AI visibility, search analytics, and traffic evidence to content, indexing, and ChatGPT Ads actions through CLI, REST API, MCP, and webhooks. Rerun measurements to check what changed.](https://raw.githubusercontent.com/Canonry/canonry/main/docs/images/measure-act.svg)
 
-*Track your share of answer-engine brand mentions over time.*
+**Example workflow:** Find a weak page → review a content change → publish through WordPress → submit the sitemap → rerun checks.
 
-**Measure → diagnose → approve action → measure change**
-
-| Phase | What Canonry does |
-|---|---|
-| **Measure** | Track mentions and citations across Gemini, ChatGPT, Claude, Perplexity, and local models. Join them with GSC, GA4, Bing, server side traffic, Business Profile, and backlink data. |
-| **Diagnose** | Crawl the site, score Page Health, inspect evidence, compare competitors, and explain regressions. |
-| **Act** | Give your agent the context + skills to make surgical on-site technical SEO changes and coordinate content, indexing, analytics, and paid media. |
-| **Operate** | Create automation workflows, schedule checks, sync data, send webhooks, and generate client-ready reports. |
+Use the connected tools to investigate and carry out each step. Review content before publishing; activating ChatGPT Ads requires explicit approval of the prepared campaign tree.
 
 ### Built-in integrations and workflows
 
@@ -113,6 +108,10 @@ If a Canonry installation or connected plugin/MCP is available, use it. Do not c
 </details>
 
 ## Add AI Visibility when you need it
+
+![Canonry AI Visibility mention share trend across answer engines](https://raw.githubusercontent.com/Canonry/canonry/main/docs/images/ai-visibility-trend.png)
+
+*Track your share of answer-engine brand mentions over time.*
 
 ![Canonry AI Visibility citation map across queries and answer engines](https://raw.githubusercontent.com/Canonry/canonry/main/docs/images/ai-visibility-diagnostics.png)
 

--- a/docs/images/measure-act.svg
+++ b/docs/images/measure-act.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640" role="img" aria-labelledby="title description">
+  <title id="title">Canonry connects measurement and action</title>
+  <desc id="description">Measure AI answers and citations, search analytics, server traffic, and site health. Use Canonry's CLI, REST API, MCP tools, and webhooks to publish content and schema, submit sitemaps and URLs, and prepare ChatGPT Ads for approval. Canonry is open source, self-hosted, and uses your provider keys. Measure what changed to close the loop.</desc>
+  <defs>
+    <marker id="forward" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 10 5 0 10Z" fill="#b71912"/>
+    </marker>
+  </defs>
+
+  <rect width="1280" height="640" fill="#f8f5f4"/>
+
+  <g font-family="'SFMono-Regular', Consolas, 'Liberation Mono', monospace" fill="#b71912">
+    <text x="640" y="53" text-anchor="middle" font-size="19" letter-spacing="3">WHERE CANONRY SITS</text>
+    <path d="M606 76H674" stroke="#b71912" stroke-width="2.5"/>
+  </g>
+  <text x="640" y="137" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="47" fill="#242120">One open system across both halves.</text>
+
+  <!-- Evidence and work flank the shared operating system. -->
+  <g stroke="#ded9d6" stroke-width="1.5">
+    <path d="M48 195H365M48 508H365M918 195H1232M918 508H1232"/>
+    <path d="M48 374H365M48 429H365M918 374H1232M918 429H1232"/>
+  </g>
+  <rect x="411" y="195" width="458" height="313" fill="#fff" stroke="#b71912" stroke-width="1.5"/>
+
+  <g font-family="'SFMono-Regular', Consolas, 'Liberation Mono', monospace" font-size="19" letter-spacing="1.6" fill="#b71912">
+    <text x="48" y="239">MEASURE</text>
+    <text x="435" y="239">CANONRY</text>
+    <text x="918" y="239">ACT</text>
+  </g>
+  <g font-family="Georgia, 'Times New Roman', serif" font-size="36" fill="#242120">
+    <text x="48" y="286">The evidence</text>
+    <text x="435" y="286" fill="#b71912">The bridge</text>
+    <text x="918" y="286">The work</text>
+  </g>
+
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif" font-size="23" fill="#514c49">
+    <text x="48" y="353">AI answers and citations</text>
+    <text x="48" y="408">Search and analytics</text>
+    <text x="48" y="462">Server traffic and site health</text>
+    <text x="918" y="353">Publish content and schema</text>
+    <text x="918" y="408">Submit sitemaps and URLs</text>
+    <text x="918" y="459">Prepare ChatGPT Ads</text>
+    <text x="918" y="488">for approval</text>
+  </g>
+
+  <g fill="none" stroke="#b71912" stroke-width="1.5">
+    <rect x="435" y="319" width="134" height="39"/>
+    <rect x="579" y="319" width="134" height="39"/>
+    <rect x="723" y="319" width="122" height="39"/>
+  </g>
+  <g font-family="'SFMono-Regular', Consolas, 'Liberation Mono', monospace" font-size="17" fill="#b71912" text-anchor="middle">
+    <text x="502" y="344">OPEN SOURCE</text>
+    <text x="646" y="344">SELF-HOSTED</text>
+    <text x="784" y="344">YOUR KEYS</text>
+  </g>
+  <path d="M435 386H845" stroke="#e5e1df" stroke-width="1.5"/>
+  <g font-family="'SFMono-Regular', Consolas, 'Liberation Mono', monospace" font-size="21" fill="#514c49">
+    <text x="435" y="428"><tspan fill="#b71912">+</tspan><tspan dx="10">CLI</tspan></text>
+    <text x="651" y="428"><tspan fill="#b71912">+</tspan><tspan dx="10">REST API</tspan></text>
+    <text x="435" y="473"><tspan fill="#b71912">+</tspan><tspan dx="10">MCP TOOLS</tspan></text>
+    <text x="651" y="473"><tspan fill="#b71912">+</tspan><tspan dx="10">WEBHOOKS</tspan></text>
+  </g>
+
+  <g fill="none" stroke="#b71912" stroke-width="2.5" marker-end="url(#forward)">
+    <path d="M374 354H398"/>
+    <path d="M880 354H905"/>
+    <path d="M1075 526V577H206V527"/>
+  </g>
+  <rect x="480" y="559" width="320" height="36" fill="#f8f5f4"/>
+  <text x="640" y="585" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif" font-size="23" fill="#b71912">Measure what changed</text>
+</svg>

--- a/docs/images/measure-act.svg
+++ b/docs/images/measure-act.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640" role="img" aria-labelledby="title description">
-  <title id="title">Canonry connects measurement and action</title>
-  <desc id="description">Measure AI answers and citations, search analytics, server traffic, and site health. Use Canonry's CLI, REST API, MCP tools, and webhooks to publish content and schema, submit sitemaps and URLs, and prepare ChatGPT Ads for approval. Canonry is open source, self-hosted, and uses your provider keys. Measure what changed to close the loop.</desc>
+  <title id="title">Your agent uses Canonry to measure and act</title>
+  <desc id="description">Your agent uses Canonry's evidence and tools to operate across measurement and action. Read AI answers and citations, search analytics, server traffic, and site health. Through Canonry's CLI, REST API, MCP tools, and webhooks, your agent can publish content and schema, submit sitemaps and URLs, and prepare ChatGPT Ads for approval. Canonry is open source, self-hosted, and uses your provider keys. Your agent measures what changed to close the loop.</desc>
   <defs>
     <marker id="forward" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0 0 10 5 0 10Z" fill="#b71912"/>
@@ -10,10 +10,10 @@
   <rect width="1280" height="640" fill="#f8f5f4"/>
 
   <g font-family="'SFMono-Regular', Consolas, 'Liberation Mono', monospace" fill="#b71912">
-    <text x="640" y="53" text-anchor="middle" font-size="19" letter-spacing="3">WHERE CANONRY SITS</text>
+    <text x="640" y="53" text-anchor="middle" font-size="19" letter-spacing="3">BUILT FOR YOUR AGENT</text>
     <path d="M606 76H674" stroke="#b71912" stroke-width="2.5"/>
   </g>
-  <text x="640" y="137" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="47" fill="#242120">One open system across both halves.</text>
+  <text x="640" y="137" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="43" fill="#242120">Your agent. One system to measure and act.</text>
 
   <!-- Evidence and work flank the shared operating system. -->
   <g stroke="#ded9d6" stroke-width="1.5">
@@ -29,7 +29,7 @@
   </g>
   <g font-family="Georgia, 'Times New Roman', serif" font-size="36" fill="#242120">
     <text x="48" y="286">The evidence</text>
-    <text x="435" y="286" fill="#b71912">The bridge</text>
+    <text x="435" y="286" font-size="34" fill="#b71912">Your agent’s tools</text>
     <text x="918" y="286">The work</text>
   </g>
 


### PR DESCRIPTION
- Lead with the user's agent as the operator, using Canonry's evidence, tools, and skills through the Agent Plugin, MCP, CLI, or REST API.
- Add an agent-focused measurement/action diagram and a concrete job prompt. Make agent setup primary while preserving its existing link, and move the visibility chart into its own section.
- Describe the dashboard's role in reviewing evidence and recommendations.

[Preview the diagram](https://github.com/Canonry/canonry/blob/ax/readme-evidence-to-action/docs/images/measure-act.svg). The README uses the canonical main-branch asset URL for npm compatibility; it will resolve after merge.

Validation: documentation checks, links/image targets, unchanged setup commands and prompt, preserved setup anchor through GitHub's Markdown renderer, SVG XML/accessibility checks, visual review at 830px, and the latest lint commit hook passed. Runtime code is unchanged. Earlier typecheck and lint passed; the full test run had 696 passing files and 41 failing files (9,301 tests passed, 270 failed, 48 skipped), including sandbox `listen EPERM` errors and other assertions. Rerunning the snapshot-command and MCP stdio suites with loopback access passed all 12 tests.