### PR TITLE
fix(site-health): stop reporting a bounded crawl as partial, and stop labels overlapping

### DIFF
--- a/apps/web/src/components/project/site-graph-sigma.ts
+++ b/apps/web/src/components/project/site-graph-sigma.ts
@@ -205,6 +205,41 @@ export function siteGraphLabelBudget(cameraRatio: number): number {
   return SITE_GRAPH_OVERVIEW_LABEL_BUDGET
 }
 
+/**
+ * How wide a rendered label may get, in characters.
+ *
+ * Sigma keeps labels apart with a grid (`labelGridCellSize`), which assumes a
+ * label is roughly as wide as its cell. A deep path is not: on a real site
+ * `/apartments/atlanta-metro/dunwoody-apts/` renders about twice the cell
+ * width, so labels chosen from neighbouring cells overlap and stack into an
+ * unreadable smear. Bounding the TEXT is what makes the grid's assumption true;
+ * widening the grid instead would just drop labels that do fit.
+ */
+const SITE_GRAPH_LABEL_MAX_CHARS = 24
+
+/**
+ * Shorten a path for display, keeping the LAST segment.
+ *
+ * The leaf is what identifies a page to a reader — `dunwoody-apts` says which
+ * node this is, while a shared `/apartments/atlanta-metro/` prefix says only
+ * which neighbourhood of the graph it sits in, something the layout already
+ * shows. The full path stays on the node's `path` attribute for the hover card,
+ * so nothing is lost, only deferred to the moment a reader asks for it.
+ */
+export function siteGraphDisplayPath(path: string, maxChars = SITE_GRAPH_LABEL_MAX_CHARS): string {
+  const value = path || '/'
+  if (value.length <= maxChars) return value
+  const trailingSlash = value.endsWith('/') && value.length > 1
+  const segments = value.split('/').filter(Boolean)
+  const leaf = segments.at(-1)
+  if (!leaf) return value.slice(0, maxChars - 1) + '…'
+  const tail = `/${leaf}${trailingSlash ? '/' : ''}`
+  // A leaf that is itself too long is cut from its END: the start of a slug
+  // ("dunwoody-apts-phase-two") is the identifying part.
+  if (tail.length + 2 > maxChars) return `…${tail.slice(0, maxChars - 2)}…`
+  return `…${tail}`
+}
+
 function lexical(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0
 }
@@ -344,7 +379,7 @@ export function buildSigmaSiteGraph(
       size: siteGraphNodeSize(node, isRoot, nodesByKey.size),
       color,
       baseColor: color,
-      label: `${glyph} ${node.path || '/'}`,
+      label: `${glyph} ${siteGraphDisplayPath(node.path)}`,
       nodeKey: node.nodeKey,
       url: node.url,
       path: node.path,

--- a/apps/web/test/site-graph-sigma-adapter.test.ts
+++ b/apps/web/test/site-graph-sigma-adapter.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { parseColor } from 'sigma/utils'
 
 import {
+  siteGraphDisplayPath,
   buildSigmaSiteGraph,
   createSigmaSiteGraphReducers,
   findSiteGraphNodes,
@@ -119,6 +120,19 @@ describe('buildSigmaSiteGraph', () => {
       fetchState: 'fetch-error-but-not-a-crawler-state',
       indexabilityState: 'indexable',
     }))).toBe('unchecked')
