### PR TITLE
fix: correct client portfolio visibility and reporting states

### DIFF
--- a/apps/web/src/components/project/CompetitorLandscape.tsx
+++ b/apps/web/src/components/project/CompetitorLandscape.tsx
@@ -36,6 +36,21 @@ function formatShare(share: number | null): string {
   return share === null ? 'Not measured' : `${share.toFixed(1)}%`
 }
 
+type MetricAvailability = 'measured' | 'not-measured' | 'unavailable'
+
+function metricAvailability(landscape: CompetitorLandscapeData | undefined): MetricAvailability {
+  if (!landscape) return 'unavailable'
+  // A zero count is meaningful only after the selected window contains stored
+  // answer or source evidence. A completely empty window has no denominator.
+  return landscape.evidence.answeredResults > 0 || landscape.evidence.sourceResults > 0
+    ? 'measured'
+    : 'not-measured'
+}
+
+function unavailableMetricLabel(availability: MetricAvailability): string {
+  return availability === 'unavailable' ? 'Unavailable' : 'Not measured'
+}
+
 function sourceClassLabel(sourceClass: CompetitorLandscapeRow['surfaceClass']): string {
   switch (sourceClass) {
     case 'own': return 'Your domain'
@@ -101,14 +116,14 @@ function WindowControl({
 function LandscapeRow({
   row,
   isProject = false,
-  metricsAvailable = true,
+  metricState = 'measured',
   canManage,
   onPin,
   onUnpin,
 }: {
   row: CompetitorLandscapeRow
   isProject?: boolean
-  metricsAvailable?: boolean
+  metricState?: MetricAvailability
   canManage: boolean
   onPin?: CompetitorMutation
   onUnpin?: CompetitorMutation
@@ -118,6 +133,7 @@ function LandscapeRow({
   // look like current evidence. Pinning is the only truthful row action here.
   const canPin = !isProject && canManage && !row.pinned && Boolean(onPin)
   const canUnpin = !isProject && canManage && row.pinned && Boolean(onUnpin)
+  const metricsAvailable = metricState === 'measured'
   const hasWindowSources = metricsAvailable && row.sampleUrls.length > 0
   const [mutationPending, setMutationPending] = useState(false)
   const [mutationError, setMutationError] = useState<string | null>(null)
@@ -144,9 +160,9 @@ function LandscapeRow({
         {isProject ? <span className="ml-1 text-secondary">(you)</span> : null}
       </th>
       <td className="text-secondary">{isProject ? 'Your brand' : sourceClassLabel(row.surfaceClass)}</td>
-      <td className="tabular-nums text-strong">{metricsAvailable ? formatShare(row.shareOfVoice) : 'Unavailable'}</td>
-      <td className="tabular-nums text-secondary">{metricsAvailable ? row.mentionCount : 'Unavailable'}</td>
-      <td className="tabular-nums text-secondary">{metricsAvailable ? row.citationCount : 'Unavailable'}</td>
+      <td className="tabular-nums text-strong">{metricsAvailable ? formatShare(row.shareOfVoice) : unavailableMetricLabel(metricState)}</td>
+      <td className="tabular-nums text-secondary">{metricsAvailable ? row.mentionCount : unavailableMetricLabel(metricState)}</td>
+      <td className="tabular-nums text-secondary">{metricsAvailable ? row.citationCount : unavailableMetricLabel(metricState)}</td>
       <td className="text-right">
         {canPin || canUnpin || hasWindowSources ? (
           <div className="flex min-w-max items-start justify-end gap-2">
@@ -321,6 +337,7 @@ export function CompetitorLandscape({
   const observed = landscape?.observed ?? []
   const otherSources = landscape?.otherSources ?? []
   const evidence = landscape?.evidence
+  const metricState = metricAvailability(landscape)
   const pendingDraftCompetitorCount = landscape?.marketState?.draft?.pendingCompetitorDomains.length ?? 0
 
   return (
@@ -365,12 +382,12 @@ export function CompetitorLandscape({
                 {landscape ? (
                   <>
                     <GroupHeading>You</GroupHeading>
-                    <LandscapeRow row={landscape.project} isProject canManage={false} />
+                    <LandscapeRow row={landscape.project} isProject metricState={metricState} canManage={false} />
                   </>
                 ) : null}
                 <GroupHeading>Pinned</GroupHeading>
                 {pinned.length > 0 ? pinned.map(row => (
-                  <LandscapeRow key={row.domain} row={{ ...row, pinned: true }} metricsAvailable={Boolean(landscape)} canManage={canManage} onUnpin={onUnpin} />
+                  <LandscapeRow key={row.domain} row={{ ...row, pinned: true }} metricState={metricState} canManage={canManage} onUnpin={onUnpin} />
                 )) : (
                   <tr><td colSpan={6} className="text-secondary">No pinned competitors.</td></tr>
                 )}

--- a/apps/web/src/components/project/ProjectEngineSettingsSection.tsx
+++ b/apps/web/src/components/project/ProjectEngineSettingsSection.tsx
@@ -3,6 +3,7 @@ import { Link } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 
 import { fetchSettings, isEmbed, type ApiProject } from '../../api.js'
+import { useAccount } from '../../contexts/account-context.js'
 import { Button } from '../ui/button.js'
 import { describeError } from '@ainyc/canonry-contracts'
 
@@ -34,7 +35,15 @@ export function ProjectEngineSettingsSection({
   project: EngineProject
   onSave: (next: EngineSave) => Promise<void>
 }) {
-  const settings = useQuery({ queryKey: ['settings'], queryFn: fetchSettings, staleTime: 60_000 })
+  const { isAdmin } = useAccount()
+  // Do not request settings when this section is hidden for non-admins or embeds.
+  // Bookmarked Settings tabs must not trigger an unseen 403.
+  const settings = useQuery({
+    queryKey: ['settings'],
+    queryFn: fetchSettings,
+    staleTime: 60_000,
+    enabled: isAdmin && !isEmbed(),
+  })
   const [automatic, setAutomatic] = useState(project.providers.length === 0)
   const [selected, setSelected] = useState<string[]>(project.providers)
   const [models, setModels] = useState<Record<string, string>>(() => copyModels(project.providerModels))
@@ -150,7 +159,7 @@ export function ProjectEngineSettingsSection({
     }
   }
 
-  if (isEmbed()) return null
+  if (isEmbed() || !isAdmin) return null
   if (settings.isLoading) {
     return <section className="project-engine-settings" aria-busy="true"><p role="status" className="text-sm text-secondary">Loading engine settings…</p></section>
   }

--- a/apps/web/src/components/project/ScheduleSection.tsx
+++ b/apps/web/src/components/project/ScheduleSection.tsx
@@ -289,7 +289,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
               {managedSweeps && <p className="text-sm text-secondary">{MANAGED_SWEEPS_COPY}</p>}
               <p className="text-sm font-medium text-strong">{scheduleLabel(schedule.preset ?? null, schedule.cronExpr, schedule.timezone)}</p>
               <p className="text-xs text-muted">Cron: <span className="font-mono">{schedule.cronExpr}</span></p>
-              {schedule.nextRunAt && (
+              {schedule.enabled && schedule.nextRunAt && (
                 <p className="text-xs text-muted">Next run: {new Date(schedule.nextRunAt).toLocaleString()}</p>
               )}
               {schedule.lastRunAt && (

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { buildModelChangeNotice, describeError } from '@ainyc/canonry-contracts'
 import type { BrandMetricsDto, MetricsWindow } from '@ainyc/canonry-contracts'
-import type { VisibilityReportResponse, VisibilityReportRate, VisibilityReportPopulation } from '@ainyc/canonry-contracts'
+import type { VisibilityReportQueryRow, VisibilityReportResponse, VisibilityReportRate, VisibilityReportPopulation } from '@ainyc/canonry-contracts'
 import { getApiV1ProjectsByNameVisibilityReportOptions } from '@ainyc/canonry-api-client/react-query'
 import { heyClient } from '../../api.js'
 import type { VisibilityAnswerSelection, VisibilitySelectionState } from '../../lib/measurement-view-url.js'
@@ -82,6 +82,28 @@ function reportScopeLabel(scope: VisibilityReportResponse['selection']['scope'])
 function ReportRate({ value, unit }: { value: VisibilityReportRate; unit?: 'answers' | 'properties' }) {
   if (value.rate === null) return <span className="text-sm text-secondary">{value.reason === 'not-applicable' ? 'Not applicable' : 'Not measured'}</span>
   return <span className="inline-flex flex-col gap-1"><strong className="tabular-nums text-heading">{reportPercent.format(value.rate)}</strong><span className="text-sm tabular-nums text-secondary">{value.numerator} of {value.denominator}{unit ? ` ${unit}` : ''}</span></span>
+}
+
+export interface VisibilityQueryGroup {
+  queryKey: string
+  query: string
+  rows: VisibilityReportQueryRow[]
+}
+
+/**
+ * The report API publishes one row for every observed engine context. Keep
+ * those rows intact, but nest them below their one tracked-query identity on
+ * the current page so model, location, denominator, and property scope never become an invented
+ * query-level aggregate.
+ */
+export function groupVisibilityQueryRows(rows: readonly VisibilityReportQueryRow[]): VisibilityQueryGroup[] {
+  const groups = new Map<string, VisibilityQueryGroup>()
+  for (const row of rows) {
+    const group = groups.get(row.queryKey)
+    if (group) group.rows.push(row)
+    else groups.set(row.queryKey, { queryKey: row.queryKey, query: row.query, rows: [row] })
+  }
+  return [...groups.values()]
 }
 
 function ReportTrend({ population }: { population: VisibilityReportPopulation }) {
@@ -245,7 +267,10 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
       {filterSelect('AI model', 'measurementModel', selection.model ?? '', [{ value: '', label: 'All models' }, ...Array.from(new Set(filterOptions.models.filter(model => !selection.provider || model.provider === selection.provider).map(model => model.model))).map(model => ({ value: model, label: model }))], 'Filter by the AI model recorded with each answer. This does not change the model used by future sweeps.')}
       {filterSelect('Results from', 'measurementRunId', selection.run.explicit ? selection.run.id ?? '' : '', [{ value: '', label: 'Latest saved sweep' }, ...[...report.populations[0]!.trend].reverse().map(point => ({ value: point.runId, label: new Date(point.createdAt).toLocaleString() }))], 'Choose a saved AI sweep to view its results. No new sweep starts.')}
     </div></details>
-    {report.populations.map(population => <section key={population.queryClass} aria-label={REPORT_CLASS_LABEL[population.queryClass]} className="py-4">
+    {report.populations.map(population => {
+      const queryGroups = groupVisibilityQueryRows(population.queries.items)
+      const queryColumnCount = selection.mode === 'advanced' ? 7 : 6
+      return <section key={population.queryClass} aria-label={REPORT_CLASS_LABEL[population.queryClass]} className="py-4">
       <div className="section-head"><h2>{REPORT_CLASS_LABEL[population.queryClass]}</h2><InfoTooltip text={population.queryClass === 'non-brand' ? 'Queries that do not name the measured identity. Geography alone is not a brand.' : population.queryClass === 'branded' ? 'Queries that name the measured identity.' : 'The measured definition could not establish a query class. These answers are not included in branded or non-brand rates.'} /></div>
       <div className="flex flex-wrap gap-x-8 gap-y-4 border-y border-default py-4">
         <div><div className="mb-2 flex items-center gap-1 text-sm text-secondary"><span>{selection.mode === 'advanced' && selection.scope.kind !== 'property' ? 'Answers mentioning a property' : 'Mentioned answers'}</span>{selection.mode === 'advanced' ? <InfoTooltip text="An answer counts when it mentions any assigned property. This does not mean every property was mentioned." /> : null}</div><ReportRate value={population.summary.mentionCoverage} unit="answers" /></div>
@@ -261,27 +286,32 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
       <details className="border-t border-default" data-query-results={population.queryClass} aria-label={`${REPORT_CLASS_LABEL[population.queryClass]} query results`}>
         <summary className="min-h-11 cursor-pointer py-5 text-heading focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400"><span className="font-semibold">Query results</span><span className="ml-3 text-sm font-normal text-secondary">{population.queries.total} {population.queries.total === 1 ? 'result' : 'results'} · {scopeLabel}</span></summary>
         <div className="pb-5">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">{onSearch ? <input type="search" aria-label={`Search ${REPORT_CLASS_LABEL[population.queryClass]}`} placeholder="Search queries" className={`${REPORT_CONTROL} max-w-sm`} value={search} onChange={event => onSearch(event.target.value)} /> : null}<InfoTooltip text={selection.mode === 'advanced' ? 'Each result is one query, answer engine, model, and search location. Mentioned and Cited count answers matching any of its assigned properties, not the percentage of properties found.' : 'Each result is one query, answer engine, model, and search location. Mentioned counts answers naming your brand. Cited counts answers linking to your site.'} /></div>
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">{onSearch ? <input type="search" aria-label={`Search ${REPORT_CLASS_LABEL[population.queryClass]}`} placeholder="Search queries" className={`${REPORT_CONTROL} max-w-sm`} value={search} onChange={event => onSearch(event.target.value)} /> : null}<InfoTooltip text={selection.mode === 'advanced' ? 'Each tracked query is grouped once on this page. Its engine rows retain the recorded model, location, property scope, and answer counts. Mentioned and Cited count answers matching any assigned property, not the percentage of properties found.' : 'Each tracked query is grouped once on this page. Its engine rows retain the recorded model, location, and answer counts. Mentioned counts answers naming your brand. Cited counts answers linking to your site.'} /></div>
         <div className="overflow-x-auto">
           <table className="evidence-table measurement-responsive-table">
             <thead><tr><th>Query</th>{selection.mode === 'advanced' ? <th>Properties</th> : null}<th>Answer engine</th><th>Search location</th><th>Mentioned</th><th>Cited</th><th className="measurement-table-actions"><span className="sr-only">Evidence</span></th></tr></thead>
-            <tbody>{population.queries.items.map(row => <tr key={JSON.stringify([row.queryKey, row.provider, row.model, row.location])}>
-              <td className="measurement-query-cell font-medium text-heading">{row.query}</td>
-              {selection.mode === 'advanced' ? <td className="measurement-target-cell">
-                {row.targetKeys.length === 1 ? targetLabels.get(row.targetKeys[0]!) ?? row.targetKeys[0] : row.targetKeys.length > 1 ? <details>
-                  <summary className="min-h-11 cursor-pointer py-2 text-secondary">{row.targetKeys.length} properties</summary>
-                  <ul className="max-h-48 space-y-2 overflow-y-auto py-2 text-sm text-secondary">{row.targetKeys.map(key => <li key={key}>{targetLabels.get(key) ?? key}</li>)}</ul>
-                </details> : 'No properties'}
-              </td> : null}
-              <td>{row.provider}{row.model ? <span className="block text-sm text-secondary">{row.model}</span> : null}</td>
-              <td>{row.location ?? 'No location'}</td>
-              <td><ReportRate value={row.mentionCoverage} /></td>
-              <td><ReportRate value={row.citationCoverage} /></td>
-              <td className="measurement-table-actions"><Button variant="ghost" aria-label={`View answers for ${row.query} · ${row.provider}`} onClick={() => onSelectionChange({ measurementQueryKey: row.queryKey, measurementAnswer: JSON.stringify({ queryKey: row.queryKey, queryClass: population.queryClass, provider: row.provider, model: row.model, location: row.location, runId: selection.run.id, revision: selection.revision } satisfies VisibilityAnswerSelection) })}>View answers</Button></td>
-            </tr>)}</tbody>
+            {queryGroups.map(group => <tbody key={group.queryKey} data-query-key={group.queryKey}>
+              <tr className="bg-surface-subtle">
+                <th scope="rowgroup" colSpan={queryColumnCount} className="measurement-query-cell text-sm font-medium normal-case tracking-normal text-heading">{group.query}</th>
+              </tr>
+              {group.rows.map(row => <tr key={JSON.stringify([row.provider, row.model, row.location])}>
+                <td aria-label={`Query: ${group.query}`} className="measurement-query-cell text-secondary"><span aria-hidden="true">↳</span></td>
+                {selection.mode === 'advanced' ? <td className="measurement-target-cell">
+                  {row.targetKeys.length === 1 ? targetLabels.get(row.targetKeys[0]!) ?? row.targetKeys[0] : row.targetKeys.length > 1 ? <details>
+                    <summary className="min-h-11 cursor-pointer py-2 text-secondary">{row.targetKeys.length} properties</summary>
+                    <ul className="max-h-48 space-y-2 overflow-y-auto py-2 text-sm text-secondary">{row.targetKeys.map(key => <li key={key}>{targetLabels.get(key) ?? key}</li>)}</ul>
+                  </details> : 'No properties'}
+                </td> : null}
+                <td>{row.provider}{row.model ? <span className="block text-sm text-secondary">{row.model}</span> : null}</td>
+                <td>{row.location ?? 'No location'}</td>
+                <td><ReportRate value={row.mentionCoverage} /></td>
+                <td><ReportRate value={row.citationCoverage} /></td>
+                <td className="measurement-table-actions"><Button variant="ghost" aria-label={`View answers for ${row.query} · ${row.provider}`} onClick={() => onSelectionChange({ measurementQueryKey: row.queryKey, measurementAnswer: JSON.stringify({ queryKey: row.queryKey, queryClass: population.queryClass, provider: row.provider, model: row.model, location: row.location, runId: selection.run.id, revision: selection.revision } satisfies VisibilityAnswerSelection) })}>View answers</Button></td>
+              </tr>)}
+            </tbody>)}
           </table>
         </div>
-        {population.queries.items.length === 0 ? <p className="py-4 text-sm text-secondary">No measured queries match this selection.</p> : <p className="mt-3 text-sm text-secondary">{population.queries.items.length} shown of {population.queries.total}</p>}
+        {population.queries.items.length === 0 ? <p className="py-4 text-sm text-secondary">No measured queries match this selection.</p> : <p className="mt-3 text-sm text-secondary">{queryGroups.length} {queryGroups.length === 1 ? 'query' : 'queries'} · {population.queries.items.length} {population.queries.items.length === 1 ? 'engine result' : 'engine results'} shown of {population.queries.total} results</p>}
         {population.queries.nextCursor && onPage ? <Button variant="outline" onClick={() => onPage(population.queries.nextCursor!)}>Next queries</Button> : null}
       {queryKey && answerClasses.includes(population.queryClass) ? <section tabIndex={-1} className="scroll-mt-6 border-t border-default py-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400" aria-label="Measured answers" aria-busy={isEvidenceLoading}><div className="section-head"><h3>Answers</h3><Button variant="ghost" onClick={event => { focusedQueryKey.current = undefined; event.currentTarget.closest('details[data-query-results]')?.querySelector('summary')?.focus(); onSelectionChange({ measurementQueryKey: undefined, measurementAnswer: undefined }) }}>Close answers</Button></div>
         {isEvidenceLoading ? <p role="status" className="py-4 text-sm text-secondary">Loading saved answers…</p> : evidenceError ? <div role="alert" className="py-4 text-sm text-secondary"><p>Saved answers unavailable: {evidenceError}</p>{onRetryEvidence ? <Button variant="outline" onClick={onRetryEvidence}>Retry answers</Button> : null}</div> : <>
@@ -296,7 +326,7 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
         {population.competitorAvailability.state === 'unavailable' ? <p className="text-sm text-secondary">Competitor rates unavailable for this historical definition.</p> : population.competitors.length === 0 ? <p className="text-sm text-secondary">No measured competitors in this selection.</p> : <div className="overflow-x-auto"><table className="evidence-table"><thead><tr><th>Competitor</th><th>Mentioned</th><th>Cited</th></tr></thead><tbody>{population.competitors.map(row => <tr key={row.domain}><td>{row.domain}</td><td><ReportRate value={row.mentionCoverage} /></td><td><ReportRate value={row.citationCoverage} /></td></tr>)}</tbody></table></div>}
         {population.observedCompetitors.length > 0 ? <details className="mt-4 text-sm"><summary className="min-h-11 cursor-pointer py-3 text-heading">Other names in answers</summary><ul className="divide-y divide-default">{population.observedCompetitors.map(row => <li key={row.name} className="flex items-center justify-between gap-4 py-3"><span>{row.name}</span><span className="tabular-nums text-secondary">{row.answerCount} {row.answerCount === 1 ? 'answer' : 'answers'}</span></li>)}</ul><p className="py-2 text-secondary">Observed names, not additions to your tracked competitors.</p></details> : null}
       </div></details>
-    </section>)}
+    </section>})}
   </section>
 }
 

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -1511,9 +1511,9 @@ function ReadySetupPage({
             : runStatus === 'cancelled'
               ? 'The sweep was cancelled before it produced a baseline.'
               : (runStatus === 'completed' || runStatus === 'partial') && snapshots.length === 0
-                ? 'The sweep finished without producing any snapshots. Confirm the query set and provider configuration, then retry.'
+                ? 'The sweep finished without producing any snapshots.'
                 : latestPersistedRun?.statusDetail
-                  || 'The sweep did not produce a baseline. Review provider configuration, then retry.')
+                  || 'The sweep did not produce a baseline.')
 
         let stepBadge: ReactNode = null
         if (persistedSetupComplete || successfulRun) {
@@ -1622,13 +1622,19 @@ function ReadySetupPage({
               <div className="compact-stack">
                 <div role="alert" className="rounded-md border border-negative bg-negative-soft p-3 text-sm text-negative">
                   <p>{runFailureDetail}</p>
-                  <p className="mt-1 text-xs text-secondary">{isDashboardManagedSweeps() ? MANAGED_SWEEPS_COPY : 'Fix provider or query configuration if needed, then retry without leaving setup.'}</p>
+                  <p className="mt-1 text-xs text-secondary">{isDashboardManagedSweeps()
+                    ? MANAGED_SWEEPS_COPY
+                    : isAdmin
+                      ? 'Fix provider or query configuration if needed, then retry without leaving setup.'
+                      : 'Ask an administrator to review the provider and query configuration.'}</p>
                 </div>
                 <div className="setup-nav">
-                  <Button type="button" variant="outline" asChild>
-                    <Link to="/settings">Configure providers</Link>
-                  </Button>
-                  {isDashboardManagedSweeps() ? (
+                  {isAdmin && !isDashboardManagedSweeps() ? (
+                    <Button type="button" variant="outline" asChild>
+                      <Link to="/settings">Configure providers</Link>
+                    </Button>
+                  ) : <span />}
+                  {isDashboardManagedSweeps() || !isAdmin ? (
                     <Button type="button" onClick={openProjectDashboard}>Open project dashboard →</Button>
                   ) : <Button type="button" disabled={runSaving || !!launchBlockedReason} onClick={asyncHandler(handleLaunchRun)}>
                     {runSaving ? 'Retrying...' : 'Retry visibility sweep'}

--- a/apps/web/test/competitor-landscape.test.tsx
+++ b/apps/web/test/competitor-landscape.test.tsx
@@ -207,6 +207,36 @@ describe('CompetitorLandscape', () => {
     expect(text.indexOf('Pinned zero')).toBeLessThan(text.indexOf('Observed rival'))
   })
 
+  test.each([
+    { kind: 'project' },
+    { kind: 'group', groupKey: 'north' },
+    { kind: 'all-markets' },
+  ] as const)('marks an empty $kind history window as unmeasured while retaining measured zeroes', (scope) => {
+    const emptyEvidence = {
+      answeredResults: 0,
+      sourceResults: 0,
+      missingAnswerTextResults: 0,
+      mentionCredits: 0,
+      incompleteSourceResults: 0,
+      excludedProbeResults: 0,
+      excludedNonCompletedResults: 0,
+    }
+    const { rerender, props } = renderLandscape({ landscape: landscape({ scope, evidence: emptyEvidence }) })
+
+    const brandRow = screen.getByRole('rowheader', { name: /Canonry/ }).closest('tr')!
+    expect(within(brandRow).getAllByText('Not measured')).toHaveLength(3)
+    expect(brandRow.textContent).not.toContain('0.0%')
+
+    rerender(<CompetitorLandscape {...props} landscape={landscape({
+      scope,
+      project: row({ domain: 'canonry.example', label: 'Canonry', surfaceClass: 'own', shareOfVoice: 0, mentionCount: 0, citationCount: 0 }),
+      evidence: { ...emptyEvidence, answeredResults: 1 },
+    })} />)
+    const measuredZeroRow = screen.getByRole('rowheader', { name: /Canonry/ }).closest('tr')!
+    expect(within(measuredZeroRow).getByText('0.0%')).toBeTruthy()
+    expect(within(measuredZeroRow).getAllByText('0')).toHaveLength(2)
+  })
+
   test('does not link historical rows to the latest-only evidence table', () => {
     renderLandscape()
 

--- a/apps/web/test/project-engine-settings-section.test.tsx
+++ b/apps/web/test/project-engine-settings-section.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
 
 import { ProjectEngineSettingsSection } from '../src/components/project/ProjectEngineSettingsSection.js'
+import { AccountProvider } from '../src/contexts/account-context.js'
 import { mockFetch, jsonResponse } from './mock-fetch.js'
 
 afterEach(cleanup)
@@ -92,4 +93,29 @@ test('a background project refetch does not clobber in-progress edits', async ()
   // The in-progress "Choose engines" selection must survive the refetch.
   expect((screen.getByLabelText('Choose engines') as HTMLInputElement).checked).toBe(true)
   expect((screen.getByLabelText('Gemini') as HTMLInputElement).checked).toBe(true)
+})
+
+test.each([
+  { label: 'project-scoped writer', apiKey: { id: 'project-writer', scopes: ['*'], projectId: 'project-1', readOnly: false }, embed: false },
+  { label: 'embed', apiKey: undefined, embed: true },
+])('does not render or request the administrator provider catalogue for $label', async ({ apiKey, embed }) => {
+  const requests: string[] = []
+  const restore = mockFetch(url => {
+    requests.push(url)
+    throw new Error(`The provider catalogue must not be requested: ${url}`)
+  })
+  onTestFinished(restore)
+  if (embed) window.__CANONRY_CONFIG__ = { embed: { enabled: true } }
+  onTestFinished(() => { delete window.__CANONRY_CONFIG__ })
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <AccountProvider account={null} apiKey={apiKey}>
+        <ProjectEngineSettingsSection project={{ name: 'demo', providers: [], providerModels: {} }} onSave={vi.fn().mockResolvedValue(undefined)} />
+      </AccountProvider>
+    </QueryClientProvider>,
+  )
+
+  expect(screen.queryByRole('heading', { name: 'Answer engines' })).toBeNull()
+  expect(requests).toEqual([])
 })

--- a/apps/web/test/research-queries-section.test.tsx
+++ b/apps/web/test/research-queries-section.test.tsx
@@ -1,16 +1,25 @@
 import React from 'react'
 import { afterEach, expect, onTestFinished, test } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import { DiscoverySection } from '../src/components/project/DiscoverySection.js'
+import { AccountProvider } from '../src/contexts/account-context.js'
 import { jsonResponse, mockFetch } from './mock-fetch.js'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  delete window.__CANONRY_CONFIG__
+})
 
-function installApiMock() {
-  const restoreFetch = mockFetch((url) => {
+function installApiMock(posts?: string[]) {
+  const restoreFetch = mockFetch((url, init) => {
     const path = new URL(url).pathname
+
+    if (init?.method === 'POST' && posts) {
+      posts.push(path)
+      return jsonResponse({ error: { code: 'INTERNAL_ERROR', message: 'Test provider unavailable' } }, 503)
+    }
 
     if (path === '/api/v1/projects/demo/discover/sessions') return jsonResponse([])
     if (path === '/api/v1/projects/demo/research/runs') return jsonResponse({ runs: [] })
@@ -38,6 +47,30 @@ function installApiMock() {
   })
   onTestFinished(restoreFetch)
 }
+
+test.each([false, true])('managedSweeps=%s preserves client Discovery and Research run access', async (managedSweeps) => {
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps } }
+  const posts: string[] = []
+  installApiMock(posts)
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  onTestFinished(() => queryClient.clear())
+  render(
+    <AccountProvider account={null} apiKey={{ id: 'client-key', scopes: ['*'], projectId: 'project_demo', readOnly: false }}>
+      <QueryClientProvider client={queryClient}><DiscoverySection projectName="demo" /></QueryClientProvider>
+    </AccountProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /Find queries/ }))
+  await waitFor(() => expect(posts).toContain('/api/v1/projects/demo/discover/run'))
+
+  fireEvent.click(screen.getByRole('tab', { name: 'Research queries' }))
+  await screen.findByRole('option', { name: 'OpenAI' })
+  fireEvent.change(screen.getByPlaceholderText(/one query per line/i), { target: { value: 'How do I measure AI citations?' } })
+  const run = screen.getByRole('button', { name: /^Run .*quer/ }) as HTMLButtonElement
+  await waitFor(() => expect(run.disabled).toBe(false))
+  fireEvent.click(run)
+  await waitFor(() => expect(posts).toContain('/api/v1/projects/demo/research/runs'))
+})
 
 test('switches to research, deduplicates query lines, gates exact model choice, and states that research is not tracked', async () => {
   installApiMock()

--- a/apps/web/test/schedule-section.test.tsx
+++ b/apps/web/test/schedule-section.test.tsx
@@ -84,6 +84,20 @@ test('discovers an existing schedule through the zero-noise collection read', as
   expect(scheduleReads).toBe(1)
 })
 
+test('does not present a persisted next run for a paused schedule', async () => {
+  const restore = mockFetch(() => jsonResponse([makeSchedule({ enabled: false })]))
+  onTestFinished(restore)
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ScheduleSection projectName="citypoint" />
+    </QueryClientProvider>,
+  )
+
+  expect(await screen.findByText('Paused')).toBeTruthy()
+  expect(screen.queryByText(/Next run:/)).toBeNull()
+})
+
 test('refreshes a stale cached absence before schedule editing is available', async () => {
   let resolveScheduleRead!: (response: Response) => void
   const scheduleRead = new Promise<Response>((resolve) => {

--- a/apps/web/test/setup-ai-visibility-onboarding.test.tsx
+++ b/apps/web/test/setup-ai-visibility-onboarding.test.tsx
@@ -360,6 +360,22 @@ test('keeps a confirmed missing provider blocked for scoped writers without cred
   expect(screen.queryByRole('link', { name: 'Open provider settings' })).toBeNull()
 })
 
+test.each([
+  { status: 'completed' as const, snapshots: [], expected: 'The sweep finished without producing any snapshots.' },
+  { status: 'failed' as const, snapshots: [], error: { message: 'Provider quota exceeded' }, expected: 'Provider quota exceeded' },
+].flatMap(scenario => [false, true].map(managedSweeps => ({ ...scenario, managedSweeps }))))('gives a scoped writer coherent guidance after a $status sweep (managed=$managedSweeps)', async ({ status, snapshots, error, expected, managedSweeps }) => {
+  window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps } }
+  renderColdScopedSetup(() => jsonResponse({ answerVisibilityProviderReady: true }), { status, snapshots, ...(error ? { error } : {}) })
+  fireEvent.click(await screen.findByRole('button', { name: 'Continue' }))
+
+  expect(await screen.findByText(expected)).toBeTruthy()
+  expect(screen.getByText(managedSweeps ? 'Sweeps are run by your Canonry team' : 'Ask an administrator to review the provider and query configuration.')).toBeTruthy()
+  expect(screen.queryByText('Fix provider or query configuration if needed, then retry without leaving setup.')).toBeNull()
+  expect(screen.queryByRole('link', { name: 'Configure providers' })).toBeNull()
+  expect(screen.queryByRole('button', { name: 'Retry visibility sweep' })).toBeNull()
+  expect(screen.getByRole('button', { name: 'Open project dashboard →' })).toBeTruthy()
+})
+
 test('keeps a stale project-list handoff scoped to the exact onboarding project', async () => {
   const fixture = createDashboardFixture()
   fixture.dashboard.projects = []

--- a/apps/web/test/visibility-report-view.test.tsx
+++ b/apps/web/test/visibility-report-view.test.tsx
@@ -137,6 +137,49 @@ describe('shared production visibility view', () => {
     expect(html).not.toContain('Run AI sweep')
   })
 
+  it.each([
+    { mode: 'simple' as const, showsProperties: false },
+    { mode: 'advanced' as const, showsProperties: true },
+  ])('groups each tracked query once while preserving every $mode engine context and its rates', ({ mode, showsProperties }) => {
+    const report = reportFixture()
+    report.selection.mode = mode
+    const population = report.populations[0]!
+    population.queries.items.push({
+      ...population.queries.items[0]!,
+      provider: 'openai',
+      model: 'gpt-5.6',
+      location: 'Detroit',
+      targetKeys: ['p2'],
+      answerCount: 1,
+      mentionCoverage: { numerator: 0, denominator: 1, rate: 0 },
+      citationCoverage: { numerator: 1, denominator: 1, rate: 1 },
+    })
+    population.queries.total = 2
+    if (showsProperties) report.scopeOptions.push(
+      { id: 'p1', label: 'Northstar Alpha 01', kind: 'property', targetCount: 1 },
+      { id: 'p2', label: 'Harbor House', kind: 'property', targetCount: 1 },
+    )
+
+    const { container } = render(<VisibilityReportView report={report} onSelectionChange={() => {}} />)
+    fireEvent.click(screen.getByText('Query results', { selector: 'span' }).closest('summary')!)
+
+    const table = container.querySelector('table.measurement-responsive-table')!
+    expect(table.querySelectorAll('[data-query-key="query-context"]')).toHaveLength(1)
+    expect(within(table).getByRole('button', { name: 'View answers for apartments near transit · gemini' })).toBeTruthy()
+    expect(within(table).getByRole('button', { name: 'View answers for apartments near transit · openai' })).toBeTruthy()
+    expect(within(table).getByText('gpt-5.6')).toBeTruthy()
+    expect(within(table).getByText('Detroit')).toBeTruthy()
+    if (showsProperties) {
+      expect(within(table).getByText('Northstar Alpha 01')).toBeTruthy()
+      expect(within(table).getByText('Harbor House')).toBeTruthy()
+    } else {
+      expect(within(table).queryByRole('columnheader', { name: 'Properties' })).toBeNull()
+    }
+    expect(within(table).getByText('1 of 3')).toBeTruthy()
+    expect(within(table).getByText('0 of 1')).toBeTruthy()
+    expect(container.textContent).toContain('1 query · 2 engine results shown of 2 results')
+  })
+
   it('explains frozen prior measurement without claiming new assignments have answers', () => {
     const html = renderToStaticMarkup(<VisibilityReportView report={reportFixture()} onSelectionChange={() => {}} />)
     expect(html).toContain('Measured under revision 2')

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -81,6 +81,9 @@ Simple and Advanced Measurement dashboards replace sweep launch controls with
 the enabled answer-visibility schedule's actual `nextRunAt`, displayed in UTC.
 Without a usable next-run time, they show “Sweeps are run by your Canonry team”.
 Site Health scans and other run kinds keep their controls.
+Discovery and Research runs remain available to clients with write access.
+They use provider quota separately from scheduled visibility sweeps. Existing
+viewer and read-only restrictions still apply.
 Running sweeps, baseline results, and failure details remain visible. Project
 Settings shows the schedule without controls to change it. Dashboard Aero uses
 read-only tools and disables its sweep shortcut and write-scope toggle.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.186.0",
+  "version": "4.186.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -73,6 +73,7 @@ import {
 import { loadDismissedTargetRefs } from './content.js'
 import { mergeGscDailyTotalsWithFallback, mergeGscQueryTotalsWithFallback, readGscDailyTotals, readGscQueryDailyRows } from './gsc-totals.js'
 import { notProbeRun, resolveProject } from './helpers.js'
+import { activeMeasurementPlan } from './measurement-overview.js'
 import { renderReportHtml } from './report-renderer.js'
 import { pickWinningAttributionDimension } from './ga-ai-referral-aggregation.js'
 import {
@@ -1640,6 +1641,21 @@ function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAud
   return action.audience === 'both' || action.audience === audience
 }
 
+/** Active plan competitors suppress only the setup action; report metrics keep their existing source. */
+function configuredCompetitorDomainsForActionPlan(
+  db: DatabaseClient,
+  projectId: string,
+  projectCompetitorDomains: readonly string[],
+): string[] {
+  const active = activeMeasurementPlan(db, projectId)
+  if (!active) return [...projectCompetitorDomains]
+
+  const planCompetitorDomains = active.plan.schemaVersion === 2
+    ? active.plan.groups.flatMap(group => group.competitors.map(competitor => competitor.domain))
+    : active.plan.groups.flatMap(group => group.competitors ?? [])
+  return [...new Set([...projectCompetitorDomains, ...planCompetitorDomains])]
+}
+
 interface ReportActionPlanInput {
   canonicalDomain: string
   competitorDomains: string[]
@@ -1659,7 +1675,7 @@ function buildReportActionPlan(input: ReportActionPlanInput): ReportActionPlanIt
   if (input.competitorDomains.length === 0 && input.aiSourceOrigin.topDomains.length > 0) {
     const topDomains = input.aiSourceOrigin.topDomains.slice(0, 5)
     actions.push({
-      audience: 'both',
+      audience: 'agency',
       priority: 10,
       horizon: 'immediate',
       category: 'competitors',
@@ -2254,6 +2270,11 @@ function buildProjectReport(db: DatabaseClient, projectName: string, periodDays:
 
   const competitorRows = db.select().from(competitors).where(eq(competitors.projectId, project.id)).all()
   const competitorDomains = competitorRows.map(c => c.domain)
+  const actionPlanCompetitorDomains = configuredCompetitorDomainsForActionPlan(
+    db,
+    project.id,
+    competitorDomains,
+  )
 
   // Treat ownedDomains the same way determineCitationState does — anything
   // matching the canonical domain or an owned subdomain counts as "ours".
@@ -2439,7 +2460,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string, periodDays:
 
   const actionPlan = buildReportActionPlan({
     canonicalDomain: project.canonicalDomain,
-    competitorDomains,
+    competitorDomains: actionPlanCompetitorDomains,
     citationScorecard,
     aiSourceOrigin,
     gsc: gscSection,

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -5,6 +5,14 @@ import path from 'node:path'
 import Fastify from 'fastify'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import {
+  canonicalMeasurementPlanJson,
+  canonicalMeasurementPlanV2Json,
+  compileMeasurementPlan,
+  type MeasurementPlan,
+  type MeasurementPlanV2,
+  type ProjectReportDto,
+} from '@ainyc/canonry-contracts'
+import {
   createClient,
   migrate,
   projects,
@@ -24,9 +32,11 @@ import {
   trafficSources,
   crawlerEventsHourly,
   aiReferralEventsHourly,
+  measurementPlans,
+  measurementPlanVersions,
 } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
-import type { ProjectReportDto } from '@ainyc/canonry-contracts'
+import { measurementPlanV2Fixture } from './measurement-plan-v2-fixture.js'
 
 function buildApp() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-report-'))
@@ -523,13 +533,112 @@ describe('GET /api/v1/projects/:name/report', () => {
     const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/az-actions/report' })
     const body = JSON.parse(res.body) as ProjectReportDto
 
-    expect(body.actionPlan.some(a => a.category === 'competitors' && a.audience === 'both')).toBe(true)
+    expect(body.actionPlan.some(a => a.category === 'competitors' && a.audience === 'agency')).toBe(true)
     expect(body.actionPlan.some(a => a.category === 'content' && a.title.includes('best industrial coatings'))).toBe(true)
     expect(body.actionPlan.some(a => a.category === 'indexing' && a.evidence.some(e => e.includes('20% indexed')))).toBe(true)
     expect(body.actionPlan.some(a => a.category === 'provider' && a.evidence.some(e => e.includes('openai: 0/2')))).toBe(true)
     expect(body.actionPlan.some(a => a.category === 'search-demand' && a.evidence.some(e => e.includes('epoxy floor coatings contractors')))).toBe(true)
     expect(body.clientSummary.actionItems.length).toBeGreaterThan(0)
+    expect(body.clientSummary.actionItems.some(a => a.category === 'competitors')).toBe(false)
+    expect(body.agencyDiagnostics.priorities.some(a => a.category === 'competitors')).toBe(true)
     expect(body.agencyDiagnostics.priorities.some(a => a.category === 'provider')).toBe(true)
+  })
+
+  test('does not recommend competitors already configured by the active measurement plan', async () => {
+    const projectId = insertProject(ctx.db, 'plan-competitors')
+    const queryId = insertQuery(ctx.db, projectId, 'homes near harbor')
+    const runId = insertRun(ctx.db, projectId)
+    insertSnapshot(ctx.db, runId, queryId, {
+      citationState: 'not-cited',
+      answerMentioned: false,
+      citedDomains: ['external-directory.example'],
+    })
+
+    const activePlan: MeasurementPlanV2 = measurementPlanV2Fixture()
+    const versionId = crypto.randomUUID()
+    ctx.db.insert(measurementPlanVersions).values({
+      id: versionId,
+      projectId,
+      revision: 1,
+      canonicalJson: canonicalMeasurementPlanV2Json(activePlan),
+      checksum: 'a'.repeat(64),
+      schemaVersion: 2,
+      compiledChecksum: activePlan.compiledChecksum,
+      createdAt: new Date().toISOString(),
+    }).run()
+    ctx.db.insert(measurementPlans).values({
+      projectId,
+      activeVersionId: versionId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/plan-competitors/report' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.actionPlan.some(action => action.category === 'competitors')).toBe(false)
+    expect(body.agencyDiagnostics.priorities.some(action => action.category === 'competitors')).toBe(false)
+  })
+
+  test('does not recommend competitors already configured by an active v1 measurement plan', async () => {
+    const projectId = insertProject(ctx.db, 'v1-plan-competitors')
+    const queryId = insertQuery(ctx.db, projectId, 'homes near harbor')
+    const runId = insertRun(ctx.db, projectId)
+    insertSnapshot(ctx.db, runId, queryId, {
+      citationState: 'not-cited',
+      answerMentioned: false,
+      citedDomains: ['external-directory.example'],
+    })
+
+    const activePlan: MeasurementPlan = compileMeasurementPlan({
+      schemaVersion: 1,
+      targets: [{
+        stableKey: 'harbor',
+        label: 'Harbor Homes',
+        urls: [{ kind: 'host', host: 'v1-plan-competitors.example.com' }],
+        aliases: ['Harbor Homes'],
+      }],
+      groups: [{
+        stableKey: 'regional',
+        label: 'Regional comparison',
+        targetKeys: ['harbor'],
+        competitors: ['challenger.example'],
+      }],
+      targetQuerySelections: [{ targetKey: 'harbor', queryIds: [queryId] }],
+    }, {
+      canonicalDomain: 'v1-plan-competitors.example.com',
+      ownedDomains: [],
+      brandNames: ['V1 Plan Competitors'],
+      trackedQueries: [{ id: queryId, query: 'homes near harbor' }],
+      locations: [],
+      defaultContext: null,
+      expectedSnapshots: 1,
+    })
+    const versionId = crypto.randomUUID()
+    ctx.db.insert(measurementPlanVersions).values({
+      id: versionId,
+      projectId,
+      revision: 1,
+      canonicalJson: canonicalMeasurementPlanJson(activePlan),
+      checksum: 'b'.repeat(64),
+      schemaVersion: 1,
+      createdAt: new Date().toISOString(),
+    }).run()
+    ctx.db.insert(measurementPlans).values({
+      projectId,
+      activeVersionId: versionId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/v1-plan-competitors/report' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.actionPlan.some(action => action.category === 'competitors')).toBe(false)
   })
 
   test('GSC section returns top queries, totals, category breakdown', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.186.0",
+  "version": "4.186.1",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/test/save-config.test.ts
+++ b/packages/canonry/test/save-config.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { test, expect, beforeEach, afterEach, vi } from 'vitest'
 import { parse, stringify } from 'yaml'
 
+import { runCli } from '../src/cli.js'
 import { saveConfig, saveConfigPatch, loadConfig, loadConfigRaw, getConfigPath } from '../src/config.js'
 import type { CanonryConfig } from '../src/config.js'
 
@@ -304,7 +305,6 @@ test.each(['text', 'json', 'jsonl'])('invalid managed sweeps is a path-qualified
   const original = stringify({ ...baseConfig(), dashboard: { managedSweeps: invalidValue } })
   fs.writeFileSync(getConfigPath(), original)
   const stderr = vi.spyOn(console, 'error').mockImplementation(() => {})
-  const { runCli } = await import('../src/cli.js')
 
   expect(await runCli(['telemetry', 'enable', '--format', format])).toBe(1)
   const output = stderr.mock.calls.map(args => args.join(' ')).join('\n')

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.186.0",
+  "version": "4.186.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.186.0",
+  "version": "4.186.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.186.0",
+  "version": "4.186.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
- Group tracked queries with nested engine, model, and location results, preserving Property scope and sample counts.
- Gate engine settings before fetching; fix paused schedule timestamps, client setup failure guidance, and unmeasured competitor counts.
- Make competitor setup recommendations agency-only and recognize competitors in active v1/v2 measurement plans.
- Keep client Discovery and Research runs available under existing permissions, with regression coverage and deployment documentation.
- Bump Canonry and plugin manifests to 4.186.1; move CLI test imports outside timed test cases.

Validation: focused regressions and the production web build passed. Four Terra agents implemented or reviewed the changes. Checked grouped queries and empty competitor states in a browser preview. Full `pnpm verify` remains incomplete: generation, typechecking, and lint passed; an unchanged Ads timing test failed under host load. The later rerun was stopped when this PR was rebased. The rebase onto `53766082` changes no part of the PR patch; verification of the rebased head is pending.

Active-plan competitors only suppress the false setup recommendation; report metric aggregation is unchanged. Query pagination retains its existing engine-result contract.