### PR TITLE
Allow concurrent run kinds with same-kind admission guards

### DIFF
--- a/packages/api-routes/AGENTS.md
+++ b/packages/api-routes/AGENTS.md
@@ -84,6 +84,14 @@ WordPress backfill is forbidden while either continuation field is set.
 
 ## Patterns
 
+### Run admission
+
+Visibility admission is locked by `(projectId, kind)` in `queueRunIfProjectIdle`
+and the all-locations transaction. Unrelated run kinds may overlap. A location
+fan-out remains one atomic admission; a second visibility sweep is refused until
+all its active siblings finish. `RUN_IN_PROGRESS` includes the kind and blocking
+run ID. Keep existing per-kind deduplication and shared provider limits.
+
 ### Simple measurement provenance
 
 `captureSimpleMeasurementDefinition` stores resolved inputs before a simple run calls providers.

--- a/packages/api-routes/src/query-replace.ts
+++ b/packages/api-routes/src/query-replace.ts
@@ -150,7 +150,7 @@ export function assertNoActivePlanlessSweep(
     inArray(runs.status, [RunStatuses.queued, RunStatuses.running]),
     isNull(runs.measurementPlanVersionId),
   )).get()
-  if (activeRun) throw runInProgress(scope.projectName)
+  if (activeRun) throw runInProgress(scope.projectName, RunKinds['answer-visibility'], activeRun.id)
 }
 
 /** Check the legacy replacement inside the same transaction as its writes. */

--- a/packages/api-routes/src/run-queue.ts
+++ b/packages/api-routes/src/run-queue.ts
@@ -563,6 +563,7 @@ export type QueueRunResult =
   | { conflict: true; activeRunId: string }
   | { conflict: false; runId: string }
 
+/** Queue only when this project has no active run of the requested kind. */
 export function queueRunIfProjectIdle(db: DatabaseClient, params: QueueRunParams): QueueRunResult {
   const createdAt = params.createdAt ?? new Date().toISOString()
   const kind = params.kind ?? 'answer-visibility'
@@ -576,6 +577,7 @@ export function queueRunIfProjectIdle(db: DatabaseClient, params: QueueRunParams
       .where(
         and(
           eq(runs.projectId, params.projectId),
+          eq(runs.kind, kind),
           or(eq(runs.status, 'queued'), eq(runs.status, 'running')),
         ),
       )

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -170,8 +170,8 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
 
     // Handle --all-locations: create one run per configured location.
     //
-    // The fan-out is atomic with respect to the project-level idle lock:
-    // a single transaction checks for any active run and, only if none
+    // The fan-out is atomic with respect to the (project, kind) idle lock:
+    // a single transaction checks for an active run of this kind and, if none
     // exists, inserts the per-location runs. Two concurrent --all-locations
     // calls (manual + scheduled, two CLI shells, etc.) can no longer stack
     // duplicate sweeps on the same project, double-billing provider calls
@@ -187,11 +187,12 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
           .from(runs)
           .where(and(
             eq(runs.projectId, project.id),
+            eq(runs.kind, kind),
             or(eq(runs.status, 'queued'), eq(runs.status, 'running')),
           ))
           .get()
         if (activeRun) {
-          return { conflict: true as const }
+          return { conflict: true as const, activeRunId: activeRun.id }
         }
 
         const inserted: Array<{ runId: string; loc: LocationContext }> = []
@@ -213,7 +214,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
       })
 
       if (result.conflict) {
-        throw runInProgress(project.name)
+        throw runInProgress(project.name, kind, result.activeRunId)
       }
 
       const results = []
@@ -248,7 +249,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
       measurementScope: body.measurementScope ?? null,
     })
 
-    if (queueResult.conflict) throw runInProgress(project.name)
+    if (queueResult.conflict) throw runInProgress(project.name, kind, queueResult.activeRunId)
 
     const runId = queueResult.runId
 

--- a/packages/api-routes/test/run-all-locations-idle-lock.test.ts
+++ b/packages/api-routes/test/run-all-locations-idle-lock.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import os from 'node:os'
 import Fastify from 'fastify'
 import { and, eq, or } from 'drizzle-orm'
