### PR TITLE
fix: enforce full verification before push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       # while only `ci.yml` was listed.
       - '.github/workflows/**'
       - '.github/actions/setup/action.yml'
+      - '.husky/**'
       - '.dockerignore'
       - 'Dockerfile'
       - 'docker/**'
@@ -43,6 +44,7 @@ on:
       # while only `ci.yml` was listed.
       - '.github/workflows/**'
       - '.github/actions/setup/action.yml'
+      - '.husky/**'
       - '.dockerignore'
       - 'Dockerfile'
       - 'docker/**'

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,18 @@
+# Package suites omit drift checks and workspace guards. Run the full merge gate.
+# Tests create their own repositories. Do not pass the pushing repository's
+# Git environment to them, or their Git commands can alter this checkout.
+git_env=$(git rev-parse --local-env-vars) || exit 1
+for git_var in $git_env; do
+  unset "$git_var"
+done
+log="$(mktemp "${TMPDIR:-/tmp}/canonry-prepush-verify.XXXXXX")" || exit 1
+echo "pre-push: running pnpm verify (log: $log)" >&2
+if pnpm verify > "$log" 2>&1; then
+  rm -f "$log"
+  echo "pre-push: pnpm verify passed" >&2
+else
+  echo "pre-push: pnpm verify FAILED" >&2
+  tail -40 "$log" >&2
+  echo "pre-push: full verification output -> $log" >&2
+  exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ ADR index, or canonical roadmap. For file-level navigation use `docs/CODEMAP.md`
 3. **Use `docs/CODEMAP.md` for file lookup** — one-line role per file + recipe table (`change first-run → App.tsx → SetupPage.tsx → execute-site-audit.ts`). Regenerated file list, not stale prose.
 4. **Search with `muse.search` (ripgrep, bounded)** — `muse.bash` fan-out (`find /`, `ls -R`) saturates the host. `muse.read_file` caps at 500 lines; chunk `SetupPage.tsx` (1260), `ProjectPage.tsx` (2728), `server.ts` (2969).
 5. **Web API calls MUST use `@ainyc/canonry-api-client`** (`heyClient` in `apps/web/src/api.ts`) — raw `fetch` is ESLint-banned. New route = `contracts` Zod → `api-routes` handler → `openapi.ts` → `pnpm gen` → web query.
-6. **Verify with `pnpm run typecheck && pnpm run test && pnpm run lint`** and `pnpm plugin:check` if you touched `plugins/` or `skills/`.
+6. **Run `pnpm verify` from the repository root before every push.** Package suites are intermediate checks. The lead agent must run the full gate after integrating sub-agent changes.
 7. **Use architecture diagrams when they clarify complicated topics.** New ideas and discussions warrant a back-and-forth.
 
 **Recipes:** `add API route` → `packages/contracts/src/*.ts` Zod → `packages/api-routes/src/<domain>.ts` → `openapi.ts` → `pnpm gen` → `apps/web/src/queries/*.ts`; `add CLI command` → `packages/canonry/src/cli-commands/<cmd>.ts` → `src/mcp/tool-registry.ts` tier + `openapi-classification.ts` → test; `add web section` → `PRODUCT.md` + `apps/web/src/pages/ProjectPage.tsx` tab → `apps/web/src/components/project/*` → update per-package `AGENTS.md`.
@@ -99,6 +99,7 @@ When proposing work, requesting feedback, or showcasing changes:
 ./canonry-install.sh
 
 pnpm install
+pnpm verify                     # required before every push: drift checks + all workspace checks
 pnpm run typecheck
 pnpm run test
 pnpm run lint
@@ -1019,7 +1020,7 @@ This is not optional. If you add a table to the schema but omit the migration, t
 
 - [ ] Table/column added to `schema.ts`
 - [ ] Matching migration added to `MIGRATIONS` in `migrate.ts`
-- [ ] `pnpm typecheck && pnpm lint && pnpm test` all pass before committing
+- [ ] `pnpm verify` passes before pushing
 
 ## Third-party HTTP calls (Critical)
 
@@ -1190,7 +1191,7 @@ The failure mode this prevents: a new semantics-bearing parameter is wired parse
 - Cover both the happy path and meaningful edge cases (invalid input, env var overrides, error handling).
 - When testing CLI commands, capture stdout/stderr and assert on output rather than only checking side effects.
 - Use temp directories (`os.tmpdir()`) for file-system tests; clean up in `afterEach`.
