### PR TITLE
fix(site-audit): ship the crawl duration fix by bumping aeo-audit to 7.2.0

### DIFF
--- a/apps/vals/ai-visibility-check/AGENTS.md
+++ b/apps/vals/ai-visibility-check/AGENTS.md
@@ -144,10 +144,10 @@ The kit's `visibility/share.ts` ranks every domain the engine attributed as a so
 ## The engine pin lives in source, so the bump sweeps source
 
 Val Town ignores an import map, so every import is fully qualified inline:
-`npm:@canonry/aeo-audit@7.1.0`, repeated in each file that imports the engine. That is N places to drift instead of
+`npm:@canonry/aeo-audit@<version>`, repeated in each file that imports the engine. That is N places to drift instead of
 one `deno.json` key.
 
-`scripts/bump-aeo-audit.mjs` therefore SWEEPS `apps/vals/ai-visibility-check/src` and `main.http.tsx` rather than editing a manifest
+`scripts/bump-aeo-audit.mjs` therefore SWEEPS `apps/vals/ai-visibility-check/src`, `test`, and `main.http.tsx` rather than editing a manifest
 key, and `aeo-audit-dependency-contract.test.ts` asserts the set of inline specifiers collapses to exactly one version
 that equals Canonry's pin. Both were written against the import map the val briefly had; the bump would have thrown on
 every engine release and the val would have sat on an old engine while Canonry moved.