-import { createClient, migrate, runs } from '@ainyc/canonry-db'
+import { createClient, migrate, projects, runs } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 
 function buildApp() {
@@ -66,6 +66,34 @@ describe('POST /api/v1/projects/:name/runs with allLocations respects the idle l
     // setup is correct.
     return name
   }
+
+  it.each(['queued', 'running'])('admits a location fan-out alongside a %s audit and refuses a second sweep', async (status) => {
+    const project = db.select().from(projects).get()!
+    db.insert(runs).values({
+      id: 'audit', projectId: project.id, kind: 'site-audit', status, createdAt: new Date().toISOString(),
+    }).run()
+
+    const first = await app.inject({
+      method: 'POST', url: '/api/v1/projects/multi-loc/runs', payload: { allLocations: true },
+    })
+    expect(first.statusCode).toBe(207)
+    const fanout = first.json<Array<{ id: string; kind: string; location: string }>>()
+    expect(fanout.map(run => run.location).sort()).toEqual(['east', 'south', 'west'])
+    expect(fanout.every(run => run.kind === 'answer-visibility')).toBe(true)
+
+    const second = await app.inject({
+      method: 'POST', url: '/api/v1/projects/multi-loc/runs', payload: { allLocations: true },
+    })
+    expect(second.statusCode).toBe(409)
+    expect(second.json()).toMatchObject({ error: {
+      code: 'RUN_IN_PROGRESS',
+      message: expect.stringContaining('answer-visibility'),
+      details: { projectName: 'multi-loc', kind: 'answer-visibility', activeRunId: expect.any(String) },
+    } })
+    expect(fanout.map(run => run.id)).toContain(second.json().error.details.activeRunId)
+    expect(db.select().from(runs).all()).toHaveLength(4)
+    expect(db.select().from(runs).where(eq(runs.id, 'audit')).get()?.status).toBe(status)
+  })
 
   it('returns 409 RUN_IN_PROGRESS when a queued run already exists for the project', async () => {
     // First, kick off a single-location run to learn the project_id (read

--- a/packages/api-routes/test/run-queue-measurement-v2.test.ts
+++ b/packages/api-routes/test/run-queue-measurement-v2.test.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import Fastify from 'fastify'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it, onTestFinished } from 'vitest'
 import {
@@ -24,6 +25,7 @@ import {
   type DatabaseClient,
 } from '@ainyc/canonry-db'
 import { assertMeasurementRunStampable, queueRunIfProjectIdle } from '../src/run-queue.js'
+import { apiRoutes } from '../src/index.js'
 
 const NOW = '2026-08-01T00:00:00.000Z'
 const NORTH: LocationContext = { label: 'north-city', city: 'North City', region: 'NC', country: 'US' }
@@ -160,6 +162,67 @@ function queue(db: DatabaseClient, projectId: string, params: Parameters<typeof 
 }
 
 describe('a published v2 revision at queue time', () => {
+  it.each(['simple', 'advanced'].flatMap(portfolio =>
+    ['manual', 'batch'].flatMap(entry => ['queued', 'running'].map(status => ({ portfolio, entry, status }))),
+  ))('$portfolio $entry sweeps coexist with a $status audit and still reject duplicate sweeps', async ({ portfolio, entry, status }) => {
+    const { db, projectId } = seed({ projectProviders: ['openai'] })
+    const versionId = portfolio === 'advanced'
+      ? publishV2(db, projectId, v2Plan({
+        targets: ['north-branch', 'south-branch'],
+        groups: [{ key: 'region', targetKeys: ['north-branch', 'south-branch'] }],
+        nodes: [
+          { key: 'exec-north', queryId: 'q-1', queryText: 'widget question 0', providers: ['openai'], location: NORTH },
+          { key: 'exec-south', queryId: 'q-1', queryText: 'widget question 0', providers: ['openai'], location: SOUTH },
+        ],
+        assignments: [
+          { targetKey: 'north-branch', nodeKey: 'exec-north' },
+          { targetKey: 'south-branch', nodeKey: 'exec-south' },
+        ],
+      }), 1)
+      : null
+    db.insert(runs).values({ id: 'audit', projectId, kind: 'site-audit', status, createdAt: NOW }).run()
+
+    const app = Fastify()
+    onTestFinished(() => app.close())
+    const dispatched: string[] = []
+    app.register(apiRoutes, {
+      db, skipAuth: true, getRunnableProviderNames: () => ['openai'],
+      onRunCreated: (id) => { dispatched.push(id) },
+    })
+    const url = entry === 'manual' ? '/api/v1/projects/planned/runs' : '/api/v1/runs'
+    const first = await app.inject({ method: 'POST', url })
+    expect(first.statusCode).toBe(entry === 'manual' ? 201 : 207)
+    const created = entry === 'manual' ? first.json() : first.json()[0]
+    const row = queuedRun(db, created.id)
+    expect(row).toMatchObject({ kind: 'answer-visibility', status: 'queued', measurementPlanVersionId: versionId })
+    expect(row.queryBasketRevision).toBe(1)
+    if (versionId) {
+      const slots = parseMeasurementRunManifestV1(row.measurementManifest).expectedSlots
+      expect(slots).toHaveLength(2)
+      expect(slots.map(slot => slot.executionId).sort()).toEqual(['exec-north', 'exec-south'])
+      expect(slots.map(slot => slot.context?.label).sort()).toEqual(['north-city', 'south-city'])
+      expect(slots.every(slot => slot.provider === 'openai')).toBe(true)
+    } else {
+      expect(row.measurementManifest).toBeNull()
+    }
+
+    const second = await app.inject({ method: 'POST', url })
+    if (entry === 'manual') {
+      expect(second.statusCode).toBe(409)
+      expect(second.json()).toMatchObject({ error: {
+        code: 'RUN_IN_PROGRESS',
+        message: expect.stringContaining('answer-visibility'),
+        details: { projectName: 'planned', kind: 'answer-visibility', activeRunId: row.id },
+      } })
+    } else {
+      expect(second.statusCode).toBe(207)
+      expect(second.json()[0]).toMatchObject({ status: 'conflict', error: 'run_in_progress' })
+    }
+    expect(dispatched).toEqual([row.id])
+    expect(db.select().from(runs).all()).toHaveLength(2)
+    expect(queuedRun(db, 'audit').status).toBe(status)
+  })
+
   it('materializes the manifest from the revision\'s own execution nodes and frozen engines', () => {
     // The project row names an engine the revision does not run. A v2 revision
     // freezes provider configuration, so the plan wins.

--- a/packages/api-routes/test/run-queue.test.ts
+++ b/packages/api-routes/test/run-queue.test.ts
@@ -30,6 +30,27 @@ function seedProject(db: ReturnType<typeof createClient>, id: string, name: stri
 }
 
 describe('queueRunIfProjectIdle', () => {
+  it.each(Object.values(RunKinds).filter(kind => kind !== RunKinds['answer-visibility']).flatMap(kind =>
+    [RunStatuses.queued, RunStatuses.running].map(status => ({ kind, status })),
+  ))('allows a visibility sweep alongside $status $kind, but still blocks a duplicate sweep', ({ kind, status }) => {
+    const { db, tmpDir } = createTempDb()
+    onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    seedProject(db, 'proj_1', 'test-project')
+    db.insert(runs).values({
+      id: 'other-run', projectId: 'proj_1', kind, status, createdAt: new Date().toISOString(),
+    }).run()
+
+    const sweep = queueRunIfProjectIdle(db, { projectId: 'proj_1' })
+    expect(sweep.conflict).toBe(false)
+    if (sweep.conflict) throw new Error('visibility should not be blocked by another kind')
+    expect(queueRunIfProjectIdle(db, { projectId: 'proj_1' }))
+      .toEqual({ conflict: true, activeRunId: sweep.runId })
+    expect(queueRunIfProjectIdle(db, { projectId: 'proj_1', kind }))
+      .toEqual({ conflict: true, activeRunId: 'other-run' })
+    expect(db.select().from(runs).all()).toHaveLength(2)
+    expect(db.select().from(runs).where(eq(runs.id, 'other-run')).get()?.status).toBe(status)
+  })
+
   it('queues a run when project has no active runs', () => {
     const { db, tmpDir } = createTempDb()
     onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -170,6 +170,12 @@ The CLI also keeps interactive chrome (the "new version available" banner) off a
 
 ### Run completion pipeline
 
+Different run kinds may overlap on one project. Preserve shared provider gates
+and same-kind admission guards. Project-only cancellation requires exactly one
+active run; otherwise the CLI lists the candidates and requires a run ID.
+Boot recovery fails every queued/running run and its active crawl attempts;
+it does not resume interrupted work.
+
 Before provider dispatch, `JobRunner` captures the resolved inputs of each official simple run.
 The frozen definition records exact query text, identity, classification, location, and requested models.
 Capture failure prevents provider calls. Probe and advanced runs retain their existing paths.

--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -252,11 +252,28 @@ export async function triggerRunAll(opts?: { provider?: string; wait?: boolean; 
 export async function cancelRun(project: string, runId?: string, format?: string): Promise<void> {
   const client = getClient()
 
-  // If no run ID given, find the active run for the project
+  // Infer a target only when exactly one run is active, across all kinds.
   let targetId = runId
   if (!targetId) {
-    const runs = await client.listRuns(project) as Array<{ id: string; status: string }>
-    const active = runs.find(r => r.status === 'queued' || r.status === 'running')
+    const runs = await client.listRuns(project)
+    const activeRuns = runs.filter(r => r.status === 'queued' || r.status === 'running')
+    if (activeRuns.length > 1) {
+      const candidates = activeRuns.map(({ id, kind, status }) => ({ id, kind, status }))
+      throw new CliError({
+        code: 'MULTIPLE_ACTIVE_RUNS',
+        message: `Multiple active runs found for project "${project}". Specify a run ID.`,
+        displayMessage:
+          `Error: Multiple active runs found for project "${project}". Specify a run ID.\n`
+          + candidates.map(r => `  ${r.id}  ${r.kind}  ${r.status}`).join('\n')
+          + `\nTo cancel by ID: canonry run cancel ${project} <run-id>`,
+        details: {
+          project,
+          activeRuns: candidates,
+          suggestedCommands: [`canonry run cancel ${project} <run-id>`],
+        },
+      })
+    }
+    const active = activeRuns[0]
     if (!active) {
       throw new CliError({
         code: 'NO_ACTIVE_RUN',

--- a/packages/canonry/test/run-cancel-command.test.ts
+++ b/packages/canonry/test/run-cancel-command.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
+import { eq } from 'drizzle-orm'
 import { createClient, migrate, apiKeys, runs } from '@ainyc/canonry-db'
 import { createServer } from '../src/server.js'
 import { ApiClient } from '../src/client.js'
@@ -71,13 +72,14 @@ describe('cancelRun command', () => {
     if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  async function insertQueuedRun(): Promise<string> {
+  async function insertQueuedRun(kind = 'answer-visibility', status = 'queued'): Promise<string> {
     const project = await client.getProject('test-proj') as { id: string }
     const runId = crypto.randomUUID()
     db.insert(runs).values({
       id: runId,
       projectId: project.id,
-      status: 'queued',
+      kind,
+      status,
       createdAt: new Date().toISOString(),
     }).run()
     return runId
@@ -85,6 +87,7 @@ describe('cancelRun command', () => {
 
   it('cancels a run by explicit run ID and outputs confirmation', async () => {
     const runId = await insertQueuedRun()
+    const auditId = await insertQueuedRun('site-audit', 'running')
 
     const { cancelRun } = await import('../src/commands/run.js')
     const logs: string[] = []
@@ -99,6 +102,31 @@ describe('cancelRun command', () => {
     const output = logs.join('\n')
     expect(output).toContain(runId)
     expect(output).toContain('cancelled')
+    expect(db.select().from(runs).where(eq(runs.id, runId)).get()?.status).toBe('cancelled')
+    expect(db.select().from(runs).where(eq(runs.id, auditId)).get()?.status).toBe('running')
+  })
+
+  it.each(['site-audit', 'answer-visibility'])('requires a run ID when a sweep and another %s are active', async (kind) => {
+    const sweepId = await insertQueuedRun()
+    const otherId = await insertQueuedRun(kind, 'running')
+    await insertQueuedRun('ads-sync', 'completed')
+    const { cancelRun } = await import('../src/commands/run.js')
+
+    await expect(cancelRun('test-proj')).rejects.toMatchObject({
+      code: 'MULTIPLE_ACTIVE_RUNS',
+      message: expect.stringContaining('Specify a run ID'),
+      displayMessage: expect.stringContaining(otherId),
+      details: {
+        project: 'test-proj',
+        activeRuns: [
+          { id: sweepId, kind: 'answer-visibility', status: 'queued' },
+          { id: otherId, kind, status: 'running' },
+        ],
+        suggestedCommands: ['canonry run cancel test-proj <run-id>'],
+      },
+    })
+    expect(db.select().from(runs).where(eq(runs.id, sweepId)).get()?.status).toBe('queued')
+    expect(db.select().from(runs).where(eq(runs.id, otherId)).get()?.status).toBe('running')
   })
 
   it('auto-detects and cancels the active run when no run ID given', async () => {

--- a/packages/canonry/test/scheduler-measurement-plan.test.ts
+++ b/packages/canonry/test/scheduler-measurement-plan.test.ts
@@ -111,6 +111,20 @@ function trigger(db: ReturnType<typeof createClient>, projectId: string, runnabl
   return created
 }
 
+test('a scheduled plan sweep overlaps a site audit but a second sweep is skipped', () => {
+  const runnable = ['openai', 'gemini']
+  const { db, projectId } = harness([], runnable)
+  db.insert(runs).values({
+    id: 'audit', projectId, kind: 'site-audit', status: 'running', createdAt: new Date().toISOString(),
+  }).run()
+
+  const created = trigger(db, projectId, runnable)
+  expect(created).toHaveLength(1)
+  expect(trigger(db, projectId, runnable)).toEqual([])
+  expect(db.select().from(runs).all()).toHaveLength(2)
+  expect(db.select().from(runs).where(eq(runs.id, 'audit')).get()?.status).toBe('running')
+})
+
 test('a scheduled plan sweep resolves an empty project provider list to every configured provider', () => {
   const runnable = ['openai', 'gemini']
   const { db, projectId } = harness([], runnable)

--- a/packages/canonry/test/site-audit-recovery.test.ts
+++ b/packages/canonry/test/site-audit-recovery.test.ts
@@ -14,7 +14,7 @@ afterEach(async () => {
 })
 
 describe('site-audit crash recovery', () => {
-  it('fails a stale site-audit run and its active attempt at server boot', async () => {
+  it.each([RunStatuses.queued, RunStatuses.running])('recovers a %s crawl and a batch of other active run kinds at server boot', async (status) => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-site-audit-recovery-'))
     cleanup.push(dir)
     const dbPath = path.join(dir, 'data.db')
@@ -27,12 +27,26 @@ describe('site-audit crash recovery', () => {
     }).run()
     db.insert(runs).values({
       id: 'stale-run', projectId: 'project', kind: RunKinds['site-audit'],
-      status: RunStatuses.running, trigger: 'manual', startedAt: now, createdAt: now,
+      status, trigger: 'manual', startedAt: now, createdAt: now,
     }).run()
     db.insert(siteCrawlAttempts).values({
       id: 'stale-attempt', projectId: 'project', runId: 'stale-run', attemptNumber: 1,
-      state: 'running', startedAt: now, lastEventSequence: 7, createdAt: now, updatedAt: now,
+      state: status, startedAt: now, lastEventSequence: 7, createdAt: now, updatedAt: now,
     }).run()
+
+    const otherStaleRuns = Object.values(RunKinds).filter(kind => kind !== RunKinds['site-audit'])
+      .map((kind, index) => ({
+        id: `stale-${kind}`, projectId: 'project', kind,
+        status: index % 2 === 0 ? RunStatuses.queued : RunStatuses.running,
+        createdAt: now,
+      }))
+    db.insert(runs).values(otherStaleRuns).run()
+    const terminalRuns = [RunStatuses.completed, RunStatuses.partial, RunStatuses.failed, RunStatuses.cancelled]
+      .map(status => ({
+        id: `terminal-${status}`, projectId: 'project', kind: RunKinds['answer-visibility'],
+        status, finishedAt: now, createdAt: now,
+      }))
+    db.insert(runs).values(terminalRuns).run()
 
     // An active-looking attempt on a terminal parent must not be reaped just
     // because it shares the site-audit table; the parent transition is the CAS.
@@ -65,6 +79,19 @@ describe('site-audit crash recovery', () => {
       })
       expect(staleAttempt?.finishedAt).toBeTruthy()
 
+      for (const run of otherStaleRuns) {
+        expect(db.select().from(runs).where(eq(runs.id, run.id)).get()).toMatchObject({
+          status: RunStatuses.failed,
+          error: 'Server restarted while run was in progress',
+          finishedAt: expect.any(String),
+        })
+      }
+      for (const run of terminalRuns) {
+        expect(db.select().from(runs).where(eq(runs.id, run.id)).get()).toMatchObject({
+          status: run.status, finishedAt: now, error: null,
+        })
+      }
+      expect(db.select().from(runs).where(eq(runs.id, 'terminal-run')).get()?.status).toBe(RunStatuses.completed)
       expect(db.select().from(siteCrawlAttempts).where(eq(siteCrawlAttempts.id, 'terminal-attempt')).get()?.state).toBe('running')
     } finally {
       await app.close()

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -123,8 +123,13 @@ export function noQueries(projectName: string): AppError {
   )
 }
 
-export function runInProgress(projectName: string): AppError {
-  return new AppError('RUN_IN_PROGRESS', `A run is already in progress for '${projectName}'`, 409)
+export function runInProgress(projectName: string, kind = 'answer-visibility', activeRunId?: string): AppError {
+  return new AppError(
+    'RUN_IN_PROGRESS',
+    `A '${kind}' run is already in progress for '${projectName}'`,
+    409,
+    { projectName, kind, ...(activeRunId ? { activeRunId } : {}) },
+  )
 }
 
 export function operationInProgress(


### PR DESCRIPTION
## Summary

- Allow different run kinds to overlap within a project.
- Keep visibility runs deduplicated by `(projectId, kind)`.
- Include run kind and blocking run ID in conflict errors.
- Require an explicit run ID when cancelling multiple active runs.
- Recover all interrupted queued and running runs at startup.

## Testing

- Added API route, queue, scheduler, CLI cancellation, and recovery unit/integration coverage.