-- Run `pnpm run test` to verify before committing.
+- Run focused tests during development. Run `pnpm verify` before pushing.
 - **Test boundary matchers with data as STORED, not idealized.** Before writing a filter/normalizer/matcher over a stored column, check how that column is actually populated (project upsert/apply store `canonicalDomain` raw — full URLs and mixed case included) and sample real values when a database is available. Use the canonical helpers (`hostOf`, `normalizeQueryText`) from contracts instead of inline normalization: a clean-fixture-only suite passes while production values miss the match.
 - **Test default-value propagation end-to-end.** When a feature stores a default (e.g., `defaultLocation` on a project) that another feature consumes (e.g., run creation), write a test that exercises the full path with no explicit override. Don't just test that the default is stored and that the consumer accepts a value — test that they connect.
 
@@ -1207,10 +1208,18 @@ Several rules in this file are true only because a lint guard enforces them — 
 
 - Validation CI: `typecheck`, `test`, `lint` across the full workspace on PRs.
 - Keep explicit job permissions.
-- **Run `pnpm verify` before pushing.** It is the merge gate in one command:
-  `gen:check`, `plugin:check`, `typecheck`, `lint`, `test`, cheapest first. The
-  two drift checks fail in seconds and are the ones most often forgotten, since
-  nothing local reminds you that editing a route means regenerating the SDK.
+- **Run `pnpm verify` from the repository root before every push.** It runs
+  `gen:check`, `plugin:check`, `val:skills:check`, `typecheck`, `lint`, and `test`.
+  Package suites omit generated mirrors and workspace guards, including documentation assertions.
+- **The lead agent owns the final gate.** After integrating sub-agent changes,
+  run `pnpm verify` in the checkout you will push. A sub-agent's result is only
+  evidence for its reported checks. Record the checkout, commit, command, and result.
+  After any further edit, regeneration, or rebase, rerun the full gate.
+- **Fix drift at its source.** Use `pnpm gen`, `pnpm plugin:sync`, or
+  `pnpm val:skills` for the corresponding generated files. Review the generated
+  changes, then rerun `pnpm verify`. Do not weaken assertions to obtain a pass.
+- The Husky `pre-push` hook runs this gate and blocks the push on failure.
+  `pnpm install` installs the hooks. Do not bypass them to avoid a failed gate.
 
 ### Vals and the kit
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ This runs `pnpm install`, builds all packages, and installs `canonry` globally v
 Individual commands:
 
 ```bash
+pnpm verify                 # Required before every push
 pnpm run typecheck          # Type-check all packages
 pnpm run test               # Run test suite
 pnpm run lint               # Lint all packages
@@ -57,7 +58,13 @@ Use [`docs/README.md`](docs/README.md) as the entrypoint for the current referen
 ## Before Submitting a PR
 
 ```bash
-pnpm run typecheck && pnpm run test && pnpm run lint
+pnpm verify
 ```
 
-All three must pass.
+Run this command from the repository root before every push, after all changes are integrated.
+It includes generated API, plugin, and Val Town mirror checks, plus workspace typecheck, lint, and tests.
+Package suites are intermediate checks. They do not replace this gate.
+
+`pnpm install` installs the Husky hooks. The `pre-push` hook blocks the push if `pnpm verify` fails.
+On failure, the hook prints the last log lines and the full log path.
+After a fix, regeneration, or rebase, rerun the full gate.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,23 +12,31 @@ Tests live in `test/` directories colocated with each package (e.g. `packages/ca
 
 ## Workspace Checks
 
-Run before opening a PR:
+Run from the repository root before every push:
 
 ```bash
-pnpm run typecheck
-pnpm run test
-pnpm run lint
+pnpm verify
 ```
+
+This is the merge gate, including generated-file drift and documentation assertions.
+Package suites are intermediate checks. The lead agent must run the full gate after integrating sub-agent changes.
+After any edit, regeneration, or rebase, rerun it in the checkout you will push.
+
+The Husky `pre-push` hook runs the same command and blocks the push on failure.
+`pnpm install` installs the hooks. Failed runs retain a log and print its path.
 
 ## CI Mapping
 
-The validation job in `ci.yml` runs:
+Separate jobs in `ci.yml` cover the checks in `pnpm verify`:
 
+- `pnpm gen:check`
+- `pnpm plugin:check` (CI also supplies `--base-ref`)
+- `pnpm val:skills:check`
 - `pnpm run typecheck`
