### PR TITLE
feat(web): add managed-sweeps deployment flag

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -141,6 +141,16 @@ ship with a registered Zod schema.
 
 Base path comes from `window.__CANONRY_CONFIG__.basePath`. Never hardcode `/api/v1`.
 
+### Managed sweeps
+
+`isDashboardManagedSweeps()` reads the optional deployment flag. When true,
+replace answer-visibility launch controls and empty-state launch instructions
+for every dashboard role, including admins. `ManagedSweepStatus` reads
+`GET /projects/:name/schedule?kind=answer-visibility`; only an enabled schedule
+with a valid `nextRunAt` gets a UTC date. Keep Site Health and other run kinds
+unchanged. The operator's manual lever is `canonry run <project>`, and the flag
+must never enter authorization checks. Unset/false preserves existing markup.
+
 ### Read-only embed mode (#716)
 
 When the server injects `window.__CANONRY_CONFIG__.embed` (via `canonry serve --embed`), `RootLayout` (`src/App.tsx`) takes a chromeless branch — placed AFTER every hook so Rules of Hooks hold on both paths — rendering only `<Outlet/>` inside a minimal `app-shell-embed` shell with NO sidebar / topbar / mobile nav / footer / drawers / `RunNotificationObserver` / `Toaster` / `AeroBarHost`. The optional `embed.views` allowlist gates the route via `embedViewIdForPath` (a non-allowlisted route renders a `embed-view-unavailable` state instead of the page, so surfaces like `/settings` are not reachable inside the iframe — a presentational gate, NOT a security boundary; the API key scope is the real boundary). The optional `embed.projectTabs` allowlist is a FINER gate that `ProjectPage` applies to the in-page tab subnav (Overview / Search Engines / Activity / Site Health / Local / Discovery / Backlinks / Report / Settings): it filters the rendered tabs to the allowlist and `resolveEmbedProjectTab` falls a direct-URL hit on a hidden tab back to Overview (or the first allowed tab). Site Health retains the stable `technical-aeo` allowlist token. This is what `embed.views` cannot do — every `/projects/*` collapses to the one `project` view id. Same posture as `views`: presentational, NOT a security boundary; unset = all tabs. The optional `embed.theme` supports `mode`, `bg`, `fg`, and `accent` through `embedThemeStyle` (sanitized, via the React `style` prop). Font overrides are unsupported. Every dashboard uses the bundled Geist files. With embed off, `getEmbedConfig()` returns `null` and the full chrome renders exactly as before.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -150,6 +150,12 @@ for every dashboard role, including admins. `ManagedSweepStatus` reads
 with a valid `nextRunAt` gets a UTC date. Keep Site Health and other run kinds
 unchanged. The operator's manual lever is `canonry run <project>`, and the flag
 must never enter authorization checks. Unset/false preserves existing markup.