+  })
+
+  it('renders the node label through the truncator, not the raw path', () => {
+    // Guards the WIRING, not the helper: a unit test of siteGraphDisplayPath
+    // still passes when the label is built from node.path directly, which is
+    // the state that shipped the overlapping labels.
+    const deep = '/apartments/atlanta-metro/dunwoody-apts/'
+    const result = buildSigmaSiteGraph([node('deep', { path: deep })], [], theme)
+    const label = result.graph.getNodeAttribute('deep', 'label')
+
+    expect(label).not.toContain('atlanta-metro')
+    expect(label).toContain('dunwoody-apts')
+    expect(result.graph.getNodeAttribute('deep', 'path')).toBe(deep)
   })
 
   it('adds a distinct status glyph to labels so color is never the only visual cue', () => {
@@ -568,6 +582,40 @@ describe('the customer-facing state vocabulary', () => {
     for (const state of SITE_GRAPH_LEGEND_STATES) {
       expect(siteGraphStatusLegendLabel(state)).not.toBe('')
       expect(siteGraphStatusDescription(state)).not.toBe('')
+    }
+  })
+})
+
+describe('siteGraphDisplayPath', () => {
+  // Sigma keeps labels apart with a fixed-size grid, so a label far wider than
+  // its cell overlaps its neighbours. A real crawl of a property site produced
+  // exactly this: three metro paths drawn on top of each other, unreadable.
+  it('keeps the leaf segment, which is what identifies the page', () => {
+    expect(siteGraphDisplayPath('/apartments/atlanta-metro/dunwoody-apts/')).toBe('…/dunwoody-apts/')
+  })
+
+  it('leaves a path that already fits completely untouched', () => {
+    expect(siteGraphDisplayPath('/apartments/')).toBe('/apartments/')
+    expect(siteGraphDisplayPath('/')).toBe('/')
+  })
+
+  it('treats an empty path as the root rather than rendering nothing', () => {
+    expect(siteGraphDisplayPath('')).toBe('/')
+  })
+
+  it('bounds the result even when the leaf alone is too long', () => {
+    const result = siteGraphDisplayPath('/a/an-extremely-long-single-slug-that-will-not-fit-anywhere')
+    expect(result.length).toBeLessThanOrEqual(24)
+    expect(result.startsWith('…')).toBe(true)
+  })
+
+  it('never renders wider than the grid cell assumes, for any depth', () => {
+    for (const path of [
+      '/apartments/dallas-fort-worth-metro/uptown-apts/',
+      '/apartments/northern-virginia-and-dc-metro/rosslyn-apts/',
+      '/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z/',
+    ]) {
+      expect(siteGraphDisplayPath(path).length).toBeLessThanOrEqual(24)
     }
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.186.6",
+  "version": "4.186.7",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.186.6",
+  "version": "4.186.7",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/execute-site-audit.ts
+++ b/packages/canonry/src/execute-site-audit.ts
@@ -19,6 +19,7 @@ import type {
   CrawlEvent,
   CrawlPageMetrics,
   CrawlPageObservation,
+  CrawlTerminationReason,
   SiteCrawlReport,
 } from '@canonry/aeo-audit'
 import {
@@ -74,6 +75,54 @@ type DatabaseTransaction = Parameters<Parameters<DatabaseClient['transaction']>[
 
 class SiteAuditCancelledError extends Error {
   override name = 'SiteAuditCancelledError'
+}
+
+/**
+ * Did this stop leave part of the SITE uncrawled, or only decline URLs that
+ * were never going to add coverage?
+ *
+ * Deliberately NOT the engine's hard/soft split. That one answers "should we
+ * keep fetching?" — a resource and politeness question, where `max-pages` is
+ * soft because the crawler stopped admitting rather than ran out. The run
+ * status answers a different question: "was the site covered?" Under that
+ * question `max-pages` is a truncation, because capping a 12,000-page site at
+ * 1,000 leaves 11,000 pages unseen however politely the crawler stopped.
+ *
+ * `bounded` is therefore narrow, and every member has the same property: the
+ * URLs it declined would not have added site coverage.
+ *
+ *   max-query-variants  faceted search (`?field=neighborhood&value=...`)
+ *                       generates unbounded near-duplicates of pages already
+ *                       crawled. Real estate sites latch this every run.
+ *   max-page-bytes      one oversized page's body was truncated; the page
+ *                       itself is in the graph.
+ *   max-links-per-page  one page's link list was capped; the page is crawled
+ *                       and its neighbours are reachable by other paths.
+ *
+ * Everything else — pages, edges, depth, sitemap caps, and all four hard
+ * stops — means URLs the site really has are missing, so `partial` is honest.
+ *
+ * Exhaustive on the engine's own union on purpose: when aeo-audit adds a
+ * termination reason this stops compiling until someone classifies it, rather
+ * than silently defaulting it into whichever class reads better.
+ */
+const CRAWL_STOP_COVERAGE: Record<CrawlTerminationReason, 'truncated' | 'bounded'> = {
+  'max-fetches': 'truncated',
+  'max-duration': 'truncated',
+  'max-bytes': 'truncated',
+  'root-host-redirect': 'truncated',
+  'max-pages': 'truncated',
+  'max-edges': 'truncated',
+  'max-depth': 'truncated',
+  'max-sitemap-fanout': 'truncated',
+  'max-sitemap-urls': 'truncated',
+  'max-query-variants': 'bounded',
+  'max-page-bytes': 'bounded',
+  'max-links-per-page': 'bounded',
+}
+
+function isTruncatingStop(reason: CrawlTerminationReason | null | undefined): boolean {
+  return reason != null && CRAWL_STOP_COVERAGE[reason] === 'truncated'
 }
 
 function toHomepageUrl(canonicalDomain: string): string {
@@ -701,7 +750,9 @@ export async function executeSiteAudit(
     const finishedAt = new Date().toISOString()
     const factors = computeFactorAverages([...observedPages.values()])
     const errorCount = observedErrorCount(observedPages.values())
-    const terminalStatus: RunStatus = crawlSummary.complete ? 'completed' : 'partial'
+    const terminalStatus: RunStatus = crawlSummary.complete || !isTruncatingStop(crawlSummary.terminationReason)
+      ? 'completed'
+      : 'partial'
     const deadLinksChecked = opts.checkDeadLinks ? deadLinkCheckedCount(observedEdges.values(), observedPages.values()) : 0
     // The engine makes the broken-vs-unverified split itself (6.0.0+): a
     // finding always carries a real error status, and a target that never

--- a/packages/canonry/test/execute-site-audit.test.ts
+++ b/packages/canonry/test/execute-site-audit.test.ts
@@ -145,6 +145,7 @@ async function emitCompleteGraph(
   options: { onEvent?: (event: unknown) => Promise<void> | void },
   complete = true,
   rootUrl = 'https://example.com/',
+  terminationReason = 'max-pages',
 ) {
   const childUrl = new URL('/a', rootUrl).href
   await options.onEvent?.({
@@ -168,7 +169,7 @@ async function emitCompleteGraph(
   const endSummary = summary({
     rootUrl,
     finalRootUrl: rootUrl,
-    ...(complete ? {} : { complete: false, terminationReason: 'max-pages' }),
+    ...(complete ? {} : { complete: false, terminationReason }),
   })
   await options.onEvent?.({ type: 'summary', sequence: 4, batchId: 'summary-1', checksum: complete ? 'summary-ok' : 'summary-partial', summary: endSummary })
   return { mode: 'summary', summary: endSummary, deadLinks: { state: 'disabled', findings: [], unverified: [] } }
@@ -708,6 +709,24 @@ describe('executeSiteAudit', () => {
     })
     expect(db.select().from(siteCrawlSnapshots).where(eq(siteCrawlSnapshots.runId, goodRun)).get()).toBeDefined()
     expect(db.select().from(siteCrawlAttempts).where(eq(siteCrawlAttempts.runId, partialRun)).get()?.state).toBe('partial')
+  })
+
+  it('reports a coverage-neutral stop as completed while still recording the termination', async () => {
+    // A faceted search generates unbounded near-duplicate URLs, so the crawler
+    // declines them and latches `max-query-variants`. Every page the site has
+    // was still fetched, so reporting `partial` would send an operator hunting
+    // for a budget to raise when nothing is missing. The snapshot keeps the
+    // reason either way; only the run STATUS distinguishes bounded from cut short.
+    vi.mocked(runSiteCrawl).mockImplementation(async (_url, options) =>
+      emitCompleteGraph(options, false, 'https://example.com/', 'max-query-variants'))
+    const runId = seedRun()
+    await executeSiteAudit(db, runId, projectId)
+
+    expect(db.select().from(runs).where(eq(runs.id, runId)).get()?.status).toBe('completed')
+    expect(db.select().from(siteCrawlSnapshots).where(eq(siteCrawlSnapshots.runId, runId)).get()).toMatchObject({
+      complete: false,
+      termination: 'max-query-variants',
+    })
   })
 
   it('publishes a zero-audit terminated crawl as an inspectable partial graph', async () => {

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.186.6",
+  "version": "4.186.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.186.6",
+  "version": "4.186.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.186.6",
+  "version": "4.186.7",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## What

Two defects a real 12,000-page crawl surfaced.

**1. A bounded crawl reported `partial`.** The dashboard said "This scan ran out
of time, so some pages were not checked" for a crawl that had not run out of
time. It had declined faceted-search URLs (`?field=neighborhood&value=...`),
which a property site generates without limit.

**2. Node labels overlapped into an unreadable smear.** Three metro paths drew
on top of each other in the site map.

## Why

**Status.** The engine already latches hard and soft stops separately; the run
status collapsed both into `partial`.

The status question is not the engine's question. `isHardFetchStop` asks
"should we keep fetching?", where `max-pages` is soft because the crawler
stopped admitting rather than ran out of resources. Run status asks "was the
site covered?", and under that question `max-pages` is a truncation: capping a
12,000-page site at 1,000 leaves 11,000 pages unseen however politely the
crawler stopped.

So this classifies on coverage. `bounded` holds only the three stops whose
declined URLs could not have added coverage — `max-query-variants`,
`max-page-bytes`, `max-links-per-page` — and everything else stays `partial`.
The map is exhaustive on the engine's own union, so a termination reason added
upstream fails to compile until someone classifies it.

**Labels.** Sigma spaces labels on a grid that assumes a label is roughly as
wide as its cell (`labelGridCellSize: 140`). A deep path is not:
`/apartments/atlanta-metro/dunwoody-apts/` renders about double that, so labels
chosen from neighbouring cells overlap. Bounding the TEXT is what makes the
grid's assumption true; widening the grid instead would drop labels that do fit.
The leaf segment is kept because it identifies the page, and the full path stays
on the node for the hover card.

## Notes

Both changes mutation-verified: reverting each fails exactly the test written
for it.

Worth calling out on the label test. My first version asserted only
`siteGraphDisplayPath` in isolation, and it still passed with the label built
from `node.path` directly — the exact state that shipped the overlap. The
committed test asserts the BUILT graph's label attribute instead.

`pnpm verify` passes.