-- `pnpm run test`
 - `pnpm run lint`
+- `pnpm run test`
 
-across the full workspace on every PR.
+CI also runs build, Deno, and release guards. `pnpm verify` does not replace those additional checks.
 
 ## Package Verification
 

--- a/test/pre-push.test.ts
+++ b/test/pre-push.test.ts
@@ -1,0 +1,64 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, expect, test } from 'vitest'
+
+const tempDirs: string[] = []
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+test.each([0, 1])('push reaches the remote only when verification succeeds (exit %i)', (verifyExit) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-push-'))
+  tempDirs.push(dir)
+  const repo = path.join(dir, 'repo')
+  const remote = path.join(dir, 'remote.git')
+  const bin = path.join(dir, 'bin')
+  const hooks = path.join(dir, 'hooks')
+  for (const folder of [repo, bin, hooks]) fs.mkdirSync(folder)
+  const env = {
+    ...Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))),
+    PATH: `${bin}${path.delimiter}${process.env.PATH ?? ''}`,
+    TMPDIR: dir,
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_CONFIG_GLOBAL: '/dev/null',
+  }
+  const git = (args: string[], cwd = repo) => execFileSync('git', args, { cwd, env, encoding: 'utf8', stdio: 'pipe' }).trim()
+  git(['init', '--initial-branch=main'])
+  git(['init', '--bare', remote])
+  git(['config', 'core.hooksPath', hooks])
+  git(['-c', 'user.name=Hook Test', '-c', 'user.email=hook@example.com', 'commit', '--allow-empty', '-m', 'fixture'])
+  const hook = fs.readFileSync(new URL('../.husky/pre-push', import.meta.url), 'utf8')
+  fs.writeFileSync(path.join(hooks, 'pre-push'), `#!/bin/sh\n${hook}`, { mode: 0o755 })
+  // Substitute only the expensive verifier; exercise a real Git push and hook.
+  fs.writeFileSync(path.join(bin, 'pnpm'), `#!/bin/sh
+pwd > gate-cwd
+printf '%s\\n' "$*" >> gate-args
+git init --quiet nested-repo || exit 90
+git -C nested-repo -c user.name=Test -c user.email=test@example.com commit --quiet --allow-empty -m fixture || exit 91
+echo 'verification output'
+exit ${verifyExit}
+`, { mode: 0o755 })
+
+  const before = git(['rev-parse', 'HEAD'])
+  const pushed = spawnSync('git', ['push', remote, 'HEAD:refs/heads/main'], {
+    cwd: repo,
+    env: { ...env, GIT_DIR: path.join(repo, '.git'), GIT_WORK_TREE: repo },
+    encoding: 'utf8',
+  })
+  expect(fs.readFileSync(path.join(repo, 'gate-args'), 'utf8').trim()).toBe('verify')
+  expect(fs.realpathSync(fs.readFileSync(path.join(repo, 'gate-cwd'), 'utf8').trim())).toBe(fs.realpathSync(repo))
+  const remoteHead = git(['for-each-ref', '--format=%(objectname)', 'refs/heads/main'], remote)
+  expect(pushed.status).toBe(verifyExit)
+  expect(remoteHead).toBe(verifyExit === 0 ? git(['rev-parse', 'HEAD']) : '')
+  expect(git(['rev-parse', 'HEAD'])).toBe(before)
+  expect(fs.realpathSync(git(['rev-parse', '--show-toplevel'], path.join(repo, 'nested-repo')))).toBe(fs.realpathSync(path.join(repo, 'nested-repo')))
+  const logs = fs.readdirSync(dir).filter((name) => name.startsWith('canonry-prepush-verify.'))
+  expect(logs).toHaveLength(verifyExit === 0 ? 0 : 1)
+  if (verifyExit !== 0) {
+    expect(pushed.stderr).toContain('pnpm verify FAILED')
+    expect(pushed.stderr).toContain('verification output')
+    expect(fs.readFileSync(path.join(dir, logs[0]), 'utf8')).toContain('verification output')
+  }
+})


### PR DESCRIPTION
- Run `pnpm verify` in the pre-push hook, block failed pushes, and retain failure logs.
- Clear inherited Git repository variables so verification fixtures cannot alter the checkout being pushed.
- Align contributor and agent instructions, include hook changes in CI triggers, and test passing/failing pushes and nested repositories.
- Validation: full `pnpm verify` passed through the pre-push hook on the final commit. Hook regression tests also passed on Ubuntu.