### PR TITLE
fix(web): simplify competitor landscape evidence notes

### DIFF
--- a/apps/web/src/components/project/CompetitorLandscape.tsx
+++ b/apps/web/src/components/project/CompetitorLandscape.tsx
@@ -1,4 +1,5 @@
 import { useId, useState, type KeyboardEvent } from 'react'
+import { ChevronDown } from 'lucide-react'
 import type { CompetitorLandscapeResponse, CompetitorLandscapeRow as CompetitorLandscapeRowDto } from '@ainyc/canonry-contracts'
 
 import { Button } from '../ui/button.js'
@@ -200,11 +201,9 @@ function ObservedCompetitors({
   return (
     <tbody>
       <GroupHeading>Observed in this window</GroupHeading>
-      {visibleRows.length > 0 ? visibleRows.map(row => (
+      {visibleRows.map(row => (
         <LandscapeRow key={row.domain} row={{ ...row, pinned: false }} canManage={canManage} onPin={onPin} />
-      )) : (
-        <tr><td colSpan={6} className="text-secondary">No direct competitors were observed in this window.</td></tr>
-      )}
+      ))}
       {rows.length > OBSERVED_PREVIEW_LIMIT ? (
         <tr>
           <td colSpan={6}>
@@ -376,7 +375,7 @@ export function CompetitorLandscape({
                   <tr><td colSpan={6} className="text-secondary">No pinned competitors.</td></tr>
                 )}
               </tbody>
-              {landscape ? (
+              {landscape && observed.length > 0 ? (
                 <ObservedCompetitors
                   // Refreshes and pin changes keep the operator's choice. A new
                   // project, window, or measurement scope starts compact again.
@@ -390,20 +389,35 @@ export function CompetitorLandscape({
           </div>
 
           {evidence ? (
-            <p className="text-sm text-secondary">
-              {evidence.answeredResults} answer results and {evidence.sourceResults} source results in this window.
-              {evidence.missingAnswerTextResults > 0 ? ` ${evidence.missingAnswerTextResults} result${evidence.missingAnswerTextResults === 1 ? '' : 's'} without answer text excluded from mention share.` : ''}
-              {evidence.incompleteSourceResults > 0 ? ` ${evidence.incompleteSourceResults} incomplete source result${evidence.incompleteSourceResults === 1 ? '' : 's'} excluded from negative citation evidence.` : ''}
-              {evidence.excludedProbeResults > 0 || evidence.excludedNonCompletedResults > 0
-                ? ` ${evidence.excludedProbeResults + evidence.excludedNonCompletedResults} probe or incomplete run${evidence.excludedProbeResults + evidence.excludedNonCompletedResults === 1 ? '' : 's'} excluded.`
-                : ''}
-            </p>
-          ) : null}
-
-          {landscape?.truncated ? (
-            <p className="text-sm text-secondary">
-              Results are limited to the top 100 observed competitors and other sources. Pinned competitors are complete.
-            </p>
+            <details className="group text-sm text-secondary">
+              <summary className="flex min-h-11 cursor-pointer list-none flex-wrap items-center justify-between gap-x-4 gap-y-1 rounded-md hover:text-heading focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-500 [&::-webkit-details-marker]:hidden">
+                <span className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                  <span>{evidence.answeredResults} {evidence.answeredResults === 1 ? 'answer' : 'answers'}</span>
+                  {evidence.missingAnswerTextResults > 0 ? <span className="text-caution">Answer data incomplete</span> : null}
+                  {evidence.incompleteSourceResults > 0 ? <span className="text-caution">Citation data incomplete</span> : null}
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  About these results
+                  <ChevronDown size={14} aria-hidden="true" className="transition-transform group-open:rotate-180 motion-reduce:transition-none" />
+                </span>
+              </summary>
+              <div className="max-w-prose space-y-2 pb-2 pt-1">
+                {observed.length === 0 ? <p>No additional competitors were identified in this period.</p> : null}
+                <p>{evidence.sourceResults} {evidence.sourceResults === 1 ? 'result includes' : 'results include'} source URLs.</p>
+                {evidence.missingAnswerTextResults > 0 ? (
+                  <p>{evidence.missingAnswerTextResults} {evidence.missingAnswerTextResults === 1 ? 'result has' : 'results have'} no answer text and {evidence.missingAnswerTextResults === 1 ? 'is' : 'are'} excluded from mention share.</p>
+                ) : null}
+                {evidence.incompleteSourceResults > 0 ? (
+                  <p>{evidence.incompleteSourceResults} {evidence.incompleteSourceResults === 1 ? 'result has an incomplete source list' : 'results have incomplete source lists'}. Recorded citations still count; missing citations are not treated as confirmed misses.</p>
+                ) : null}
+                {evidence.excludedProbeResults + evidence.excludedNonCompletedResults > 0 ? (
+                  <p>{evidence.excludedProbeResults + evidence.excludedNonCompletedResults} test or unfinished {evidence.excludedProbeResults + evidence.excludedNonCompletedResults === 1 ? 'result is' : 'results are'} excluded.</p>
+                ) : null}
+                {landscape.truncated ? (
+                  <p>Lists include up to 100 observed competitors and 100 other sources. All pinned competitors are included.</p>
+                ) : null}
+              </div>
+            </details>
           ) : null}
 
           {pendingDraftCompetitorCount > 0 ? (

--- a/apps/web/test/competitor-landscape.test.tsx
+++ b/apps/web/test/competitor-landscape.test.tsx
@@ -94,7 +94,7 @@ describe('CompetitorLandscape', () => {
     expect(screen.getByRole('rowheader', { name: 'Observed rival 8' })).toBeTruthy()
     expect(screen.getByText('Showing 8 of 8 observed competitors.')).toBeTruthy()
     expect(within(brand).getByText('50.0%')).toBeTruthy()
-    expect(screen.getByText(/20 answer results and 21 source results/)).toBeTruthy()
+    expect(screen.getByText('20 answers')).toBeTruthy()
 
     const showFewer = screen.getByRole('button', { name: 'Show fewer observed competitors' })
     expect(showFewer.getAttribute('aria-expanded')).toBe('true')
@@ -107,6 +107,63 @@ describe('CompetitorLandscape', () => {
     renderLandscape({ landscape: landscape({ observed: observedRows(count) }) })
     expect(screen.queryByRole('button', { name: /Show all/ })).toBeNull()
     expect(screen.queryByText(/Showing \d+ of \d+ observed competitors/)).toBeNull()
+  })
+
+  test.each([
+    { kind: 'project' },
+    { kind: 'group', groupKey: 'north' },
+    { kind: 'all-markets' },
+  ] as const)('keeps empty observations and detailed evidence notes out of the default $kind view', (scope) => {
+    renderLandscape({ landscape: landscape({
+      scope,
+      observed: [],
+      truncated: true,
+      evidence: {
+        answeredResults: 44,
+        sourceResults: 42,
+        missingAnswerTextResults: 0,
+        mentionCredits: 12,
+        incompleteSourceResults: 42,
+        excludedProbeResults: 2,
+        excludedNonCompletedResults: 1,
+      },
+    }) })
+
+    expect(screen.queryByText('Observed in this window')).toBeNull()
+    expect(screen.getByRole('rowheader', { name: 'Pinned zero' })).toBeTruthy()
+    const disclosure = screen.getByText('About these results').closest('details')!
+    expect(disclosure.open).toBe(false)
+    const summary = disclosure.querySelector('summary')!
+    expect(within(summary).getByText('44 answers')).toBeTruthy()
+    expect(within(summary).getByText('Citation data incomplete')).toBeTruthy()
+    expect(within(summary).queryByText(/100/)).toBeNull()
+    expect(screen.getByText(/42 results have incomplete source lists/).closest('details')).toBe(disclosure)
+    expect(screen.getByText(/All pinned competitors are included/).closest('details')).toBe(disclosure)
+
+    fireEvent.click(summary)
+    expect(disclosure.open).toBe(true)
+    expect(within(disclosure).getByText('42 results include source URLs.')).toBeTruthy()
+    expect(within(disclosure).getByText('3 test or unfinished results are excluded.')).toBeTruthy()
+    expect(within(disclosure).getByText('No additional competitors were identified in this period.')).toBeTruthy()
+  })
+
+  test('only shows data-quality warnings when the corresponding evidence is incomplete', () => {
+    const data = landscape()
+    const { props, rerender } = renderLandscape({ landscape: {
+      ...data,
+      evidence: { ...data.evidence, incompleteSourceResults: 0 },
+    } })
+    expect(screen.queryByText('Citation data incomplete')).toBeNull()
+    expect(screen.getByText('Answer data incomplete').closest('summary')).not.toBeNull()
+    expect(screen.getByText(/2 results have no answer text/).closest('details')?.open).toBe(false)
+
+    rerender(<CompetitorLandscape {...props} landscape={{
+      ...data,
+      evidence: { ...data.evidence, answeredResults: 1, missingAnswerTextResults: 0, incompleteSourceResults: 0 },
+    }} />)
+    expect(screen.queryByText('Answer data incomplete')).toBeNull()
+    expect(screen.queryByText('Citation data incomplete')).toBeNull()
+    expect(screen.getByText('1 answer')).toBeTruthy()
   })
 
   test.each([
@@ -288,7 +345,8 @@ describe('CompetitorLandscape', () => {
   test('states when ranked observed rows are truncated while pins remain complete', () => {
     renderLandscape({ landscape: landscape({ truncated: true }) })
 
-    expect(screen.getByText('Results are limited to the top 100 observed competitors and other sources. Pinned competitors are complete.')).not.toBeNull()
+    const note = screen.getByText('Lists include up to 100 observed competitors and 100 other sources. All pinned competitors are included.')
+    expect(note.closest('details')?.open).toBe(false)
   })
 
   test('marks Advanced draft-only competitors as pending publication', () => {


### PR DESCRIPTION
## Changes

- Remove the empty observed-competitor section.
- Move detailed counts, exclusions, and list limits into a collapsed “About these results” section.
- Keep concise answer counts and incomplete-data warnings visible.
- Preserve Simple and Advanced scopes, pins, metrics, and Show all behavior.

## Validation

- 1,295 web tests passed.
- Web typecheck and build passed; repository-wide lint passed.
- Browser-checked empty/populated states and mouse/keyboard disclosure behavior with synthetic data.