--- a/apps/vals/ai-visibility-check/deno.dev.lock
+++ b/apps/vals/ai-visibility-check/deno.dev.lock
@@ -1,14 +1,14 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@canonry/aeo-audit@7.1.0": "7.1.0",
+    "npm:@canonry/aeo-audit@7.2.0": "7.2.0",
     "npm:@canonry/val-kit@0.2.0": "0.2.0",
     "npm:@libsql/client@0.17.2": "0.17.2",
     "npm:hono@4.12.25": "4.12.25"
   },
   "npm": {
-    "@canonry/aeo-audit@7.1.0": {
-      "integrity": "sha512-XwWEfzVqrzBkaCCAe4ficJW52LUhpxzsNF3uB3v3u2RsUHD3nRhv03jSgyTpj7hILTUNJTt8Xqn5HNMgDqX19w==",
+    "@canonry/aeo-audit@7.2.0": {
+      "integrity": "sha512-ka4+Ik9VxFcxBacSkf9hbdUdfbLqt4c96143mzbDsCsrvbaIIfyw9pBN9ZgldYVE1p7BfpjGg9515lJ8vF//rQ==",
       "dependencies": [
         "cheerio",
         "ipaddr.js",

--- a/apps/vals/ai-visibility-check/deno.lock
+++ b/apps/vals/ai-visibility-check/deno.lock
@@ -1,14 +1,14 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@canonry/aeo-audit@7.1.0": "7.1.0",
+    "npm:@canonry/aeo-audit@7.2.0": "7.2.0",
     "npm:@canonry/val-kit@0.2.0": "0.2.0",
     "npm:@libsql/client@0.17.2": "0.17.2",
     "npm:hono@4.12.25": "4.12.25"
   },
   "npm": {
-    "@canonry/aeo-audit@7.1.0": {
-      "integrity": "sha512-XwWEfzVqrzBkaCCAe4ficJW52LUhpxzsNF3uB3v3u2RsUHD3nRhv03jSgyTpj7hILTUNJTt8Xqn5HNMgDqX19w==",
+    "@canonry/aeo-audit@7.2.0": {
+      "integrity": "sha512-ka4+Ik9VxFcxBacSkf9hbdUdfbLqt4c96143mzbDsCsrvbaIIfyw9pBN9ZgldYVE1p7BfpjGg9515lJ8vF//rQ==",
       "dependencies": [
         "cheerio",
         "ipaddr.js",

--- a/apps/vals/ai-visibility-check/src/site-health/runner.ts
+++ b/apps/vals/ai-visibility-check/src/site-health/runner.ts
@@ -1,5 +1,5 @@
-import { runSiteCrawl } from 'npm:@canonry/aeo-audit@7.1.0'
-import type { CrawlPageObservation, SiteCrawlOptions, SiteCrawlReport } from 'npm:@canonry/aeo-audit@7.1.0'
+import { runSiteCrawl } from 'npm:@canonry/aeo-audit@7.2.0'
+import type { CrawlPageObservation, SiteCrawlOptions, SiteCrawlReport } from 'npm:@canonry/aeo-audit@7.2.0'
 import { wwwAlternate } from 'npm:@canonry/val-kit@0.2.0/security'
 import { buildSiteMap } from './site-map.ts'
 import type { FactorSample, SiteHealthPageSample, SiteHealthRunner, SiteHealthSample } from './types.ts'

--- a/apps/vals/ai-visibility-check/src/site-health/site-map.ts
+++ b/apps/vals/ai-visibility-check/src/site-health/site-map.ts
@@ -15,7 +15,7 @@
  * always produces the same picture, and a cached result never disagrees with
  * the run that produced it.
  */
-import type { CrawlEdgeObservation, CrawlPageObservation } from 'npm:@canonry/aeo-audit@7.1.0'
+import type { CrawlEdgeObservation, CrawlPageObservation } from 'npm:@canonry/aeo-audit@7.2.0'
 import type { SiteMapEdge, SiteMapNode, SiteMapSample } from './types.ts'
 
 /**

--- a/apps/vals/ai-visibility-check/test/backend/site-health.test.ts
+++ b/apps/vals/ai-visibility-check/test/backend/site-health.test.ts
@@ -1,4 +1,4 @@
-import { runSiteCrawl } from 'npm:@canonry/aeo-audit@7.1.0'
+import { runSiteCrawl } from 'npm:@canonry/aeo-audit@7.2.0'
 import { createSiteHealthRunner, VAL_TOWN_SITE_HEALTH_LIMITS } from '../../src/site-health/runner.ts'
 
 function equal<T>(actual: T, expected: T, message = 'values differ'): void {

--- a/apps/vals/ai-visibility-check/test/backend/site-map.test.ts
+++ b/apps/vals/ai-visibility-check/test/backend/site-map.test.ts
@@ -1,4 +1,4 @@
-import type { CrawlEdgeObservation, CrawlPageObservation } from 'npm:@canonry/aeo-audit@7.1.0'
+import type { CrawlEdgeObservation, CrawlPageObservation } from 'npm:@canonry/aeo-audit@7.2.0'
 import { buildSiteMap, SITE_MAP_MAX_NODES } from '../../src/site-health/site-map.ts'
 
 declare const Deno: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.186.1",
+  "version": "4.186.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.186.1",
+  "version": "4.186.2",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
-    "@canonry/aeo-audit": "7.1.0",
+    "@canonry/aeo-audit": "7.2.0",
     "@fastify/rate-limit": "^11.2.0",
     "@fastify/static": "^9.1.1",
     "@google/genai": "^1.46.0",

--- a/packages/canonry/test/aeo-audit-dependency-contract.test.ts
+++ b/packages/canonry/test/aeo-audit-dependency-contract.test.ts
@@ -96,7 +96,17 @@ describe('AEO audit dependency boundary', () => {
     // The bump has to reach the Val, and it can only do that by sweeping source.
     const bumpScript = readText('scripts/bump-aeo-audit.mjs')
     expect(bumpScript).toContain("const DEP = '@canonry/aeo-audit'")
-    expect(bumpScript).toContain("const VAL_SOURCE_ROOTS = ['apps/vals/ai-visibility-check/src', 'apps/vals/ai-visibility-check/main.http.tsx']")
+    // Assert the roots the sweep must cover, not the literal formatting of the
+    // array. `test` is load-bearing: deno.dev.lock resolves the DEV graph, so a
+    // test left on the old specifier fails the Val job while this file, which
+    // only scans src, stays green.
+    for (const root of [
+      'apps/vals/ai-visibility-check/src',
+      'apps/vals/ai-visibility-check/test',
+      'apps/vals/ai-visibility-check/main.http.tsx',
+    ]) {
+      expect(bumpScript).toContain(`'${root}'`)
+    }
     expect(bumpScript).toContain('function rewriteValSpecifiers(')
     // A manifest key it can no longer find would throw on every bump.
     expect(bumpScript).not.toContain("'apps/vals/ai-visibility-check/deno.json'")

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.186.1",
+  "version": "4.186.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.186.1",
+  "version": "4.186.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.186.1",
+  "version": "4.186.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,8 +297,8 @@ importers:
         specifier: ^0.91.1
         version: 0.91.1(zod@4.3.6)
       '@canonry/aeo-audit':
-        specifier: 7.1.0
-        version: 7.1.0
+        specifier: 7.2.0
+        version: 7.2.0
       '@fastify/rate-limit':
         specifier: ^11.2.0
         version: 11.2.0
@@ -938,8 +938,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@canonry/aeo-audit@7.1.0':
-    resolution: {integrity: sha512-XwWEfzVqrzBkaCCAe4ficJW52LUhpxzsNF3uB3v3u2RsUHD3nRhv03jSgyTpj7hILTUNJTt8Xqn5HNMgDqX19w==}
+  '@canonry/aeo-audit@7.2.0':
+    resolution: {integrity: sha512-ka4+Ik9VxFcxBacSkf9hbdUdfbLqt4c96143mzbDsCsrvbaIIfyw9pBN9ZgldYVE1p7BfpjGg9515lJ8vF//rQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -5538,7 +5538,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@canonry/aeo-audit@7.1.0':
+  '@canonry/aeo-audit@7.2.0':
     dependencies:
       cheerio: 1.2.0
       ipaddr.js: 2.3.0

--- a/scripts/bump-aeo-audit.mjs
+++ b/scripts/bump-aeo-audit.mjs
@@ -51,7 +51,15 @@ const DEP_TARGETS = [
 // the engine. That is N places to drift instead of one, so the bump SWEEPS the
 // tree rather than editing a manifest key. A new file that imports the engine
 // is picked up with no change here, which is the point.
-const VAL_SOURCE_ROOTS = ['apps/vals/ai-visibility-check/src', 'apps/vals/ai-visibility-check/main.http.tsx']
+// `test` is in the list because deno.dev.lock resolves the DEV graph, which
+// includes the val's tests. Sweeping only src leaves a test importing the old
+// version, the dev lock then disagrees with the pin, and CI fails in the Val
+// job alone: the dependency-contract test scans src and stays green.
+const VAL_SOURCE_ROOTS = [
+  'apps/vals/ai-visibility-check/src',
+  'apps/vals/ai-visibility-check/test',
+  'apps/vals/ai-visibility-check/main.http.tsx',
+]
 const VAL_SPECIFIER = new RegExp(`npm:${DEP.replace('/', '\\/')}@\\d+\\.\\d+\\.\\d+`, 'g')
 
 /** Every `.ts`/`.tsx` file under the Val roots. */


### PR DESCRIPTION
## What

Bumps the pinned `@canonry/aeo-audit` from 7.1.0 to 7.2.0.

## Why

7.2.0 changed the derived crawl duration budget so it acts as a ceiling rather
than a cap (`SCALED_PAGES_PER_SECOND` 2.5 -> 1). That fix has never run
anywhere, because `packages/canonry` still pinned 7.1.0. Publishing the library
did not ship the change.

The effect reaches the dashboard. A 12,000-page crawl was allowed 80 minutes
instead of 200 and stopped after 8,246 of 12,307 pages, surfacing "This scan ran
out of time, so some pages were not checked". Measured rate was ~1.8 pages/sec,
so a full crawl needs ~114 minutes and fits the corrected budget.

## Notes

Bumped with `scripts/bump-aeo-audit.mjs`, so the Val Town sources and both deno
locks move with the package pin. The dependency-contract test enforces that
agreement and fails when only one side moves.

Deno is not installed on this machine, so the two lock entries were updated
using the integrity npm publishes for 7.2.0 rather than regenerated. 7.2.0's
dependency set is identical to 7.1.0 (cheerio, ipaddr.js, undici) and the
integrity matches what pnpm-lock.yaml resolved independently. A regenerated lock
from a machine with deno would be worth having if you want belt and braces.

`pnpm verify` passes: 10,317 tests.