+Keep queued/running signals, baseline results, and failure details visible.
+Settings keeps schedule reads but hides create/edit/pause/resume/delete controls.
+Aero blocks typed `/run-sweep` at submission and uses `read-only` scope in
+managed mode, regardless of a saved write preference; hide its scope toggle.
+Test Simple and Advanced behavior through `ProjectPage`: it does not supply
+`AdvancedMeasurementOverview.onRunMeasurement`.
 
 ### Read-only embed mode (#716)
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -174,6 +174,7 @@ declare global {
       dashboard?: {
         showResourceLinks?: boolean
         showUpdateNotification?: boolean
+        managedSweeps?: boolean
         showAgentBar?: boolean
         /** Runtime rollout selection for the first-open setup experience. */
         onboardingMode?: OnboardingMode
@@ -294,6 +295,12 @@ export function shouldShowDashboardAgentBar(): boolean {
 export function shouldShowDashboardUpdateNotification(): boolean {
   if (typeof window === 'undefined') return true
   return window.__CANONRY_CONFIG__?.dashboard?.showUpdateNotification !== false
+}
+
+/** Presentation only; manual operator sweeps remain available through the CLI. */
+export function isDashboardManagedSweeps(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.__CANONRY_CONFIG__?.dashboard?.managedSweeps === true
 }
 
 /**

--- a/apps/web/src/components/project/CitationVisibilitySection.tsx
+++ b/apps/web/src/components/project/CitationVisibilitySection.tsx
@@ -3,7 +3,8 @@ import { useQuery } from '@tanstack/react-query'
 import { Minus } from 'lucide-react'
 import type { CitationCoverageProvider, CitationVisibilityResponse } from '@ainyc/canonry-contracts'
 import { getApiV1ProjectsByNameCitationsVisibilityOptions } from '@ainyc/canonry-api-client/react-query'
-import { heyClient } from '../../api.js'
+import { heyClient, isDashboardManagedSweeps } from '../../api.js'
+import { MANAGED_SWEEPS_COPY } from './ManagedSweepStatus.js'
 import { STATIC_VISIBILITY_STALE_MS } from '../../queries/query-client.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { ProviderBadge } from '../shared/ProviderBadge.js'
@@ -45,10 +46,10 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
             <h2>Citation + answer-mention coverage</h2>
           </div>
         </div>
-        <p className="text-sm text-muted">
+        <p className={isDashboardManagedSweeps() ? 'text-sm text-secondary' : 'text-sm text-muted'}>
           {data.reason === 'no-queries'
             ? 'Add queries to start tracking AI citations.'
-            : 'Run a sweep to see which engines cite this project.'}
+            : isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Run a sweep to see which engines cite this project.'}
         </p>
       </section>
     )

--- a/apps/web/src/components/project/ManagedSweepStatus.tsx
+++ b/apps/web/src/components/project/ManagedSweepStatus.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query'
+import { getApiV1ProjectsByNameScheduleOptions } from '@ainyc/canonry-api-client/react-query'
+import { RunKinds } from '@ainyc/canonry-contracts'
+import { heyClient } from '../../api.js'
+
+export const MANAGED_SWEEPS_COPY = 'Sweeps are run by your Canonry team'
+
+export function ManagedSweepStatus({ projectName }: { projectName: string }) {
+  const scheduleQuery = useQuery({
+    ...getApiV1ProjectsByNameScheduleOptions({
+      client: heyClient,
+      path: { name: projectName },
+      query: { kind: RunKinds['answer-visibility'] },
+    }),
+    retry: false,
+    refetchInterval: 60_000,
+  })
+  const schedule = scheduleQuery.isError ? undefined : scheduleQuery.data
+  const nextRun = schedule?.enabled && schedule.nextRunAt ? new Date(schedule.nextRunAt) : null
+  const nextSync = nextRun && Number.isFinite(nextRun.getTime())
+    ? nextRun.toLocaleString('en-GB', {
+        weekday: 'long', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
+        timeZone: 'UTC', hourCycle: 'h23',
+      })
+    : null
+
+  return (
+    <p className="text-sm text-secondary" role="status">
+      {nextSync && nextRun ? <>
+        Next sync <time dateTime={nextRun.toISOString()}>{nextSync} UTC</time> · managed by your Canonry team
+      </> : MANAGED_SWEEPS_COPY}
+    </p>
+  )
+}

--- a/apps/web/src/components/project/ManagedSweepStatus.tsx
+++ b/apps/web/src/components/project/ManagedSweepStatus.tsx
@@ -5,7 +5,7 @@ import { heyClient } from '../../api.js'
 
 export const MANAGED_SWEEPS_COPY = 'Sweeps are run by your Canonry team'
 
-export function ManagedSweepStatus({ projectName }: { projectName: string }) {
+export function ManagedSweepStatus({ projectName, running = false }: { projectName: string; running?: boolean }) {
   const scheduleQuery = useQuery({
     ...getApiV1ProjectsByNameScheduleOptions({
       client: heyClient,
@@ -26,6 +26,7 @@ export function ManagedSweepStatus({ projectName }: { projectName: string }) {
 
   return (
     <p className="text-sm text-secondary" role="status">
+      {running && <span className="text-neutral">AI sweep running… · </span>}
       {nextSync && nextRun ? <>
         Next sync <time dateTime={nextRun.toISOString()}>{nextSync} UTC</time> · managed by your Canonry team
       </> : MANAGED_SWEEPS_COPY}

--- a/apps/web/src/components/project/ProjectHistorySection.tsx
+++ b/apps/web/src/components/project/ProjectHistorySection.tsx
@@ -6,7 +6,8 @@ import {
   getApiV1ProjectsByNameSnapshotsDiffOptions,
 } from '@ainyc/canonry-api-client/react-query'
 
-import { heyClient } from '../../api.js'
+import { heyClient, isDashboardManagedSweeps } from '../../api.js'
+import { MANAGED_SWEEPS_COPY } from './ManagedSweepStatus.js'
 import { AuditHistoryPanel } from '../shared/AuditHistoryPanel.js'
 import { Card } from '../ui/card.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
@@ -85,7 +86,7 @@ export function ProjectHistorySection({ projectName }: { projectName: string }) 
           {!healthQuery.isLoading && healthRows.length === 0 ? (
             <Card className="surface-card empty-card mt-4">
               <h3>No coverage history yet</h3>
-              <p>Complete an answer visibility sweep to create the first snapshot.</p>
+              <p>{isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Complete an answer visibility sweep to create the first snapshot.'}</p>
             </Card>
           ) : null}
           {healthRows.length > 0 ? (
@@ -150,7 +151,7 @@ export function ProjectHistorySection({ projectName }: { projectName: string }) 
           {!runsQuery.isLoading && comparableRuns.length < 2 ? (
             <Card className="surface-card empty-card mt-4">
               <h3>Two completed sweeps are required</h3>
-              <p>Run another answer visibility sweep before comparing historical evidence.</p>
+              <p>{isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Run another answer visibility sweep before comparing historical evidence.'}</p>
             </Card>
           ) : null}
           {diffQuery.data && changedRows.length === 0 ? (

--- a/apps/web/src/components/project/ScheduleSection.tsx
+++ b/apps/web/src/components/project/ScheduleSection.tsx
@@ -8,7 +8,8 @@ import { ToneBadge } from '../shared/ToneBadge.js'
 import { formatHour, buildPreset, parsePreset, scheduleLabel } from '../../lib/format-helpers.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
-import { ApiError, heyClient, saveSchedule, removeSchedule, isEmbed, type ApiSchedule } from '../../api.js'
+import { ApiError, heyClient, saveSchedule, removeSchedule, isEmbed, isDashboardManagedSweeps, type ApiSchedule } from '../../api.js'
+import { MANAGED_SWEEPS_COPY } from './ManagedSweepStatus.js'
 
 // --- Schedule helpers ---
 const FREQ_OPTIONS = [
@@ -39,6 +40,8 @@ const COMMON_TIMEZONES = [
 
 
 export function ScheduleSection({ projectName }: { projectName: string }) {
+  const managedSweeps = isDashboardManagedSweeps()
+  const canManageSchedule = !isEmbed() && !managedSweeps
   const queryClient = useQueryClient()
   const [editing, setEditing] = useState(false)
   const [freq, setFreq] = useState('daily')
@@ -105,6 +108,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
   }
 
   const startEditing = () => {
+    if (!canManageSchedule) return
     loadScheduleIntoEditor(schedule)
     setError(null)
     setEditing(true)
@@ -135,6 +139,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
   }
 
   const handleSave = async () => {
+    if (!canManageSchedule) return
     if (scheduleChangedElsewhere || editingVersion === undefined) return
     setSaving(true)
     setError(null)
@@ -176,7 +181,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
   }
 
   const handleToggleEnabled = async () => {
-    if (!schedule) return
+    if (!canManageSchedule || !schedule) return
     const editingScheduleVersion = schedule.updatedAt
     setSaving(true)
     setError(null)
@@ -215,7 +220,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
   }
 
   const handleRemove = async () => {
-    if (!schedule) return
+    if (!canManageSchedule || !schedule) return
     const removingScheduleVersion = schedule.updatedAt
     setRemoving(true)
     setError(null)
@@ -245,7 +250,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
           <p className="eyebrow eyebrow-soft">Automation</p>
           <h2>Scheduled runs</h2>
         </div>
-        {!isEmbed() && !scheduleLoading && !loadFailed && !editing && (
+        {canManageSchedule && !scheduleLoading && !loadFailed && !editing && (
           <Button type="button" variant="outline" size="sm" onClick={startEditing}>
             {schedule ? 'Edit schedule' : '+ Set schedule'}
           </Button>
@@ -273,7 +278,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
 
       {!scheduleLoading && !loadFailed && !editing && schedule === null && (
         <Card className="surface-card compact-card">
-          <p className="supporting-copy">No schedule configured. Set one to automatically trigger visibility sweeps.</p>
+          <p className="supporting-copy">{managedSweeps ? MANAGED_SWEEPS_COPY : 'No schedule configured. Set one to automatically trigger visibility sweeps.'}</p>
         </Card>
       )}
 
@@ -281,6 +286,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
         <Card className="surface-card compact-card">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
+              {managedSweeps && <p className="text-sm text-secondary">{MANAGED_SWEEPS_COPY}</p>}
               <p className="text-sm font-medium text-strong">{scheduleLabel(schedule.preset ?? null, schedule.cronExpr, schedule.timezone)}</p>
               <p className="text-xs text-muted">Cron: <span className="font-mono">{schedule.cronExpr}</span></p>
               {schedule.nextRunAt && (
@@ -294,12 +300,12 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
               <ToneBadge tone={schedule.enabled ? 'positive' : 'neutral'}>
                 {schedule.enabled ? 'Active' : 'Paused'}
               </ToneBadge>
-              {!isEmbed() && (
+              {canManageSchedule && (
                 <Button type="button" variant="outline" size="sm" disabled={saving} onClick={asyncHandler(handleToggleEnabled)}>
                   {schedule.enabled ? 'Pause' : 'Resume'}
                 </Button>
               )}
-              {!isEmbed() && (
+              {canManageSchedule && (
                 <Button type="button" variant="ghost" size="sm" disabled={removing} onClick={asyncHandler(handleRemove)}>
                   {removing ? 'Removing...' : 'Remove'}
                 </Button>
@@ -309,7 +315,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
         </Card>
       )}
 
-      {!isEmbed() && editing && (
+      {canManageSchedule && editing && (
         <div className="rounded-lg border border-base bg-bg-elevated/40 p-4 space-y-3">
           {scheduleChangedElsewhere && (
             <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-caution bg-caution-soft px-3 py-2 text-sm text-caution" role="alert">

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -22,7 +22,8 @@ import {
   YAxis,
 } from '../shared/ChartPrimitives.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
-import { fetchAnalyticsMetrics } from '../../api.js'
+import { fetchAnalyticsMetrics, isDashboardManagedSweeps } from '../../api.js'
+import { MANAGED_SWEEPS_COPY } from './ManagedSweepStatus.js'
 import { STATIC_VISIBILITY_STALE_MS } from '../../queries/query-client.js'
 import {
   buildSelectedTrendRows,
@@ -682,7 +683,7 @@ export function VisibilityTrendSection({
         <p className="text-sm text-secondary">
           {metric === 'mentionShare'
             ? `No answer-text brand mentions for you or tracked competitors on ${mentionShareScopeLabel(mentionShareScope)} in this window yet.`
-            : 'Run a sweep to start tracking citations and mentions over time.'}
+            : isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Run a sweep to start tracking citations and mentions over time.'}
         </p>
       )
     } else if (byProviderMode && series.length === 0) {

--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -2,7 +2,6 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { ChevronDown } from 'lucide-react'
 import type { KeyboardEvent, ReactNode } from 'react'
 import type { MetricTone } from '../../../view-models.js'
-import { isDashboardManagedSweeps } from '../../../api.js'
 
 import { InfoTooltip } from '../../shared/InfoTooltip.js'
 import { ToneBadge } from '../../shared/ToneBadge.js'
@@ -757,7 +756,7 @@ export function AdvancedMeasurementOverview({
               {progressLabel ? <span className="text-sm text-secondary tabular-nums">{progressLabel}</span> : null}
               {measurementDate ? <span className="text-sm text-secondary">{measurementDate}</span> : null}
               {statusMessage ? <span className="text-sm text-secondary">{statusMessage}</span> : null}
-              {!isDashboardManagedSweeps() && canEdit && classReportingAvailable && onRunMeasurement ? (
+              {canEdit && classReportingAvailable && onRunMeasurement ? (
                 <Button className="ml-auto" size="sm" onClick={() => { void onRunMeasurement() }} disabled={isRunningMeasurement}>
                   {isRunningMeasurement ? 'Starting measurement…' : 'Run measurement'}
                 </Button>

--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { ChevronDown } from 'lucide-react'
 import type { KeyboardEvent, ReactNode } from 'react'
 import type { MetricTone } from '../../../view-models.js'
+import { isDashboardManagedSweeps } from '../../../api.js'
 
 import { InfoTooltip } from '../../shared/InfoTooltip.js'
 import { ToneBadge } from '../../shared/ToneBadge.js'
@@ -756,7 +757,7 @@ export function AdvancedMeasurementOverview({
               {progressLabel ? <span className="text-sm text-secondary tabular-nums">{progressLabel}</span> : null}
               {measurementDate ? <span className="text-sm text-secondary">{measurementDate}</span> : null}
               {statusMessage ? <span className="text-sm text-secondary">{statusMessage}</span> : null}
-              {canEdit && classReportingAvailable && onRunMeasurement ? (
+              {!isDashboardManagedSweeps() && canEdit && classReportingAvailable && onRunMeasurement ? (
                 <Button className="ml-auto" size="sm" onClick={() => { void onRunMeasurement() }} disabled={isRunningMeasurement}>
                   {isRunningMeasurement ? 'Starting measurement…' : 'Run measurement'}
                 </Button>

--- a/apps/web/src/components/shared/AeroBar.tsx
+++ b/apps/web/src/components/shared/AeroBar.tsx
@@ -18,7 +18,7 @@ import {
 import { Link, useLocation } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import ReactMarkdown from 'react-markdown'
-import { heyClient } from '../../api.js'
+import { heyClient, isDashboardManagedSweeps } from '../../api.js'
 import {
   getApiV1ProjectsByNameAgentProvidersOptions,
   getApiV1ProjectsOptions,
@@ -195,7 +195,8 @@ export function AeroBar({ projectName }: AeroBarProps) {
     if (/\s/.test(trimmed)) return []
     const q = trimmed.toLowerCase()
     return SLASH_COMMANDS.filter(
-      (cmd) => cmd.command.startsWith(q) || cmd.label.toLowerCase().includes(q.slice(1)),
+      (cmd) => (!isDashboardManagedSweeps() || cmd.command !== '/run-sweep')
+        && (cmd.command.startsWith(q) || cmd.label.toLowerCase().includes(q.slice(1))),
     )
   }, [draft])
 

--- a/apps/web/src/components/shared/AeroBar.tsx
+++ b/apps/web/src/components/shared/AeroBar.tsx
@@ -26,6 +26,7 @@ import {
 import { asyncHandler } from '../../lib/async-handler.js'
 import { useAccount } from '../../contexts/account-context.js'
 import { Button } from '../ui/button.js'
+import { MANAGED_SWEEPS_COPY } from '../project/ManagedSweepStatus.js'
 import {
   extractAssistantText,
   fetchAeroTranscript,
@@ -157,6 +158,7 @@ function removePreference(key: string): void {
 }
 
 export function AeroBar({ projectName }: AeroBarProps) {
+  const managedSweeps = isDashboardManagedSweeps()
   const { canWrite } = useAccount()
   const [open, setOpen] = useState(false)
   const [expanded, setExpanded] = useState(false)
@@ -177,10 +179,13 @@ export function AeroBar({ projectName }: AeroBarProps) {
   // choice; `all` lets Aero fire write tools like run_sweep without a
   // confirmation UX. Persist so the user doesn't have to re-opt-in each
   // visit, but key by project so the choice doesn't leak across tenants.
-  const [scope, setScope] = useState<AeroToolScope>(() => {
+  const [preferredScope, setScope] = useState<AeroToolScope>(() => {
     const stored = readPreference(SCOPE_PREF_KEY(projectName))
     return stored === 'all' ? 'all' : 'read-only'
   })
+  // A saved write preference cannot turn the managed dashboard into a sweep
+  // control. Keep it stored for operator deployments, but use read tools here.
+  const scope = managedSweeps ? 'read-only' : preferredScope
   const abortRef = useRef<AbortController | null>(null)
   const { ref: transcriptRef } = useChatScroll<HTMLDivElement>([messages, streamingText, liveTrail])
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
@@ -195,10 +200,10 @@ export function AeroBar({ projectName }: AeroBarProps) {
     if (/\s/.test(trimmed)) return []
     const q = trimmed.toLowerCase()
     return SLASH_COMMANDS.filter(
-      (cmd) => (!isDashboardManagedSweeps() || cmd.command !== '/run-sweep')
+      (cmd) => (!managedSweeps || cmd.command !== '/run-sweep')
         && (cmd.command.startsWith(q) || cmd.label.toLowerCase().includes(q.slice(1))),
     )
-  }, [draft])
+  }, [draft, managedSweeps])
 
   // Keep the selected index in range as matches narrow. Reset to 0 whenever
   // the palette toggles, so the top option is always the "enter to pick"
@@ -248,12 +253,13 @@ export function AeroBar({ projectName }: AeroBarProps) {
   )
 
   const toggleScope = useCallback(() => {
+    if (managedSweeps) return
     setScope((prev) => {
       const next: AeroToolScope = prev === 'all' ? 'read-only' : 'all'
       writePreference(SCOPE_PREF_KEY(projectName), next)
       return next
     })
-  }, [projectName])
+  }, [projectName, managedSweeps])
 
   // Escape key collapses expanded → compact first, then closes.
   useEffect(() => {
@@ -305,6 +311,10 @@ export function AeroBar({ projectName }: AeroBarProps) {
   async function send(promptText: string) {
     const trimmed = promptText.trim()
     if (!trimmed || streaming || !activeProvider) return
+    if (managedSweeps && /^\/run-sweep(?:\s|$)/i.test(trimmed)) {
+      setError(MANAGED_SWEEPS_COPY)
+      return
+    }
     setError(null)
     setDraft('')
     setStreaming(true)
@@ -566,6 +576,7 @@ export function AeroBar({ projectName }: AeroBarProps) {
               activeProvider={activeProvider}
               scope={scope}
               onToggleScope={toggleScope}
+              scopeLocked={managedSweeps}
               disabled={streaming}
             />
             <div className="relative">
@@ -791,12 +802,14 @@ function ContextPills({
   activeProvider,
   scope,
   onToggleScope,
+  scopeLocked,
   disabled,
 }: {
   projectName: string
   activeProvider: AgentProviderOption | null
   scope: AeroToolScope
   onToggleScope: () => void
+  scopeLocked?: boolean
   disabled?: boolean
 }) {
   const providerLabel = activeProvider?.label.replace(/\s+\(.+\)$/, '') ?? null
@@ -807,7 +820,7 @@ function ContextPills({
       {providerLabel && (
         <><span aria-hidden="true">·</span><span>{providerLabel}</span></>
       )}
-      <button
+      {scopeLocked ? <span className="ml-auto">Read only</span> : <button
         type="button"
         onClick={onToggleScope}
         disabled={disabled}
@@ -823,7 +836,7 @@ function ContextPills({
         }
       >
         {writeMode ? 'Can make changes' : 'Read only'}
-      </button>
+      </button>}
     </div>
   )
 }

--- a/apps/web/src/pages/MeasurementPropertyPage.tsx
+++ b/apps/web/src/pages/MeasurementPropertyPage.tsx
@@ -16,7 +16,8 @@ import {
   getApiV1ProjectsByNameMeasurementQuestionResultOptions,
 } from '@ainyc/canonry-api-client/react-query'
 
-import { heyClient } from '../api.js'
+import { heyClient, isDashboardManagedSweeps } from '../api.js'
+import { MANAGED_SWEEPS_COPY } from '../components/project/ManagedSweepStatus.js'
 import { getEmbedConfig } from '../api.js'
 import { isEmbedProjectTabAllowed } from '../embed.js'
 import { Button } from '../components/ui/button.js'
@@ -977,7 +978,7 @@ export function MeasurementPropertyPage() {
       {selected && (selected.measurement.state === 'not_measured' || selected.nextAction.kind === 'run_measurement') ? (
         <section className="flex flex-wrap items-center justify-between gap-3 border-y border-default py-4" aria-label="Measurement next step">
           <p className="text-sm text-secondary">
-            {canWrite
+            {isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : canWrite
               ? 'Run a measurement from the project overview to collect this Property’s coverage and source evidence.'
               : 'This Property needs a new measurement before coverage and source evidence are available.'}
           </p>
@@ -1039,7 +1040,7 @@ export function MeasurementPropertyPage() {
         ) : evidenceState === 'not_measured' ? (
           // Not measured is not "no evidence". Saying "none" here would report
           // an absent measurement as a measured result.
-          <p className="text-sm text-secondary">Not measured yet. Run a measurement to collect the answers for this Property.</p>
+          <p className="text-sm text-secondary">{isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Not measured yet. Run a measurement to collect the answers for this Property.'}</p>
         ) : evidenceShapeMismatch ? (
           <p role="alert" className="text-sm text-caution">
             This measurement was returned in an older format, so the answers cannot be shown here.

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -52,6 +52,7 @@ import { addToast } from '../lib/toast-store.js'
 import { asyncHandler } from '../lib/async-handler.js'
 import { ProjectSettingsSection } from '../components/project/ProjectSettingsSection.js'
 import { ProjectEngineSettingsSection } from '../components/project/ProjectEngineSettingsSection.js'
+import { ManagedSweepStatus, MANAGED_SWEEPS_COPY } from '../components/project/ManagedSweepStatus.js'
 import { ScheduleSection } from '../components/project/ScheduleSection.js'
 import { NotificationsSection } from '../components/project/NotificationsSection.js'
 import {
@@ -73,6 +74,7 @@ import {
   heyClient,
   getEmbedConfig,
   isEmbed,
+  isDashboardManagedSweeps,
   type ApiBingConnection,
   type ApiBingSite,
   type ApiBingInspection,
@@ -1196,7 +1198,7 @@ function OverviewBrief({
             <p className="mt-4 border-t border-subtle pt-4 text-sm font-medium text-strong">
               {sweepRunning
                 ? 'Your first sweep is running. Results will appear when it completes.'
-                : 'Complete your first AI Visibility sweep to measure both signals.'}
+                : isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Complete your first AI Visibility sweep to measure both signals.'}
             </p>
           </div>
         </div>
@@ -1218,7 +1220,7 @@ function OverviewBrief({
             {!comparison.hasPreviousRun ? (
               <>
                 <p className="overview-brief-panel-title">No comparison yet</p>
-                <p className="overview-brief-panel-copy">Run another sweep to measure mention and citation movement.</p>
+                <p className="overview-brief-panel-copy">{isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Run another sweep to measure mention and citation movement.'}</p>
               </>
             ) : (
               <>
@@ -1960,7 +1962,7 @@ function ProjectPageContent({
   // after queries or providers are removed.
   const sweepSchedulesQuery = useQuery({
     ...getApiV1ProjectsByNameSchedulesOptions({ client: heyClient, path: { name: projectName } }),
-    enabled: !isEmbed() && Boolean(projectName),
+    enabled: !isEmbed() && !isDashboardManagedSweeps() && Boolean(projectName),
     retry: false,
   })
   // Only claim a next sweep when one is genuinely coming: a schedule that
@@ -2312,9 +2314,11 @@ function ProjectPageContent({
             </div>
           )}
         </div>
-        <div className="page-header-right">
+        <div className={isDashboardManagedSweeps() ? 'page-header-right min-w-0 flex-wrap sm:shrink sm:justify-end' : 'page-header-right'}>
           <p className="text-sm text-muted">{model.dateRangeLabel}</p>
-          {!isEmbed() && (
+          {!isEmbed() && (isDashboardManagedSweeps() ? (
+            <ManagedSweepStatus projectName={projectName} />
+          ) : (
             <div className="flex items-center gap-3">
               {nextSweepLabel ? <p className="text-sm text-secondary">{nextSweepLabel}</p> : null}
               {/* Secondary, not primary. The schedule beside it is what actually
@@ -2345,7 +2349,7 @@ function ProjectPageContent({
                         : 'Run AI sweep'}
               </WriteButton>
             </div>
-          )}
+          ))}
         </div>
       </div>
 

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -2317,7 +2317,7 @@ function ProjectPageContent({
         <div className={isDashboardManagedSweeps() ? 'page-header-right min-w-0 flex-wrap sm:shrink sm:justify-end' : 'page-header-right'}>
           <p className="text-sm text-muted">{model.dateRangeLabel}</p>
           {!isEmbed() && (isDashboardManagedSweeps() ? (
-            <ManagedSweepStatus projectName={projectName} />
+            <ManagedSweepStatus projectName={projectName} running={hasActiveVisibilitySweep} />
           ) : (
             <div className="flex items-center gap-3">
               {nextSweepLabel ? <p className="text-sm text-secondary">{nextSweepLabel}</p> : null}

--- a/apps/web/src/pages/RunsPage.tsx
+++ b/apps/web/src/pages/RunsPage.tsx
@@ -4,10 +4,11 @@ import { useNavigate, useSearch } from '@tanstack/react-router'
 import { RunKinds, RunStatuses, type RunKind, type RunStatus } from '@ainyc/canonry-contracts'
 import { getApiV1ProjectsOptions, getApiV1RunsOptions } from '@ainyc/canonry-api-client/react-query'
 
+import { MANAGED_SWEEPS_COPY } from '../components/project/ManagedSweepStatus.js'
 import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { RunRow } from '../components/shared/RunRow.js'
-import { heyClient, isEmbed } from '../api.js'
+import { heyClient, isEmbed, isDashboardManagedSweeps } from '../api.js'
 import { toRunListItem } from '../build-dashboard.js'
 import { useInitialDashboard } from '../contexts/dashboard-context.js'
 import { toTitleCase } from '../lib/format-helpers.js'
@@ -133,11 +134,11 @@ export function RunsPage() {
           <h1 className="page-title">Runs</h1>
           <p className="page-subtitle">Recent jobs across all projects.</p>
         </div>
-        {!isEmbed() && (
+        {!isEmbed() && (isDashboardManagedSweeps() ? <p className="text-sm text-secondary">{MANAGED_SWEEPS_COPY}</p> : (
           <Button type="button" variant="outline" size="sm" disabled={triggerAllRunsMutation.isPending} onClick={() => void handleTriggerAll()}>
             {triggerAllRunsMutation.isPending ? 'Queueing…' : 'Run all projects'}
           </Button>
-        )}
+        ))}
       </div>
 
       <section>

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode, type RefCallback } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
+import { isDashboardManagedSweeps } from '../api.js'
+import { ManagedSweepStatus, MANAGED_SWEEPS_COPY } from '../components/project/ManagedSweepStatus.js'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   ONBOARDING_FLOW_VERSION,
@@ -1528,11 +1530,19 @@ function ReadySetupPage({
             <div className="section-head">
               <div>
                 <p className="eyebrow eyebrow-soft">{isProjectScoped ? 'Step 2 of 2' : 'Step 5 of 5'}</p>
-                <h2>Launch first run</h2>
+                <h2>{isDashboardManagedSweeps() ? 'Setup complete' : 'Launch first run'}</h2>
               </div>
               {stepBadge}
             </div>
-            {persistedSetupComplete ? (
+            {isDashboardManagedSweeps() ? (
+              <div className="compact-stack">
+                {createdProjectName ? <ManagedSweepStatus projectName={createdProjectName} /> : <p className="text-sm text-secondary">{MANAGED_SWEEPS_COPY}</p>}
+                <div className="setup-nav">
+                  <span />
+                  <Button type="button" onClick={openProjectDashboard}>Open project dashboard →</Button>
+                </div>
+              </div>
+            ) : persistedSetupComplete ? (
               <div className="compact-stack">
                 <p className="text-secondary">
                   Setup is complete. <span className="text-strong font-medium">{createdProjectName}</span> already has a successful answer-visibility baseline.

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -885,6 +885,7 @@ function ReadySetupPage({
   }
 
   const handleLaunchRun = async () => {
+    if (isDashboardManagedSweeps()) return
     if (!createdProjectName || launchBlockedReason) {
       setRunError(launchBlockedReason ?? 'Complete setup before launching the first sweep.')
       const reasonCode = systemBlockReason
@@ -1530,19 +1531,11 @@ function ReadySetupPage({
             <div className="section-head">
               <div>
                 <p className="eyebrow eyebrow-soft">{isProjectScoped ? 'Step 2 of 2' : 'Step 5 of 5'}</p>
-                <h2>{isDashboardManagedSweeps() ? 'Setup complete' : 'Launch first run'}</h2>
+                <h2>{isDashboardManagedSweeps() ? 'AI Visibility' : 'Launch first run'}</h2>
               </div>
               {stepBadge}
             </div>
-            {isDashboardManagedSweeps() ? (
-              <div className="compact-stack">
-                {createdProjectName ? <ManagedSweepStatus projectName={createdProjectName} /> : <p className="text-sm text-secondary">{MANAGED_SWEEPS_COPY}</p>}
-                <div className="setup-nav">
-                  <span />
-                  <Button type="button" onClick={openProjectDashboard}>Open project dashboard →</Button>
-                </div>
-              </div>
-            ) : persistedSetupComplete ? (
+            {persistedSetupComplete ? (
               <div className="compact-stack">
                 <p className="text-secondary">
                   Setup is complete. <span className="text-strong font-medium">{createdProjectName}</span> already has a successful answer-visibility baseline.
@@ -1552,6 +1545,15 @@ function ReadySetupPage({
                   <Button type="button" onClick={openProjectDashboard}>
                     {siteHealthOnboarding ? 'Finish and open project' : 'Open project dashboard →'}
                   </Button>
+                </div>
+              </div>
+            ) : !runTriggered && isDashboardManagedSweeps() ? (
+              <div className="compact-stack">
+                {createdProjectName ? <ManagedSweepStatus projectName={createdProjectName} /> : <p className="text-sm text-secondary">{MANAGED_SWEEPS_COPY}</p>}
+                {runError && <p role="alert" className="text-sm text-negative">{runError}</p>}
+                <div className="setup-nav">
+                  <span />
+                  <Button type="button" onClick={openProjectDashboard}>Open project dashboard →</Button>
                 </div>
               </div>
             ) : !runTriggered ? (
@@ -1620,15 +1622,17 @@ function ReadySetupPage({
               <div className="compact-stack">
                 <div role="alert" className="rounded-md border border-negative bg-negative-soft p-3 text-sm text-negative">
                   <p>{runFailureDetail}</p>
-                  <p className="mt-1 text-xs text-secondary">Fix provider or query configuration if needed, then retry without leaving setup.</p>
+                  <p className="mt-1 text-xs text-secondary">{isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Fix provider or query configuration if needed, then retry without leaving setup.'}</p>
                 </div>
                 <div className="setup-nav">
                   <Button type="button" variant="outline" asChild>
                     <Link to="/settings">Configure providers</Link>
                   </Button>
-                  <Button type="button" disabled={runSaving || !!launchBlockedReason} onClick={asyncHandler(handleLaunchRun)}>
+                  {isDashboardManagedSweeps() ? (
+                    <Button type="button" onClick={openProjectDashboard}>Open project dashboard →</Button>
+                  ) : <Button type="button" disabled={runSaving || !!launchBlockedReason} onClick={asyncHandler(handleLaunchRun)}>
                     {runSaving ? 'Retrying...' : 'Retry visibility sweep'}
-                  </Button>
+                  </Button>}
                 </div>
               </div>
             ) : (

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -9,7 +9,7 @@ import {
   type AdvancedMeasurementProperty,
 } from '../src/components/project/advanced-measurement/AdvancedMeasurementOverview.js'
 
-afterEach(cleanup)
+afterEach(() => { cleanup(); delete window.__CANONRY_CONFIG__ })
 
 function ratio(numerator: number, denominator: number): AdvancedMeasurementMetric {
   return { numerator, denominator }
@@ -1179,4 +1179,13 @@ describe('sorting and status', () => {
     // The exception still shows, next to the Property it belongs to.
     expect(within(table).getByText('Review')).toBeTruthy()
   })
+})
+
+
+it('managed sweeps removes the Advanced Measurement launch affordance even for an editor', () => {
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: true } }
+  const { onRunMeasurement } = renderOverview()
+  expect(screen.queryByRole('button', { name: 'Run measurement' })).toBeNull()
+  expect(onRunMeasurement).not.toHaveBeenCalled()
+  expect(screen.getByRole('region', { name: 'Advanced measurement overview' })).toBeTruthy()
 })

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -9,7 +9,7 @@ import {
   type AdvancedMeasurementProperty,
 } from '../src/components/project/advanced-measurement/AdvancedMeasurementOverview.js'
 
-afterEach(() => { cleanup(); delete window.__CANONRY_CONFIG__ })
+afterEach(cleanup)
 
 function ratio(numerator: number, denominator: number): AdvancedMeasurementMetric {
   return { numerator, denominator }
@@ -1179,13 +1179,4 @@ describe('sorting and status', () => {
     // The exception still shows, next to the Property it belongs to.
     expect(within(table).getByText('Review')).toBeTruthy()
   })
-})
-
-
-it('managed sweeps removes the Advanced Measurement launch affordance even for an editor', () => {
-  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: true } }
-  const { onRunMeasurement } = renderOverview()
-  expect(screen.queryByRole('button', { name: 'Run measurement' })).toBeNull()
-  expect(onRunMeasurement).not.toHaveBeenCalled()
-  expect(screen.getByRole('region', { name: 'Advanced measurement overview' })).toBeTruthy()
 })

--- a/apps/web/test/aero-bar-readiness.test.tsx
+++ b/apps/web/test/aero-bar-readiness.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
@@ -14,11 +14,14 @@ import { getApiV1ProjectsByNameAgentProvidersQueryKey } from '@ainyc/canonry-api
 import { heyClient } from '../src/api.js'
 import { AeroBar } from '../src/components/shared/AeroBar.js'
 import { AccountProvider } from '../src/contexts/account-context.js'
+import * as aero from '../src/api-aero.js'
 
 const PROJECT_NAME = 'citypoint'
 
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
   delete window.__CANONRY_CONFIG__
   try {
     window.localStorage.clear()
@@ -135,4 +138,53 @@ test('managed sweeps hides the Aero sweep shortcut while retaining read shortcut
   expect(screen.getByText('/status')).toBeTruthy()
   expect(screen.queryByText('/run-sweep')).toBeNull()
   expect(screen.queryByText('Run sweep now')).toBeNull()
+})
+
+async function openAeroWithSavedWriteScope(managedSweeps: boolean) {
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps } }
+  vi.stubGlobal('localStorage', { getItem: (key: string) => key.includes(':scope:') ? 'all' : null, setItem: vi.fn(), clear: vi.fn() })
+  const transcript = vi.spyOn(aero, 'fetchAeroTranscript').mockResolvedValue({ messages: [], modelProvider: null, modelId: null, updatedAt: null })
+  const prompt = vi.spyOn(aero, 'promptAero').mockResolvedValue(undefined)
+  await renderWithProviderReadiness({
+    providers: [{ id: 'openai', label: 'OpenAI', defaultModel: 'gpt-5.4', configured: true, keySource: 'config' }],
+    defaultProvider: 'openai',
+  }, 'admin')
+  fireEvent.click(screen.getByRole('button', { name: /Ask Aero about citypoint/i }))
+  await waitFor(() => expect(transcript).toHaveBeenCalled())
+  return { prompt, input: screen.getByPlaceholderText('Ask Aero, or / for commands…') }
+}
+
+test.each([
+  ['enter', '/run-sweep'], ['submit', '/run-sweep'],
+  ['enter', '  /RUN-SWEEP now'], ['submit', '/run-sweep '],
+] as const)('managed Aero blocks the typed sweep command through %s (%s)', async (method, draft) => {
+  const { prompt, input } = await openAeroWithSavedWriteScope(true)
+  fireEvent.change(input, { target: { value: draft } })
+  if (method === 'enter') fireEvent.keyDown(input, { key: 'Enter' })
+  else fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+  expect(await screen.findByText('Sweeps are run by your Canonry team')).toBeTruthy()
+  expect(prompt).not.toHaveBeenCalled()
+})
+
+test.each([false, true])('managed=%s uses the effective Aero scope even with a saved write preference', async managed => {
+  const { prompt, input } = await openAeroWithSavedWriteScope(managed)
+  if (managed) {
+    expect(screen.getByText('Read only')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Can make changes|Read only/ })).toBeNull()
+    expect(screen.queryByTitle(/run sweep|allow writes/i)).toBeNull()
+  } else {
+    expect(screen.getByRole('button', { name: 'Can make changes' })).toBeTruthy()
+  }
+  fireEvent.change(input, { target: { value: 'Show the latest sweep results' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+  await waitFor(() => expect(prompt).toHaveBeenCalledWith(expect.objectContaining({ scope: managed ? 'read-only' : 'all' })))
+})
+
+test('operator mode retains the exact Aero sweep shortcut and saved write scope', async () => {
+  const { prompt, input } = await openAeroWithSavedWriteScope(false)
+  fireEvent.change(input, { target: { value: '/run-sweep' } })
+  fireEvent.keyDown(input, { key: 'Enter' })
+  await waitFor(() => expect(prompt).toHaveBeenCalledWith(expect.objectContaining({
+    prompt: 'Run a new answer-visibility sweep for this project now and tell me when it lands.', scope: 'all',
+  })))
 })

--- a/apps/web/test/aero-bar-readiness.test.tsx
+++ b/apps/web/test/aero-bar-readiness.test.tsx
@@ -19,6 +19,7 @@ const PROJECT_NAME = 'citypoint'
 
 afterEach(() => {
   cleanup()
+  delete window.__CANONRY_CONFIG__
   try {
     window.localStorage.clear()
   } catch {
@@ -120,4 +121,18 @@ test('does not send a view-only user to administrator settings', async () => {
 
   expect(screen.getByRole('status').textContent).toContain('Ask an administrator to configure one.')
   expect(screen.queryByRole('link', { name: 'Open Settings' })).toBeNull()
+})
+
+
+test('managed sweeps hides the Aero sweep shortcut while retaining read shortcuts', async () => {
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: true } }
+  await renderWithProviderReadiness({
+    providers: [{ id: 'openai', label: 'OpenAI', defaultModel: 'gpt-5.4', configured: true, keySource: 'config' }],
+    defaultProvider: 'openai',
+  })
+  fireEvent.click(screen.getByRole('button', { name: /Ask Aero about citypoint/i }))
+  fireEvent.change(screen.getByPlaceholderText('Ask Aero, or / for commands…'), { target: { value: '/' } })
+  expect(screen.getByText('/status')).toBeTruthy()
+  expect(screen.queryByText('/run-sweep')).toBeNull()
+  expect(screen.queryByText('Run sweep now')).toBeNull()
 })

--- a/apps/web/test/managed-sweeps.test.tsx
+++ b/apps/web/test/managed-sweeps.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { isDashboardManagedSweeps } from '../src/api.js'
+import { ManagedSweepStatus, MANAGED_SWEEPS_COPY } from '../src/components/project/ManagedSweepStatus.js'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  delete window.__CANONRY_CONFIG__
+})
+
+test('managed sweeps is opt-in, including without a browser', () => {
+  expect(isDashboardManagedSweeps()).toBe(false)
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: false } }
+  expect(isDashboardManagedSweeps()).toBe(false)
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: true } }
+  expect(isDashboardManagedSweeps()).toBe(true)
+  vi.stubGlobal('window', undefined)
+  expect(isDashboardManagedSweeps()).toBe(false)
+})
+
+const schedule = {
+  id: 'schedule', projectId: 'project', kind: 'answer-visibility', enabled: true,
+  cronExpr: '0 6 * * *', timezone: 'America/New_York', providers: [],
+  nextRunAt: '2026-09-08T06:00:00.000Z', createdAt: '2026-09-01T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z',
+}
+
+function renderSchedule(response: unknown, status = 200) {
+  const request = vi.fn(async () => new Response(JSON.stringify(response), { status, headers: { 'content-type': 'application/json' } }))
+  vi.stubGlobal('fetch', request)
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  const page = render(<QueryClientProvider client={client}><ManagedSweepStatus projectName="example" /></QueryClientProvider>)
+  return { ...page, request, client }
+}
+
+test('reads the answer-visibility schedule and renders its real nextRunAt in UTC', async () => {
+  const { request, container } = renderSchedule(schedule)
+  await screen.findByText(/Next sync/)
+  const url = new URL((request.mock.calls[0] as unknown as [Request])[0].url)
+  expect(url.pathname).toBe('/api/v1/projects/example/schedule')
+  expect(url.searchParams.get('kind')).toBe('answer-visibility')
+  expect(screen.getByRole('status').textContent).toBe('Next sync Tuesday 8 Sept, 06:00 UTC · managed by your Canonry team')
+  expect(container.querySelector('time')?.dateTime).toBe(schedule.nextRunAt)
+})
+
+test.each([
+  ['no schedule', { error: { code: 'NOT_FOUND' } }, 404],
+  ['no next-run time', { ...schedule, nextRunAt: null }, 200],
+  ['paused schedule', { ...schedule, enabled: false }, 200],
+  ['invalid next-run time', { ...schedule, nextRunAt: 'invalid' }, 200],
+  ['failed schedule read', { error: { code: 'INTERNAL_ERROR' } }, 500],
+] as const)('%s shows the managed fallback without a date', async (_label, response, status) => {
+  const { container, client } = renderSchedule(response, status)
+  await waitFor(() => expect(client.isFetching()).toBe(0))
+  expect(screen.getByRole('status').textContent).toBe(MANAGED_SWEEPS_COPY)
+  expect(container.querySelector('time')).toBeNull()
+  expect(container.textContent).not.toMatch(/Next sync|2026|UTC|Invalid Date/)
+})

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -19,6 +19,7 @@ import {
   getApiV1ProjectsByNameQueriesQueryKey,
   getApiV1ProjectsByNameAnalyticsCompetitorsQueryKey,
   getApiV1ProjectsByNameSchedulesQueryKey,
+  getApiV1ProjectsByNameScheduleQueryKey,
 } from '@ainyc/canonry-api-client/react-query'
 
 type EmbedBlock = { enabled: boolean; views?: string[]; projectTabs?: string[] }
@@ -61,6 +62,8 @@ async function renderAt(
   options: {
     cdpStatus?: { connected: boolean; endpoint: string; browserVersion?: string; targets: [] }
     schedule?: unknown
+    managedSweeps?: boolean
+    accountRole?: 'admin' | 'viewer'
     seedPlan?: boolean
     apiKey?: { id: string; scopes: string[]; projectId: string | null; readOnly: boolean }
     queries?: Array<{ id: string; query: string; createdAt: string }>
@@ -71,6 +74,9 @@ async function renderAt(
 ): Promise<string> {
   if (embed) window.__CANONRY_CONFIG__ = { embed }
   else delete window.__CANONRY_CONFIG__
+  if (options.managedSweeps !== undefined) {
+    window.__CANONRY_CONFIG__ = { ...window.__CANONRY_CONFIG__, dashboard: { managedSweeps: options.managedSweeps } }
+  }
 
   const fixture = createDashboardFixture({})
   options.configureFixture?.(fixture.dashboard)
@@ -87,6 +93,10 @@ async function renderAt(
     options.queries ?? [],
   )
   if (options.schedule !== undefined) {
+    queryClient.setQueryData(
+      getApiV1ProjectsByNameScheduleQueryKey({ client: heyClient, path: { name: projectName }, query: { kind: 'answer-visibility' } }),
+      options.schedule,
+    )
     queryClient.setQueryData(
       getApiV1ProjectsByNameSchedulesQueryKey({ client: heyClient, path: { name: projectName } }),
       [options.schedule],
@@ -167,7 +177,7 @@ async function renderAt(
   await router.load()
 
   const tree = (
-    <AccountProvider account={null} apiKey={options.apiKey}>
+    <AccountProvider account={options.accountRole ? { name: 'operator', role: options.accountRole } : null} apiKey={options.apiKey}>
       <QueryClientProvider client={queryClient}>
         <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
           <RouterProvider router={router} />
@@ -1920,4 +1930,75 @@ test('a stale group key in the URL falls back to all properties instead of error
   const checked = group?.querySelector('[role="radio"][aria-checked="true"], option[selected]')
   expect(checked?.textContent).toBe('All properties')
   expect(html).not.toContain('Something went wrong')
+})
+
+const managedSchedule = {
+  id: 'managed-schedule', projectId: 'project_citypoint', kind: 'answer-visibility',
+  enabled: true, cronExpr: '0 6 * * *', timezone: 'UTC', providers: [],
+  nextRunAt: '2026-09-08T06:00:00.000Z', createdAt: '2026-09-01T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z',
+}
+
+function projectHeader(html: string) {
+  const container = document.createElement('div')
+  container.innerHTML = html
+  return container.querySelector('.page-header')!
+}
+
+test('managed sweeps unset preserves the operator sweep control and identical opt-out markup', async () => {
+  const options = { settleReadiness: true, readiness: true,
+    configureFixture(dashboard: ReturnType<typeof createDashboardFixture>['dashboard']) {
+      dashboard.projects.find(entry => entry.project.id === 'project_citypoint')!.recentRuns = []
+    },
+  }
+  const original = await renderAt('/projects/project_citypoint', undefined, undefined, options)
+  const disabled = await renderAt('/projects/project_citypoint', undefined, undefined, { ...options, managedSweeps: false })
+  expect(projectHeader(original).outerHTML).toBe(projectHeader(disabled).outerHTML)
+  expect(projectHeader(original).textContent).toContain('Run AI sweep')
+  expect(original).not.toContain('managed by your Canonry team')
+  expect(original).not.toContain('Sweeps are run by your Canonry team')
+})
+
+test.each(['simple', 'advanced'] as const)('managed sweeps replaces the %s header control for admins and viewers', async mode => {
+  for (const accountRole of ['admin', 'viewer'] as const) {
+    const html = await renderAt('/projects/project_citypoint', undefined,
+      mode === 'advanced' ? { plan: measurementPlanV2Response(2), overview: measurementOverviewResponse() } : undefined,
+      { managedSweeps: true, schedule: managedSchedule, accountRole },
+    )
+    const header = projectHeader(html)
+    expect(header.querySelector('button')).toBeNull()
+    expect(header.querySelector('time')?.dateTime).toBe(managedSchedule.nextRunAt)
+    expect(header.textContent).toContain('Next sync Tuesday 8 Sept, 06:00 UTC · managed by your Canonry team')
+    expect(html).not.toMatch(/Run AI sweep|Run measurement|Checking AI readiness|Set up AI Visibility/)
+  }
+})
+
+test('managed sweeps without a schedule replaces the header action without inventing a date', async () => {
+  const html = await renderAt('/projects/project_citypoint', undefined, undefined, { managedSweeps: true })
+  const status = projectHeader(html).querySelector('[role="status"]')!
+  expect(status.textContent).toBe('Sweeps are run by your Canonry team')
+  expect(status.querySelector('time')).toBeNull()
+  expect(projectHeader(html).querySelector('button')).toBeNull()
+  expect(status.textContent).not.toMatch(/Next sync|UTC|\d/)
+})
+
+test('managed sweeps removes Simple empty-state launch instructions', async () => {
+  const html = await renderAt('/projects/project_citypoint', undefined, undefined, {
+    managedSweeps: true, configureFixture: forceNoisyFreshVisibility,
+  })
+  expect(html).toContain('Sweeps are run by your Canonry team')
+  expect(html).not.toMatch(/Run another sweep|Complete your first AI Visibility sweep|Run a sweep/)
+})
+
+test('managed sweeps leaves Site Health scan controls available', async () => {
+  const html = await renderAt('/projects/project_citypoint/technical-aeo', undefined, undefined, { managedSweeps: true })
+  expect(html).toMatch(/Run scan|Checking scan/)
+  expect(projectHeader(html).textContent).toContain('Sweeps are run by your Canonry team')
+})
+
+test('managed sweeps replaces the global batch sweep control', async () => {
+  const original = await renderAt('/runs')
+  expect(original).toContain('Run all projects')
+  const managed = await renderAt('/runs', undefined, undefined, { managedSweeps: true })
+  expect(managed).not.toContain('Run all projects')
+  expect(managed).toContain('Sweeps are run by your Canonry team')
 })

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -68,6 +68,7 @@ async function renderAt(
     apiKey?: { id: string; scopes: string[]; projectId: string | null; readOnly: boolean }
     queries?: Array<{ id: string; query: string; createdAt: string }>
     settleReadiness?: boolean
+    settleSchedule?: boolean
     readiness?: boolean
     configureFixture?: (dashboard: ReturnType<typeof createDashboardFixture>['dashboard']) => void
   } = {},
@@ -185,7 +186,7 @@ async function renderAt(
       </QueryClientProvider>
     </AccountProvider>
   )
-  if (!options.settleReadiness || !settledSetup) return renderToStaticMarkup(tree)
+  if ((!options.settleReadiness || !settledSetup) && !options.settleSchedule) return renderToStaticMarkup(tree)
 
   // Header-readiness assertions need the authoritative refetch to settle. Most
   // route snapshots intentionally stay synchronous; this opt-in branch mounts
@@ -195,15 +196,22 @@ async function renderAt(
     const raw = input instanceof Request ? input.url : String(input)
     const url = new URL(raw, window.location.origin)
     if (decodeURIComponent(url.pathname).endsWith('/measurement-setup')) {
-      return jsonResponse(settledSetup)
+      return jsonResponse(settledSetup ?? simpleMeasurementSetupResponse())
     }
+    if (url.pathname.endsWith('/schedules')) return jsonResponse(options.schedule ? [options.schedule] : [])
+    if (url.pathname.endsWith('/schedule') && options.schedule) return jsonResponse(options.schedule)
     return jsonResponse({ code: 'NOT_FOUND', message: 'not found' }, 404)
   }) as typeof fetch
   try {
     const page = render(tree)
-    await waitFor(() => {
+    if (options.settleReadiness) await waitFor(() => {
       expect(queryClient.getQueryState(
         getApiV1ProjectsByNameMeasurementSetupQueryKey({ client: heyClient, path: { name: projectName } }),
+      )?.fetchStatus).toBe('idle')
+    })
+    if (options.settleSchedule) await waitFor(() => {
+      expect(queryClient.getQueryState(
+        getApiV1ProjectsByNameSchedulesQueryKey({ client: heyClient, path: { name: projectName } }),
       )?.fetchStatus).toBe('idle')
     })
     const html = page.container.innerHTML
@@ -1973,12 +1981,55 @@ test.each(['simple', 'advanced'] as const)('managed sweeps replaces the %s heade
 })
 
 test('managed sweeps without a schedule replaces the header action without inventing a date', async () => {
-  const html = await renderAt('/projects/project_citypoint', undefined, undefined, { managedSweeps: true })
+  const html = await renderAt('/projects/project_citypoint', undefined, undefined, {
+    managedSweeps: true, configureFixture(dashboard) {
+      dashboard.projects.find(entry => entry.project.id === 'project_citypoint')!.recentRuns = []
+    },
+  })
   const status = projectHeader(html).querySelector('[role="status"]')!
   expect(status.textContent).toBe('Sweeps are run by your Canonry team')
   expect(status.querySelector('time')).toBeNull()
   expect(projectHeader(html).querySelector('button')).toBeNull()
   expect(status.textContent).not.toMatch(/Next sync|UTC|\d/)
+})
+
+test.each(['simple', 'advanced'] as const)('managed %s project header retains queued and running sweep signals', async mode => {
+  for (const status of ['queued', 'running'] as const) {
+    const html = await renderAt('/projects/project_citypoint', undefined,
+      mode === 'advanced' ? { plan: measurementPlanV2Response(2), overview: measurementOverviewResponse() } : undefined,
+      { managedSweeps: true, schedule: managedSchedule, configureFixture(dashboard) {
+        const project = dashboard.projects.find(entry => entry.project.id === 'project_citypoint')!
+        project.recentRuns = [{ ...project.recentRuns[0]!, kind: 'answer-visibility', status }]
+      } },
+    )
+    const header = projectHeader(html)
+    expect(header.querySelector('[role="status"]')?.textContent).toContain('AI sweep running…')
+    expect(header.querySelector('time')?.dateTime).toBe(managedSchedule.nextRunAt)
+    expect(header.querySelector('button')).toBeNull()
+  }
+})
+
+test.each(['simple', 'advanced'] as const)('managed %s settings exposes schedule details without controls', async mode => {
+  const html = await renderAt('/projects/project_citypoint/settings', undefined,
+    mode === 'advanced' ? { plan: measurementPlanV2Response(2), overview: measurementOverviewResponse() } : undefined,
+    { managedSweeps: true, schedule: managedSchedule, accountRole: 'admin', settleSchedule: true },
+  )
+  const container = document.createElement('div')
+  container.innerHTML = html
+  const section = within(container).getByRole('heading', { name: 'Scheduled runs' }).closest('section')!
+  expect(section.textContent).toContain('Sweeps are run by your Canonry team')
+  expect(section.textContent).toContain('0 6 * * *')
+  expect(within(section).queryByRole('button', { name: /Set schedule|Edit schedule|Pause|Resume|Remove|Save schedule/ })).toBeNull()
+})
+
+test('managed header does not label an active Site Health scan as a sweep', async () => {
+  const html = await renderAt('/projects/project_citypoint', undefined, undefined, {
+    managedSweeps: true, configureFixture(dashboard) {
+      const project = dashboard.projects.find(entry => entry.project.id === 'project_citypoint')!
+      project.recentRuns = [{ ...project.recentRuns[0]!, kind: 'site-audit', status: 'running' }]
+    },
+  })
+  expect(projectHeader(html).textContent).not.toContain('AI sweep running')
 })
 
 test('managed sweeps removes Simple empty-state launch instructions', async () => {

--- a/apps/web/test/schedule-section.test.tsx
+++ b/apps/web/test/schedule-section.test.tsx
@@ -9,6 +9,7 @@ import { jsonResponse, mockFetch } from './mock-fetch.js'
 
 afterEach(() => {
   cleanup()
+  delete window.__CANONRY_CONFIG__
   focusManager.setFocused(undefined)
 })
 
@@ -29,6 +30,26 @@ function makeSchedule(overrides: Partial<ApiSchedule> = {}): ApiSchedule {
     ...overrides,
   }
 }
+
+test.each(['absent', 'active', 'paused'] as const)('managed %s schedule stays readable without mutation controls', async state => {
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: true } }
+  const restore = mockFetch((_url, init) => {
+    expect(init?.method).toBe('GET')
+    return jsonResponse(state === 'absent' ? [] : [makeSchedule({ enabled: state === 'active' })])
+  })
+  onTestFinished(restore)
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={client}><ScheduleSection projectName="citypoint" /></QueryClientProvider>)
+
+  if (state !== 'absent') {
+    expect(await screen.findByText('0 6 * * *')).toBeTruthy()
+    expect(screen.getByText(state === 'active' ? 'Active' : 'Paused')).toBeTruthy()
+  }
+  expect(await screen.findByText('Sweeps are run by your Canonry team')).toBeTruthy()
+  expect(screen.queryByRole('button', { name: /Set schedule|Edit schedule|Pause|Resume|Remove|Save schedule/ })).toBeNull()
+  expect(screen.queryByText(/Set one to automatically trigger/)).toBeNull()
+  expect(screen.queryByRole('combobox')).toBeNull()
+})
 
 test('discovers an existing schedule through the zero-noise collection read', async () => {
   let scheduleReads = 0

--- a/apps/web/test/setup-ai-visibility-onboarding.test.tsx
+++ b/apps/web/test/setup-ai-visibility-onboarding.test.tsx
@@ -242,17 +242,21 @@ test('keeps provider-switch keyboard focus while resetting credentials and advan
   expect(requests.filter(request => request.method === 'PUT')).toEqual([])
 })
 
-function renderColdScopedSetup(readinessResponse: () => Response | Promise<Response>) {
+function renderColdScopedSetup(readinessResponse: () => Response | Promise<Response>, existingRun?: {
+  status: 'queued' | 'running' | 'failed' | 'completed'
+  error?: { message: string }
+  snapshots?: Array<{ query: string; citationState: string; answerMentioned: boolean }>
+}) {
   const project = { ...createDashboardFixture().dashboard.projects[0]!.project, name: 'scoped-project', providers: ['gemini'] }
   const requests: string[] = []
   const telemetryEvents: Array<{ event: string }> = []
-  const run = { id: 'scoped-run', projectId: project.id, projectName: project.name, kind: 'answer-visibility', status: 'queued', createdAt: '2026-09-05T12:00:00Z' }
+  const run = { id: 'scoped-run', projectId: project.id, projectName: project.name, kind: 'answer-visibility', status: 'queued', createdAt: '2026-09-05T12:00:00Z', ...existingRun }
   let queries = [{ id: 'saved-query', query: 'best local dentist' }]
   const restore = mockFetch((url, init) => {
     const path = pathOf(url)
     requests.push(path)
     if (path === '/api/v1/projects') return jsonResponse([project])
-    if (path.split('?')[0] === '/api/v1/runs') return jsonResponse([])
+    if (path.split('?')[0] === '/api/v1/runs') return jsonResponse(existingRun ? [run] : [])
     if (path === '/api/v1/settings') return jsonResponse({ providers: [{ name: 'gemini', configured: true }] })
     if (path.endsWith('/measurement-setup')) return readinessResponse()
     if (path === '/api/v1/projects/scoped-project/runs' && init?.method === 'POST') return jsonResponse(run, 202)
@@ -657,5 +661,28 @@ test('managed sweeps finishes setup without offering to launch or retry a sweep'
   expect(screen.queryByRole('button', { name: /Launch visibility sweep|Retry visibility sweep/ })).toBeNull()
   expect(screen.queryByText(/Run a first sweep/)).toBeNull()
   fireEvent.click(screen.getByRole('button', { name: 'Open project dashboard →' }))
+  expect(requests).not.toContain('/api/v1/projects/scoped-project/runs')
+})
+
+test.each(['queued', 'running', 'failed', 'completed'] as const)('managed setup preserves the %s sweep state', async status => {
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: true } }
+  const { requests } = renderColdScopedSetup(() => jsonResponse({ answerVisibilityProviderReady: true }), {
+    status,
+    ...(status === 'failed' ? { error: { message: 'Provider quota exceeded' } } : {}),
+    snapshots: status === 'completed' ? [{ query: 'best local dentist', citationState: 'cited', answerMentioned: true }] : [],
+  })
+  fireEvent.click(await screen.findByRole('button', { name: 'Continue' }))
+  if (status === 'completed') {
+    expect(await screen.findByText('Mentioned')).toBeTruthy()
+    expect(screen.getByText('Cited')).toBeTruthy()
+    expect(screen.getByText('Results')).toBeTruthy()
+  } else if (status === 'failed') {
+    expect(await screen.findByText('Provider quota exceeded')).toBeTruthy()
+  } else {
+    expect(await screen.findByText('Sweep running. This usually takes 30 to 60 seconds.')).toBeTruthy()
+    expect(screen.getByText(status)).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: 'Setup complete' })).toBeNull()
+  }
+  expect(screen.queryByRole('button', { name: /Launch visibility sweep|Retry visibility sweep/ })).toBeNull()
   expect(requests).not.toContain('/api/v1/projects/scoped-project/runs')
 })

--- a/apps/web/test/setup-ai-visibility-onboarding.test.tsx
+++ b/apps/web/test/setup-ai-visibility-onboarding.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 
 afterEach(() => {
   cleanup()
+  delete window.__CANONRY_CONFIG__
   navigate.mockReset()
   clearOnboardingRunLaunched()
 })
@@ -645,4 +646,16 @@ test('keeps project-scoped query controls blocked until the canonical query read
   expect(await screen.findByText('saved canonical query')).toBeTruthy()
   expect(screen.queryByText('Loading saved queries…')).toBeNull()
   expect(screen.queryByLabelText('Queries (one per line)')).toBeNull()
+})
+
+
+test('managed sweeps finishes setup without offering to launch or retry a sweep', async () => {
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: true } }
+  const { requests } = renderColdScopedSetup(() => jsonResponse({ answerVisibilityProviderReady: true }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Continue' }))
+  expect(await screen.findByText('Sweeps are run by your Canonry team')).toBeTruthy()
+  expect(screen.queryByRole('button', { name: /Launch visibility sweep|Retry visibility sweep/ })).toBeNull()
+  expect(screen.queryByText(/Run a first sweep/)).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Open project dashboard →' }))
+  expect(requests).not.toContain('/api/v1/projects/scoped-project/runs')
 })

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,6 +70,25 @@ notices active.
 For container deployments, set `CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS=0` or
 `CANONRY_DASHBOARD_SHOW_UPDATE_NOTIFICATION=0`.
 
+### Managed sweeps
+
+Set `CANONRY_DASHBOARD_MANAGED_SWEEPS=1` or `dashboard.managedSweeps: true`
+for a deployment where your team runs AI Visibility sweeps for clients.
+The environment variable overrides config.yaml; `0` restores the controls.
+Restart the server with the updated environment after deploying this version.
+
+Simple and Advanced Measurement dashboards replace sweep launch controls with
+the enabled answer-visibility schedule's actual `nextRunAt`, displayed in UTC.
+Without a usable next-run time, they show “Sweeps are run by your Canonry team”.
+Site Health scans and other run kinds keep their controls.
+
+This hides sweep controls for **all dashboard roles, including admins**.
+Operators retain `canonry run <project>` against the managed instance as the
+manual lever. CLI, API, MCP, scheduling, and authorization are unchanged.
+Viewer sessions and read-only keys still cannot start sweeps, regardless of
+this presentation flag. Unset or false preserves the existing dashboard and
+injects no additional client config.
+
 ### Embed fonts
 
 Canonry ignores the `font` key in `embed.theme` and `X-Canonry-Embed-Theme`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -81,6 +81,9 @@ Simple and Advanced Measurement dashboards replace sweep launch controls with
 the enabled answer-visibility schedule's actual `nextRunAt`, displayed in UTC.
 Without a usable next-run time, they show “Sweeps are run by your Canonry team”.
 Site Health scans and other run kinds keep their controls.
+Running sweeps, baseline results, and failure details remain visible. Project
+Settings shows the schedule without controls to change it. Dashboard Aero uses
+read-only tools and disables its sweep shortcut and write-scope toggle.
 
 This hides sweep controls for **all dashboard roles, including admins**.
 Operators retain `canonry run <project>` against the managed instance as the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.183.1",
+  "version": "4.184.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -270,6 +270,11 @@ Providers are registered at server startup in `server.ts`. Each provider adapter
 
 ## Common Mistakes
 
+- `CANONRY_DASHBOARD_MANAGED_SWEEPS` overrides `dashboard.managedSweeps` and
+  defaults to false. Inject `dashboard.managedSweeps` only when true. This is
+  presentation only: all dashboard roles lose manual sweep controls, while
+  `canonry run <project>` remains the operator lever. See `docs/deployment.md`.
+
 - `competitor landscape --by-model` reads stored requested-model groups.
   Keep served identity separate. A model filter requires a provider.
   JSONL preserves the complete response as one compact document.

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.183.1",
+  "version": "4.184.0",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import os from 'node:os'
 import crypto from 'node:crypto'
 import { parse, stringify } from 'yaml'
+import { dashboardConfigSchema } from '@ainyc/canonry-config'
 import type { EmbedConfigEntry, ProviderQuotaPolicy } from '@ainyc/canonry-contracts'
 
 export type GoogleConnectionType = 'gsc' | 'ga4' | 'gbp'
@@ -350,6 +351,9 @@ export interface DashboardConfigEntry {
    * or CLI update notice.
    */
   showUpdateNotification?: boolean
+
+  /** Hide dashboard sweep controls; operators can still use `canonry run`. Defaults to false. */
+  managedSweeps?: boolean
 }
 
 /**
@@ -547,6 +551,7 @@ export function loadConfig(): CanonryConfig {
   }
 
   normalizeGoogleConfig(parsed)
+  if (parsed.dashboard) parsed.dashboard = dashboardConfigSchema.parse(parsed.dashboard)
   normalizeGoogleMarketingConfig(parsed)
   normalizeWordpressConfig(parsed)
   normalizeCloudflareTrafficConfig(parsed)

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -3,8 +3,9 @@ import path from 'node:path'
 import os from 'node:os'
 import crypto from 'node:crypto'
 import { parse, stringify } from 'yaml'
-import { dashboardConfigSchema } from '@ainyc/canonry-config'
+import { dashboardManagedSweepsSchema } from '@ainyc/canonry-config'
 import type { EmbedConfigEntry, ProviderQuotaPolicy } from '@ainyc/canonry-contracts'
+import { CliError } from './cli-error.js'
 
 export type GoogleConnectionType = 'gsc' | 'ga4' | 'gbp'
 
@@ -353,7 +354,7 @@ export interface DashboardConfigEntry {
   showUpdateNotification?: boolean
 
   /** Hide dashboard sweep controls; operators can still use `canonry run`. Defaults to false. */
-  managedSweeps?: boolean
+  managedSweeps?: boolean | null
 }
 
 /**
@@ -538,6 +539,15 @@ export function loadConfig(): CanonryConfig {
     )
   }
 
+  // Validate only the new field, without cloning/reordering the dashboard or
+  // tightening validation of legacy fields (including blank YAML values).
+  if (!dashboardManagedSweepsSchema.safeParse(parsed.dashboard?.managedSweeps).success) {
+    throw new CliError({
+      code: 'CONFIG_INVALID',
+      message: `Invalid config at ${configPath}: dashboard.managedSweeps must be true, false, or left blank.`,
+    })
+  }
+
   // Migrate legacy geminiApiKey to providers map
   if (parsed.geminiApiKey && !parsed.providers?.gemini) {
     parsed.providers = {
@@ -551,7 +561,6 @@ export function loadConfig(): CanonryConfig {
   }
 
   normalizeGoogleConfig(parsed)
-  if (parsed.dashboard) parsed.dashboard = dashboardConfigSchema.parse(parsed.dashboard)
   normalizeGoogleMarketingConfig(parsed)
   normalizeWordpressConfig(parsed)
   normalizeCloudflareTrafficConfig(parsed)

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -313,6 +313,12 @@ function resolveDashboardShowResourceLinks(env: NodeJS.ProcessEnv, config: Canon
     ?? true;
 }
 
+function resolveDashboardManagedSweeps(env: NodeJS.ProcessEnv, config: CanonryConfig): boolean {
+  return parseBooleanEnv(env.CANONRY_DASHBOARD_MANAGED_SWEEPS)
+    ?? config.dashboard?.managedSweeps
+    ?? false;
+}
+
 function resolveDashboardShowUpdateNotification(env: NodeJS.ProcessEnv, config: CanonryConfig): boolean {
   return parseBooleanEnv(env.CANONRY_DASHBOARD_SHOW_UPDATE_NOTIFICATION)
     ?? config.dashboard?.showUpdateNotification
@@ -2092,6 +2098,7 @@ export async function createServer(opts: {
   const dashboardRequirePassword = resolveDashboardRequirePassword(process.env, opts.config);
   const dashboardShowResourceLinks = resolveDashboardShowResourceLinks(process.env, opts.config);
   const dashboardShowUpdateNotification = resolveDashboardShowUpdateNotification(process.env, opts.config);
+  const dashboardManagedSweeps = resolveDashboardManagedSweeps(process.env, opts.config);
   const dashboardOnboardingMode = resolveDashboardOnboardingMode(process.env, opts.config);
   app.log.info(
     { dashboardRequirePassword },
@@ -3256,7 +3263,7 @@ export async function createServer(opts: {
       const clientConfig: Record<string, unknown> = {};
       if (basePath) clientConfig.basePath = basePath;
       // Keep the default client config byte-for-byte unchanged. Only inject the
-      // dashboard block when the operator opts out of dashboard chrome.
+      // dashboard block when the operator changes dashboard presentation.
       const dashboardConfig: Record<string, boolean | string> = {};
       if (dashboardOnboardingMode) {
         dashboardConfig.onboardingMode = dashboardOnboardingMode;
@@ -3266,6 +3273,9 @@ export async function createServer(opts: {
       }
       if (!dashboardShowUpdateNotification) {
         dashboardConfig.showUpdateNotification = false;
+      }
+      if (dashboardManagedSweeps) {
+        dashboardConfig.managedSweeps = true;
       }
       // The agent kill-switch removes the routes; without telling the browser,
       // the command bar still rendered and every request 404'd in front of the

--- a/packages/canonry/test/save-config.test.ts
+++ b/packages/canonry/test/save-config.test.ts
@@ -256,3 +256,62 @@ test('loadConfig preserves managed sweeps from config.yaml and validates its boo
   fs.writeFileSync(getConfigPath(), stringify({ ...configured, dashboard: { managedSweeps: 'true' } }))
   expect(loadConfig).toThrow(/managedSweeps/)
 })
+
+test('loadConfig accepts a legacy blank showUpdateNotification value', () => {
+  const original = `${stringify(baseConfig())}dashboard:\n  showUpdateNotification:\n`
+  fs.writeFileSync(getConfigPath(), original)
+
+  expect(loadConfig().dashboard?.showUpdateNotification).toBeNull()
+  expect(fs.readFileSync(getConfigPath(), 'utf8')).toBe(original)
+})
+
+test.each([undefined, false, true, null])('managedSweeps=%s leaves nullable legacy dashboard fields untouched', managedSweeps => {
+  const dashboard = {
+    showUpdateNotification: null,
+    showResourceLinks: null,
+    requirePassword: null,
+    onboardingMode: null,
+    extension: { label: 'preserve this' },
+    ...(managedSweeps === undefined ? {} : { managedSweeps }),
+  }
+  const original = stringify({ ...baseConfig(), dashboard })
+  fs.writeFileSync(getConfigPath(), original)
+
+  expect(loadConfig().dashboard).toEqual(dashboard)
+  saveConfigPatch(loadConfig())
+  expect(fs.readFileSync(getConfigPath(), 'utf8')).toBe(original)
+})
+
+test.each([undefined, false, true])('managedSweeps=%s preserves dashboard key order across whole-config saves', managedSweeps => {
+  const dashboard = {
+    showUpdateNotification: false,
+    extension: { label: 'preserve this' },
+    showResourceLinks: false,
+    requirePassword: true,
+    ...(managedSweeps === undefined ? {} : { managedSweeps }),
+  }
+  const original = stringify({ ...baseConfig(), dashboard })
+  fs.writeFileSync(getConfigPath(), original)
+
+  saveConfigPatch(loadConfig())
+  expect(fs.readFileSync(getConfigPath(), 'utf8')).toBe(original)
+})
+
+test.each(['text', 'json', 'jsonl'])('invalid managed sweeps is a path-qualified, non-retryable CLI error (%s)', async format => {
+  // Installed skills on the host must not trigger unrelated background config writes.
+  setEnv('CANONRY_NO_AUTO_SKILLS_SYNC', '1')
+  const invalidValue = 'private-invalid-value'
+  const original = stringify({ ...baseConfig(), dashboard: { managedSweeps: invalidValue } })
+  fs.writeFileSync(getConfigPath(), original)
+  const stderr = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const { runCli } = await import('../src/cli.js')
+
+  expect(await runCli(['telemetry', 'enable', '--format', format])).toBe(1)
+  const output = stderr.mock.calls.map(args => args.join(' ')).join('\n')
+  expect(output).toContain(getConfigPath())
+  expect(output).toContain('dashboard.managedSweeps')
+  expect(output).not.toContain(invalidValue)
+  expect(output).not.toContain('cnry_prod_key')
+  if (format !== 'text') expect(JSON.parse(output).error.code).toBe('CONFIG_INVALID')
+  expect(fs.readFileSync(getConfigPath(), 'utf8')).toBe(original)
+})

--- a/packages/canonry/test/save-config.test.ts
+++ b/packages/canonry/test/save-config.test.ts
@@ -248,3 +248,11 @@ test('loadConfigRaw reads config without applying env-var transformations', () =
   expect(raw!.apiUrl).toBe('http://localhost:4100') // not port-overridden
   expect(raw!.basePath).toBe('/original') // not env-overridden
 })
+
+test('loadConfig preserves managed sweeps from config.yaml and validates its boolean type', () => {
+  const configured = baseConfig({ dashboard: { showResourceLinks: false, managedSweeps: true } })
+  fs.writeFileSync(getConfigPath(), stringify(configured))
+  expect(loadConfig().dashboard).toEqual(configured.dashboard)
+  fs.writeFileSync(getConfigPath(), stringify({ ...configured, dashboard: { managedSweeps: 'true' } }))
+  expect(loadConfig).toThrow(/managedSweeps/)
+})

--- a/packages/canonry/test/server-embed.test.ts
+++ b/packages/canonry/test/server-embed.test.ts
@@ -229,6 +229,7 @@ describe('server embed mode (#716)', () => {
 
   it.each([
     [undefined, undefined, false],
+    [undefined, null, false],
     [undefined, false, false],
     [undefined, true, true],
     ['1', false, true],

--- a/packages/canonry/test/server-embed.test.ts
+++ b/packages/canonry/test/server-embed.test.ts
@@ -3,7 +3,8 @@ import os from 'node:os'
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import { createClient, migrate, apiKeys, projects, runs, type DatabaseClient } from '@ainyc/canonry-db'
+import { createClient, migrate, apiKeys, projects, runs, users, type DatabaseClient } from '@ainyc/canonry-db'
+import { hashUserPassword } from '@ainyc/canonry-api-routes'
 import { RunKinds } from '@ainyc/canonry-contracts'
 import { createServer } from '../src/server.js'
 import type { CanonryConfig } from '../src/config.js'
@@ -19,6 +20,7 @@ const EMBED_ENV = [
   'CANONRY_DASHBOARD_REQUIRE_PASSWORD',
   'CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS',
   'CANONRY_DASHBOARD_SHOW_UPDATE_NOTIFICATION',
+  'CANONRY_DASHBOARD_MANAGED_SWEEPS',
   'CANONRY_ONBOARDING_MODE',
 ] as const
 
@@ -220,6 +222,33 @@ describe('server embed mode (#716)', () => {
       expect(res.body).toContain(
         '<script>window.__CANONRY_CONFIG__={"dashboard":{"showUpdateNotification":false}}</script>',
       )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it.each([
+    [undefined, undefined, false],
+    [undefined, false, false],
+    [undefined, true, true],
+    ['1', false, true],
+    ['0', true, false],
+    ['invalid', true, true],
+  ] as const)('managed sweeps env=%s config=%s injects only the opt-in', async (env, configured, expected) => {
+    if (env !== undefined) process.env.CANONRY_DASHBOARD_MANAGED_SWEEPS = env
+    const { app, cleanup } = await buildServer(undefined, true, {
+      basePath: '/console',
+      dashboard: { showResourceLinks: false, ...(configured === undefined ? {} : { managedSweeps: configured }) },
+    })
+    try {
+      const expectedConfig = JSON.stringify({ basePath: '/console/', dashboard: {
+        showResourceLinks: false, ...(expected ? { managedSweeps: true } : {}),
+      } })
+      for (const url of ['/console/', '/console/projects/example']) {
+        const response = await app.inject({ method: 'GET', url })
+        const injected = response.body.match(/window\.__CANONRY_CONFIG__=(.*?)<\/script>/)?.[1]
+        expect(injected).toBe(expectedConfig)
+      }
     } finally {
       await cleanup()
     }
@@ -596,6 +625,35 @@ describe('server embed mode (#716)', () => {
         const res = await app.inject({ ...req, headers: auth })
         expect(res.statusCode, `${req.method} should be forbidden for a read-only key`).toBe(403)
         expect(JSON.parse(res.body).error.code).toBe('FORBIDDEN')
+      }
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it.each([false, true])('managedSweeps=%s preserves viewer and read-only sweep authorization', async managedSweeps => {
+    const { app, db, cleanup } = await buildServer(undefined, true, { dashboard: { managedSweeps } })
+    try {
+      seedProject(db, 'managed_project', 'managed-project')
+      const rawReadKey = `cnry_${crypto.randomBytes(16).toString('hex')}`
+      db.insert(apiKeys).values({
+        id: 'read-key', name: 'read-key', scopes: ['read'],
+        keyHash: crypto.createHash('sha256').update(rawReadKey).digest('hex'),
+        keyPrefix: rawReadKey.slice(0, 9), createdAt: new Date().toISOString(),
+      }).run()
+      const password = 'a-long-enough-viewer-password'
+      db.insert(users).values({
+        id: 'viewer', name: 'viewer', nameKey: 'viewer', role: 'viewer',
+        passwordHash: await hashUserPassword(password), createdAt: new Date().toISOString(),
+      }).run()
+      const browserHeaders = { origin: 'http://localhost:4100', host: 'localhost:4100' }
+      const login = await app.inject({ method: 'POST', url: '/api/v1/auth/login', headers: browserHeaders, payload: { name: 'viewer', password } })
+      expect(login.statusCode).toBe(200)
+      const cookie = login.cookies.map(({ name, value }) => `${name}=${value}`).join('; ')
+      for (const headers of [{ authorization: `Bearer ${rawReadKey}` }, { ...browserHeaders, cookie }]) {
+        const response = await app.inject({ method: 'POST', url: '/api/v1/projects/managed-project/runs', headers, payload: {} })
+        expect(response.statusCode).toBe(403)
+        expect(db.select().from(runs).all()).toHaveLength(0)
       }
     } finally {
       await cleanup()

--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -2,13 +2,15 @@
 
 ## Purpose
 
-Typed environment and configuration parsing. Single-file package that provides `loadConfig()` for reading `~/.canonry/config.yaml` and environment variables into a strongly-typed config object.
+Typed environment parsing and the dashboard config schema. `loadConfig()` and
+`saveConfigPatch()` live in `packages/canonry/src/config.ts`; `loadConfig()`
+validates the optional dashboard block with this package's schema.
 
 ## Key Files
 
 | File | Role |
 |------|------|
-| `src/index.ts` | Everything — config schema (Zod), `loadConfig()`, `saveConfigPatch()`, env var mapping |
+| `src/index.ts` | `dashboardConfigSchema` (including optional `managedSweeps`), `getPlatformEnv()`, `getBootstrapEnv()` |
 
 ## Patterns
 

--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -2,20 +2,20 @@
 
 ## Purpose
 
-Typed environment parsing and the dashboard config schema. `loadConfig()` and
+Typed environment parsing and the managed-sweeps flag schema. `loadConfig()` and
 `saveConfigPatch()` live in `packages/canonry/src/config.ts`; `loadConfig()`
-validates the optional dashboard block with this package's schema.
+validates only `dashboard.managedSweeps` with this package's scalar schema.
 
 ## Key Files
 
 | File | Role |
 |------|------|
-| `src/index.ts` | `dashboardConfigSchema` (including optional `managedSweeps`), `getPlatformEnv()`, `getBootstrapEnv()` |
+| `src/index.ts` | `dashboardManagedSweepsSchema`, `getPlatformEnv()`, `getBootstrapEnv()` |
 
 ## Patterns
 
 - **Config source priority**: Environment variables override `config.yaml` values.
-- **`loadConfig()`**: Returns a fully validated config object. Used by CLI commands (via `createApiClient()`) and the server.
+- **`loadConfig()`**: Loads config for CLI commands (via `createApiClient()`) and the server. Preserve legacy dashboard fields and their key order; never replace the block with schema parse output. An invalid `managedSweeps` raises a path-qualified `CliError` (exit 1). Missing or blank values leave the opt-in unset.
 - **`saveConfigPatch()`**: Merges partial updates into `~/.canonry/config.yaml`.
 - **Base path**: `CANONRY_BASE_PATH` env var and `basePath` in config.yaml are merged into `apiUrl`.
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,15 @@
 import { providerQuotaPolicySchema, type ProviderQuotaPolicy } from '@ainyc/canonry-contracts'
 import { z } from 'zod'
 
+export const dashboardConfigSchema = z.object({
+  onboardingMode: z.enum(['legacy', 'platform', 'auto']).optional(),
+  requirePassword: z.boolean().optional(),
+  showResourceLinks: z.boolean().optional(),
+  showUpdateNotification: z.boolean().optional(),
+  /** Presentation only. Operators retain the CLI manual sweep control. */
+  managedSweeps: z.boolean().optional(),
+}).passthrough()
+
 const envSchema = z.object({
   DATABASE_URL: z.string().default('postgresql://aeo:aeo@postgres:5432/aeo_platform'),
   API_PORT: z.coerce.number().int().positive().default(3000),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,14 +1,8 @@
 import { providerQuotaPolicySchema, type ProviderQuotaPolicy } from '@ainyc/canonry-contracts'
 import { z } from 'zod'
 
-export const dashboardConfigSchema = z.object({
-  onboardingMode: z.enum(['legacy', 'platform', 'auto']).optional(),
-  requirePassword: z.boolean().optional(),
-  showResourceLinks: z.boolean().optional(),
-  showUpdateNotification: z.boolean().optional(),
-  /** Presentation only. Operators retain the CLI manual sweep control. */
-  managedSweeps: z.boolean().optional(),
-}).passthrough()
+/** Presentation only. A missing or blank YAML value leaves the opt-in unset. */
+export const dashboardManagedSweepsSchema = z.boolean().nullish()
 
 const envSchema = z.object({
   DATABASE_URL: z.string().default('postgresql://aeo:aeo@postgres:5432/aeo_platform'),

--- a/packages/config/test/index.test.ts
+++ b/packages/config/test/index.test.ts
@@ -127,10 +127,12 @@ test('getBootstrapEnv parses hosted Canonry env vars', () => {
   expect(env.googleClientSecret).toBe('google-client-secret')
 })
 
-test('dashboard config accepts the managed-sweeps opt-in without injecting defaults', async () => {
-  const { dashboardConfigSchema } = await import('../src/index.js')
-  expect(dashboardConfigSchema.parse({})).toEqual({})
-  expect(dashboardConfigSchema.parse({ showResourceLinks: false, managedSweeps: true }))
-    .toEqual({ showResourceLinks: false, managedSweeps: true })
-  expect(dashboardConfigSchema.safeParse({ managedSweeps: 'true' }).success).toBe(false)
+test('managed-sweeps validation accepts booleans and blank values without injecting defaults', async () => {
+  const { dashboardManagedSweepsSchema } = await import('../src/index.js')
+  for (const value of [true, false, undefined, null]) {
+    expect(dashboardManagedSweepsSchema.parse(value)).toBe(value)
+  }
+  for (const value of ['true', 'false', 1, 0, {}, []]) {
+    expect(dashboardManagedSweepsSchema.safeParse(value).success).toBe(false)
+  }
 })

--- a/packages/config/test/index.test.ts
+++ b/packages/config/test/index.test.ts
@@ -126,3 +126,11 @@ test('getBootstrapEnv parses hosted Canonry env vars', () => {
   expect(env.googleClientId).toBe('google-client-id')
   expect(env.googleClientSecret).toBe('google-client-secret')
 })
+
+test('dashboard config accepts the managed-sweeps opt-in without injecting defaults', async () => {
+  const { dashboardConfigSchema } = await import('../src/index.js')
+  expect(dashboardConfigSchema.parse({})).toEqual({})
+  expect(dashboardConfigSchema.parse({ showResourceLinks: false, managedSweeps: true }))
+    .toEqual({ showResourceLinks: false, managedSweeps: true })
+  expect(dashboardConfigSchema.safeParse({ managedSweeps: 'true' }).success).toBe(false)
+})

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.183.1",
+  "version": "4.184.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.183.1",
+  "version": "4.184.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.183.1",
+  "version": "4.184.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Managed deployments need to show sweep progress and scheduling without exposing dashboard controls that launch or reschedule sweeps. This adds `CANONRY_DASHBOARD_MANAGED_SWEEPS=1` / `dashboard.managedSweeps: true` across Simple and Advanced Measurement, setup, Runs, and Aero, while preserving readable results, failure details, schedules, and the next sync time. Backend authorization and other job kinds retain their existing behavior.

Configuration validation accepts legacy nullable dashboard fields, preserves their key order, and returns a path-qualified `CONFIG_INVALID` error without exposing invalid values. The rebase retains these compatibility fixes, including changes previously authored in a merge commit. Canonry and plugin manifests are synchronized at `4.184.0`.

Validation: full `pnpm verify` passed on rebased commit `d98bc857` through the required pre-push hook; production web build passed. Configuration, embed, managed controls, and Aero regressions are included in the full suite.
