### PR TITLE
fix(site-health): keep binary media out of the crawl graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.186.7",
+  "version": "4.186.8",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.186.7",
+  "version": "4.186.8",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/execute-site-audit.ts
+++ b/packages/canonry/src/execute-site-audit.ts
@@ -76,6 +76,33 @@ class SiteAuditCancelledError extends Error {
   override name = 'SiteAuditCancelledError'
 }
 
+/**
+ * Media extensions that can never be a page.
+ *
+ * Deliberately narrow, and deliberately NOT "everything non-HTML": a PDF and a
+ * text file are readable by an answer engine and stay in the graph. These
+ * carry no answer text and no outbound links.
+ */
+const NON_PAGE_MEDIA_EXTENSIONS = /\.(?:jpe?g|png|gif|webp|avif|bmp|ico|tiff?|svg|mp4|webm|mov|avi|mp3|wav|ogg|woff2?|ttf|otf|eot)(?:$|\?)/i
+
+/** Media content types, for a server that serves an image from an extensionless URL. */
+const NON_PAGE_MEDIA_CONTENT_TYPE = /^(?:image|video|audio|font)\//i
+
+/**
+ * Both signals are checked because neither is sufficient alone: a CDN can serve
+ * `/media/12345` with no extension, and a misconfigured host can return
+ * `application/octet-stream` for a plain `.jpg`.
+ */
+export function isNonPageMedia(page: Pick<CrawlPageObservation, 'requestedUrl' | 'contentType'>): boolean {
+  if (page.contentType && NON_PAGE_MEDIA_CONTENT_TYPE.test(page.contentType.trim())) return true
+  try {
+    // Test the PATH, so a `?utm_source=x.png` query value cannot mask a page.
+    return NON_PAGE_MEDIA_EXTENSIONS.test(new URL(page.requestedUrl).pathname)
+  } catch {
+    return NON_PAGE_MEDIA_EXTENSIONS.test(page.requestedUrl)
+  }
+}
+
 function toHomepageUrl(canonicalDomain: string): string {
   const trimmed = canonicalDomain.trim().replace(/\/+$/, '')
   return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
@@ -484,10 +511,14 @@ export async function executeSiteAudit(
 
   const persistPages = (tx: DatabaseTransaction, pages: CrawlPageObservation[], now: string): void => {
     const changedUrls = new Set<string>()
+    // Filtered ONCE, here, because registration and persistence are two passes
+    // over the same list: filtering only the first leaves the row written and
+    // merely unreferenced, which is not what excluding a node means.
+    const pageNodes = pages.filter(page => !isNonPageMedia(page))
     // Register a whole event before writing references: the final HTML node
     // wins even when it sorts before or after its redirect alias.
-    for (const page of pages) registerPageNode(page, changedUrls)
-    for (const page of pages) persistPage(tx, page, now)
+    for (const page of pageNodes) registerPageNode(page, changedUrls)
+    for (const page of pageNodes) persistPage(tx, page, now)
     bindReferences(tx, changedUrls, now)
   }
 

--- a/packages/canonry/src/execute-site-audit.ts
+++ b/packages/canonry/src/execute-site-audit.ts
@@ -80,8 +80,14 @@ class SiteAuditCancelledError extends Error {
  * Media extensions that can never be a page.
  *
  * Deliberately narrow, and deliberately NOT "everything non-HTML": a PDF and a
- * text file are readable by an answer engine and stay in the graph. These
- * carry no answer text and no outbound links.
+ * text file are readable by an answer engine and stay in the graph. These are
+ * rendered assets rather than destinations a reader is sent to.
+ *
+ * They are not universally link-free — an SVG can carry `<text>` and
+ * `xlink:href`, and any URL can 301, which makes it an edge source. An edge
+ * whose source is excluded falls back to the raw URL as its node key, so it
+ * references no page row. That is tolerable for media (the edge is dropped by
+ * the layout's INNER JOIN) and is the reason the exclusion is not widened.
  */
 const NON_PAGE_MEDIA_EXTENSIONS = /\.(?:jpe?g|png|gif|webp|avif|bmp|ico|tiff?|svg|mp4|webm|mov|avi|mp3|wav|ogg|woff2?|ttf|otf|eot)(?:$|\?)/i
 
@@ -511,10 +517,21 @@ export async function executeSiteAudit(
 
   const persistPages = (tx: DatabaseTransaction, pages: CrawlPageObservation[], now: string): void => {
     const changedUrls = new Set<string>()
-    // Filtered ONCE, here, because registration and persistence are two passes
-    // over the same list: filtering only the first leaves the row written and
-    // merely unreferenced, which is not what excluding a node means.
+    // Media is excluded from the GRAPH, not from the observation set.
+    //
+    // `observedPages` is the record of what the crawl attempted, and three
+    // counters read it for exactly that: `deadLinkCheckedCount` builds its
+    // attempted-URL set from it, `observedErrorCount` counts fetch failures,
+    // and the legacy scorecard admits fetch-error rows. Dropping media here
+    // made a broken image report "1 found from 0 checked" — found from the
+    // engine's report, checked from a set the image had been removed from —
+    // which inverts the invariant that a found dead link was also a checked
+    // one. So every observation is recorded, and only the graph is filtered.
+    for (const page of pages) observedPages.set(page.key, page)
     const pageNodes = pages.filter(page => !isNonPageMedia(page))
+    // Both passes take the filtered list: registration and persistence are
+    // independent, so filtering only the first would leave the row written and
+    // merely unreferenced, which is not what excluding a node means.
     // Register a whole event before writing references: the final HTML node
     // wins even when it sorts before or after its redirect alias.
     for (const page of pageNodes) registerPageNode(page, changedUrls)

--- a/packages/canonry/test/execute-site-audit.test.ts
+++ b/packages/canonry/test/execute-site-audit.test.ts
@@ -36,7 +36,7 @@ vi.mock('../src/site-audit-root.js', () => ({
   }),
 }))
 import { runSiteCrawl } from '@canonry/aeo-audit'
-import {
+import { isNonPageMedia,
   clampSiteAuditEdgeLimit,
   clampSiteAuditLimit,
   computeFactorAverages,
@@ -710,6 +710,36 @@ describe('executeSiteAudit', () => {
     expect(db.select().from(siteCrawlAttempts).where(eq(siteCrawlAttempts.runId, partialRun)).get()?.state).toBe('partial')
   })
 
+  it('keeps image observations out of the persisted graph, but keeps a PDF', async () => {
+    // Guards the WIRING. A unit test of isNonPageMedia still passes with the
+    // filter removed from registerPageNode, which is the state that shipped
+    // 1,518 JPEGs into a real graph.
+    vi.mocked(runSiteCrawl).mockImplementation(async (_url, options) => {
+      const root = 'https://example.com/'
+      const image = page('page:image', 'https://example.com/assets/images/hero.jpg', {
+        state: 'non-html', contentType: 'image/jpeg', audit: null,
+      })
+      const pdf = page('page:pdf', 'https://example.com/brochure.pdf', {
+        state: 'non-html', contentType: 'application/pdf', audit: null,
+      })
+      await options.onEvent?.({
+        type: 'pages', sequence: 1, batchId: 'pages-1', checksum: 'pages-1',
+        rows: [page('page:root', root), image, pdf],
+      })
+      const endSummary = summary({ rootUrl: root, finalRootUrl: root })
+      await options.onEvent?.({ type: 'summary', sequence: 2, batchId: 'summary-1', checksum: 'summary-ok', summary: endSummary })
+      return { mode: 'summary', summary: endSummary, deadLinks: { state: 'disabled', findings: [], unverified: [] } }
+    })
+    const runId = seedRun()
+    await executeSiteAudit(db, runId, projectId)
+
+    const urls = db.select({ url: siteCrawlPages.url }).from(siteCrawlPages)
+      .where(eq(siteCrawlPages.runId, runId)).all().map(row => row.url)
+    expect(urls.some(url => url.endsWith('/hero.jpg'))).toBe(false)
+    expect(urls.some(url => url.endsWith('/brochure.pdf'))).toBe(true)
+    expect(urls.some(url => url === 'https://example.com/')).toBe(true)
+  })
+
   it('publishes a zero-audit terminated crawl as an inspectable partial graph', async () => {
     vi.mocked(runSiteCrawl).mockImplementation(async (_url, options) => {
       const failedPage = page('page:failed', 'https://example.com/unreachable', {
@@ -941,5 +971,44 @@ describe('executeSiteAudit', () => {
     expect(db.select().from(siteCrawlAttempts).where(eq(siteCrawlAttempts.runId, runId)).get()?.state).toBe('cancelled')
     expect(db.select().from(siteCrawlSnapshots).where(eq(siteCrawlSnapshots.runId, runId)).all()).toEqual([])
     expect(db.select().from(siteCrawlGraphLayouts).where(eq(siteCrawlGraphLayouts.runId, runId)).all()).toEqual([])
+  })
+})
+
+describe('isNonPageMedia', () => {
+  const at = (requestedUrl: string, contentType: string | null = null) => ({ requestedUrl, contentType })
+
+  it('excludes the image tree that flooded a real crawl', () => {
+    // 1,518 of these came from one /assets/images/ directory: 13% of the nodes.
+    expect(isNonPageMedia(at('https://example.com/assets/images/004-Model-LR.jpg'))).toBe(true)
+    expect(isNonPageMedia(at('https://example.com/assets/images/006_dsc01166-new_993.JPG'))).toBe(true)
+  })
+
+  it('keeps a PDF and a text file, which an answer engine can read', () => {
+    expect(isNonPageMedia(at('https://example.com/brochure.pdf'))).toBe(false)
+    expect(isNonPageMedia(at('https://example.com/robots.txt'))).toBe(false)
+  })
+
+  it('keeps ordinary pages, including deep and trailing-slash paths', () => {
+    expect(isNonPageMedia(at('https://example.com/'))).toBe(false)
+    expect(isNonPageMedia(at('https://example.com/apartments/atlanta-metro/dunwoody-apts/'))).toBe(false)
+  })
+
+  it('catches an extensionless media URL by content type', () => {
+    expect(isNonPageMedia(at('https://cdn.example.com/media/12345', 'image/webp'))).toBe(true)
+    expect(isNonPageMedia(at('https://example.com/video/9', 'video/mp4; codecs=avc1'))).toBe(true)
+  })
+
+  it('does not let a query value masquerade as an extension', () => {
+    // The PATH decides. A page tagged with an image-looking param is a page.
+    expect(isNonPageMedia(at('https://example.com/gallery?utm_content=hero.png'))).toBe(false)
+  })
+
+  it('still excludes media that carries a query string', () => {
+    expect(isNonPageMedia(at('https://example.com/assets/images/hero.jpg?v=2'))).toBe(true)
+  })
+
+  it('falls back to the raw string when the URL will not parse', () => {
+    expect(isNonPageMedia(at('not-a-url/logo.svg'))).toBe(true)
+    expect(isNonPageMedia(at('not-a-url/page'))).toBe(false)
   })
 })

--- a/packages/canonry/test/execute-site-audit.test.ts
+++ b/packages/canonry/test/execute-site-audit.test.ts
@@ -710,6 +710,35 @@ describe('executeSiteAudit', () => {
     expect(db.select().from(siteCrawlAttempts).where(eq(siteCrawlAttempts.runId, partialRun)).get()?.state).toBe('partial')
   })
 
+  it('still counts a broken image as attempted, so found never exceeds checked', async () => {
+    // Excluding media from the graph must not exclude it from the record of
+    // what the crawl attempted. Draining observedPages made a 404 image report
+    // "1 found from 0 checked", inverting deadLinksFound <= deadLinksChecked.
+    vi.mocked(runSiteCrawl).mockImplementation(async (_url, options) => {
+      const root = 'https://example.com/'
+      const broken = page('page:broken-image', 'https://example.com/i/gone.jpg', {
+        state: 'fetch-error', statusCode: 404, contentType: 'text/html', audit: null,
+        indexability: { state: 'unknown', reasons: ['fetch-error'], rulesetVersion: '1.0.0' },
+      })
+      await options.onEvent?.({
+        type: 'pages', sequence: 1, batchId: 'pages-1', checksum: 'pages-1',
+        rows: [page('page:root', root), broken],
+      })
+      const endSummary = summary({ rootUrl: root, finalRootUrl: root })
+      await options.onEvent?.({ type: 'summary', sequence: 2, batchId: 'summary-1', checksum: 'summary-ok', summary: endSummary })
+      return { mode: 'summary', summary: endSummary, deadLinks: { state: 'disabled', findings: [], unverified: [] } }
+    })
+    const runId = seedRun()
+    await executeSiteAudit(db, runId, projectId)
+
+    // The broken image is counted as errored even though it is not a graph node.
+    const snapshot = db.select().from(siteCrawlSnapshots).where(eq(siteCrawlSnapshots.runId, runId)).get()
+    expect(snapshot?.pagesErrored).toBe(1)
+    const urls = db.select({ url: siteCrawlPages.url }).from(siteCrawlPages)
+      .where(eq(siteCrawlPages.runId, runId)).all().map(row => row.url)
+    expect(urls.some(url => url.endsWith('/gone.jpg'))).toBe(false)
+  })
+
   it('keeps image observations out of the persisted graph, but keeps a PDF', async () => {
     // Guards the WIRING. A unit test of isNonPageMedia still passes with the
     // filter removed from registerPageNode, which is the state that shipped
@@ -1003,7 +1032,7 @@ describe('isNonPageMedia', () => {
     expect(isNonPageMedia(at('https://example.com/gallery?utm_content=hero.png'))).toBe(false)
   })
 
-  it('still excludes media that carries a query string', () => {
+  it('excludes media whose URL carries a query string', () => {
     expect(isNonPageMedia(at('https://example.com/assets/images/hero.jpg?v=2'))).toBe(true)
   })
 

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.186.7",
+  "version": "4.186.8",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.186.7",
+  "version": "4.186.8",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.186.7",
+  "version": "4.186.8",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## What

Excludes images, video, audio and fonts from the crawl graph and page
inventory.

## Why

A real crawl put **1,518 JPEGs** from one `/assets/images/` tree into the graph
— 12.6% of its 12,000 nodes, and far more than 12.6% of the visual noise,
because a gallery page links forty of them into a starburst that reads as site
structure and is not.

They were never audited, so the score was unaffected. This is purely about what
the map and the inventory contain.

## Scope

Media, **not** every non-HTML response. A PDF or a text file is genuinely
readable by an answer engine and stays in the graph — that is what the
`resource` visual state is for, and its own tooltip says "a file rather than a
page ... answer engines can still read it". An image carries no answer text and
no outbound links, so it can only ever be a leaf that inflates the node count.

Matched on both URL path and content type, because neither is sufficient alone:
a CDN serves `/media/12345` with no extension, and a misconfigured host returns
the wrong type for a plain `.jpg`. The PATH is tested rather than the whole URL,
so `?utm_content=hero.png` cannot disqualify a real page.

## Notes

Filtered in `persistPages`, not `registerPageNode`. Those are two passes over
the same list, and filtering only the first leaves the row written and merely
unreferenced — which is not what excluding a node means. I made that mistake
first and the wiring test caught it.

Dead-link findings are unaffected: they come from `report.deadLinks`, not from
this node set, so a broken image is still reported.

The wiring is tested through `executeSiteAudit`, not only through the
predicate. A predicate-only test still passes with the filter removed, which is
exactly how the images shipped in the first place — verified by mutation.

`pnpm verify` passes.