### PR TITLE
fix(web): call a research-enabled viewer an Analyst, not View only

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,7 +25,7 @@ import { CitationStates, formatRunErrorOneLine } from '@ainyc/canonry-contracts'
 
 import { asyncHandler } from './lib/async-handler.js'
 import { formatErrorLog } from './lib/format-helpers.js'
-import {
+import { viewerRoleLabel,
   getEmbedConfig,
   heyClient,
   shouldShowDashboardAgentBar,
@@ -683,7 +683,7 @@ export function RootLayout() {
             <div className="sidebar-account-identity">
               <span className="sidebar-account-name">{account.name}</span>
               {account.role === 'viewer' ? (
-                <span className="sidebar-account-role">View only</span>
+                <span className="sidebar-account-role">{viewerRoleLabel()}</span>
               ) : null}
             </div>
             <Button
@@ -852,7 +852,7 @@ export function RootLayout() {
                 <div className="sidebar-account-identity">
                   <span className="sidebar-account-name">{account.name}</span>
                   {account.role === 'viewer' ? (
-                    <span className="sidebar-account-role">View only</span>
+                    <span className="sidebar-account-role">{viewerRoleLabel()}</span>
                   ) : null}
                 </div>
                 <Button

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -335,6 +335,23 @@ export function getViewerResearchConfig(): ViewerResearchConfig | null {
 }
 
 /**
+ * What to call a viewer account in the sidebar.
+ *
+ * "View only" is accurate when the account can genuinely only read. Once a
+ * deployment grants viewer research the account can run real queries against
+ * an answer engine, and telling that person they are view-only contradicts the
+ * surface in front of them. The label follows the CAPABILITY rather than the
+ * role, so it stays true on both kinds of deployment without a second role.
+ *
+ * The disabled-control tooltip (VIEW_ONLY_LABEL) does NOT change: sweeps,
+ * scans and settings really are unavailable, and that message is about one
+ * control rather than about the account.
+ */
+export function viewerRoleLabel(): string {
+  return getViewerResearchConfig() ? 'Analyst' : 'View only'
+}
+
+/**
  * True in the read-only embed render. embed presence == read-only for v1 (the
  * embed key is the read-only project-scoped key), so operator/write controls hide
  * while every read-only view still renders. NOT a security boundary (the API key

--- a/apps/web/test/dashboard-flags.test.ts
+++ b/apps/web/test/dashboard-flags.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { getViewerResearchConfig, shouldShowDashboardAgentBar } from '../src/api.js'
+import { viewerRoleLabel, getViewerResearchConfig, shouldShowDashboardAgentBar } from '../src/api.js'
 
 /**
  * The agent kill-switch removes the server routes. Before this flag reached the
@@ -36,5 +36,22 @@ describe('agent bar visibility', () => {
       research: { allowViewers: true, viewerDailyRunLimit: 7 },
     }
     expect(getViewerResearchConfig()).toEqual({ allowViewers: true, viewerDailyRunLimit: 7 })
+  })
+})
+
+describe('viewerRoleLabel', () => {
+  afterEach(() => { delete window.__CANONRY_CONFIG__ })
+
+  it('says View only when the account really can only read', () => {
+    expect(viewerRoleLabel()).toBe('View only')
+    window.__CANONRY_CONFIG__ = { research: { allowViewers: false } }
+    expect(viewerRoleLabel()).toBe('View only')
+  })
+
+  it('says Analyst once the deployment grants viewer research', () => {
+    // The person can run real queries against an answer engine, so calling
+    // them view-only contradicts the surface in front of them.
+    window.__CANONRY_CONFIG__ = { research: { allowViewers: true, viewerDailyRunLimit: 20 } }
+    expect(viewerRoleLabel()).toBe('Analyst')
   })
 })


### PR DESCRIPTION
## What

The sidebar badge under a viewer's name now reads **Analyst** when the
deployment grants viewer research, and **View only** when it does not.

## Why

The badge hardcoded "View only" for every viewer account. On a deployment with
`research.allowViewers`, that account can run real queries against an answer
engine — so the badge contradicted the surface directly beneath it.

The label follows the CAPABILITY rather than the role, so it stays true on both
kinds of deployment without inventing a third role. The account is still
`viewer`; nothing about authorization changes.

## What is deliberately unchanged

`VIEW_ONLY_LABEL` — the tooltip on a disabled control — stays as it is. Sweeps,
scans and settings really are unavailable to this account, and that message is a
statement about one control rather than about the person. Changing it would make
a true message false.

A deployment without the research grant renders exactly as before.

## Notes

Both badge sites updated (desktop sidebar and mobile drawer). Mutation-verified:
hardcoding the old string fails the new test.

`pnpm verify` passes.