### PR TITLE
fix(web): restore saved results on simple dashboards

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -117,6 +117,9 @@ For a signed-in viewer, omit Research unless the injected `research.allowViewers
 After query publication, invalidate the project's query and measurement reads together. A refused preview or commit refreshes the workspace version while preserving the editable draft.
 `VisibilityWorkspace` in `VisibilityTrendSection.tsx` consumes the server's frozen report.
 Keep branded, non-brand, and unknown populations separate. Format server rates without deriving them from counts.
+Default the shared URL selection to all queries for Simple and Advanced, preserving explicit query-type links.
+Simple history without query labels must show its saved unclassified results on arrival. In the all-query view, omit Simple classes with no current or historical queries when another class has results; keep Advanced unmeasured classes explicit.
+Never draw an empty trend chart when every server rate is unavailable. Preserve the history table for recorded sweeps, including dates and comparison markers for partial measurements.
 Scope changes must preserve unrelated URL state. `measurementRunId` must never write the global `runId` drawer parameter.
 Keep `Run AI sweep` project-wide and admin-gated. Do not offer scoped sweeps or expose query administration in embeds.
 Managed deployments also suppress the sweep confirmation and guard its submit handler. The separate competitor-history disclosure retains pinning, follows the shared project/group and query-class selection, and uses its own explicit history window; it stays absent for unsupported Property, Market, and unclassified scopes.

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -114,23 +114,26 @@ function ReportTrend({ population }: { population: VisibilityReportPopulation })
       : [{ createdAt: point.createdAt, mentioned: null, cited: null }, plotted]
   })
   if (points.length === 0) return <p className="py-6 text-sm text-secondary">No measured trend for this selection.</p>
+  const hasRates = points.some(point => point.mentioned !== null || point.cited !== null)
   return <>
-    <ul aria-label="Trend legend" className="flex gap-5 py-3 text-sm text-secondary">
-      <li className="flex items-center gap-2"><span aria-hidden="true" className="h-0.5 w-5" style={{ backgroundColor: CHART_SERIES_COLORS[1] }} />Mentioned</li>
-      <li className="flex items-center gap-2"><span aria-hidden="true" className="h-0.5 w-5" style={{ backgroundColor: CHART_TONE.positive }} />Cited</li>
-    </ul>
-    <div className="visibility-trend-chart" role="img" aria-label={`${REPORT_CLASS_LABEL[population.queryClass]} mention and citation trend`}>
-      <ResponsiveContainer width="100%" height="100%">
-        <ComposedChart data={points} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
-          <CartesianGrid stroke={CHART_GRID_STROKE} vertical={false} />
-          <XAxis dataKey="createdAt" tick={CHART_AXIS_TICK} tickLine={false} axisLine={{ stroke: CHART_AXIS_STROKE }} tickFormatter={value => new Date(String(value)).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} minTickGap={24} />
-          <YAxis domain={[0, 1]} tick={CHART_AXIS_TICK} tickLine={false} axisLine={false} width={48} tickFormatter={value => reportPercent.format(Number(value))} />
-          <RechartsTooltip formatter={value => typeof value === 'number' ? reportPercent.format(value) : 'Not measured'} labelFormatter={value => new Date(String(value)).toLocaleDateString()} />
-          <Line type="linear" dataKey="mentioned" name="Mentioned" stroke={CHART_SERIES_COLORS[1]} strokeWidth={2} connectNulls={false} isAnimationActive={false} dot={{ r: 3 }} />
-          <Line type="linear" dataKey="cited" name="Cited" stroke={CHART_TONE.positive} strokeWidth={2} connectNulls={false} isAnimationActive={false} dot={{ r: 3 }} />
-        </ComposedChart>
-      </ResponsiveContainer>
-    </div>
+    {hasRates ? <>
+      <ul aria-label="Trend legend" className="flex gap-5 py-3 text-sm text-secondary">
+        <li className="flex items-center gap-2"><span aria-hidden="true" className="h-0.5 w-5" style={{ backgroundColor: CHART_SERIES_COLORS[1] }} />Mentioned</li>
+        <li className="flex items-center gap-2"><span aria-hidden="true" className="h-0.5 w-5" style={{ backgroundColor: CHART_TONE.positive }} />Cited</li>
+      </ul>
+      <div className="visibility-trend-chart" role="img" aria-label={`${REPORT_CLASS_LABEL[population.queryClass]} mention and citation trend`}>
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={points} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+            <CartesianGrid stroke={CHART_GRID_STROKE} vertical={false} />
+            <XAxis dataKey="createdAt" tick={CHART_AXIS_TICK} tickLine={false} axisLine={{ stroke: CHART_AXIS_STROKE }} tickFormatter={value => new Date(String(value)).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} minTickGap={24} />
+            <YAxis domain={[0, 1]} tick={CHART_AXIS_TICK} tickLine={false} axisLine={false} width={48} tickFormatter={value => reportPercent.format(Number(value))} />
+            <RechartsTooltip formatter={value => typeof value === 'number' ? reportPercent.format(value) : 'Not measured'} labelFormatter={value => new Date(String(value)).toLocaleDateString()} />
+            <Line type="linear" dataKey="mentioned" name="Mentioned" stroke={CHART_SERIES_COLORS[1]} strokeWidth={2} connectNulls={false} isAnimationActive={false} dot={{ r: 3 }} />
+            <Line type="linear" dataKey="cited" name="Cited" stroke={CHART_TONE.positive} strokeWidth={2} connectNulls={false} isAnimationActive={false} dot={{ r: 3 }} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+    </> : <p className="py-6 text-sm text-secondary">No measured trend for this selection.</p>}
     <details className="py-3 text-sm text-secondary"><summary className="min-h-11 cursor-pointer py-3">Trend data and comparability</summary>
       <div className="overflow-x-auto"><table className="evidence-table"><thead><tr><th>Date</th><th>Mentioned</th><th>Cited</th><th>Comparison</th></tr></thead><tbody>
         {population.trend.map(point => <tr key={point.runId}><td>{new Date(point.createdAt).toLocaleDateString()}</td><td><ReportRate value={point.mentionCoverage} /></td><td><ReportRate value={point.citationCoverage} /></td><td>{point.continuity.state.replaceAll('-', ' ')}</td></tr>)}
@@ -201,7 +204,7 @@ export function VisibilityReportFilters({ report, onSelectionChange }: Pick<Visi
         </div>
       </details>
     </div> : null}
-    {select('Query type', 'queryClass', selection.queryClass, [{ value: 'non-brand', label: 'Non-brand' }, { value: 'branded', label: 'Branded' }, { value: 'all', label: 'All classes, separate' }, { value: 'unknown', label: 'Unclassified' }])}
+    {select('Query type', 'queryClass', selection.queryClass, [{ value: 'all', label: 'All queries' }, { value: 'non-brand', label: 'Non-brand' }, { value: 'branded', label: 'Branded' }, { value: 'unknown', label: 'Unclassified' }])}
     {select('Answer engine', 'measurementProvider', selection.provider ?? '', [{ value: '', label: 'All engines' }, ...filterOptions.providers.map(provider => ({ value: provider, label: provider }))])}
     {select('Search location', 'measurementLocation', selection.location.kind === 'exact' ? selection.location.value : selection.location.kind === 'none' ? 'none' : '', [{ value: '', label: 'All locations' }, ...filterOptions.locations.filter(location => location.kind !== 'all').map(location => ({ value: location.kind === 'exact' ? location.value : 'none', label: location.kind === 'exact' ? location.value : 'No location' }))])}
   </div></div>
@@ -259,7 +262,7 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
       </div>
       {onManageQueries ? <Button variant="outline" onClick={onManageQueries}>Manage queries</Button> : null}
     </div>
-    {selection.provenance.kind === 'legacy-simple' ? <div className="flex flex-wrap items-center justify-between gap-3 border-b border-default py-3 text-sm text-secondary"><p>Legacy results have no frozen query classification.</p>{selection.queryClass !== 'unknown' && selection.queryClass !== 'all' ? <Button variant="outline" onClick={() => onSelectionChange({ queryClass: 'unknown', measurementQueryKey: undefined })}>View unclassified results</Button> : null}</div> : null}
+    {selection.provenance.kind === 'legacy-simple' && selection.queryClass !== 'unknown' && selection.queryClass !== 'all' ? <div className="flex flex-wrap items-center justify-between gap-3 border-b border-default py-3 text-sm text-secondary"><p>These saved results aren't separated by query type.</p><Button variant="outline" onClick={() => onSelectionChange({ queryClass: 'all', measurementQueryKey: undefined })}>View all saved results</Button></div> : null}
     <VisibilityReportFilters report={report} onSelectionChange={onSelectionChange} />
     <details className="border-b border-default text-sm text-secondary"><summary className="min-h-11 cursor-pointer py-3">More filters</summary><div className="flex flex-wrap gap-4 pb-3">
       <label className="min-w-40 flex-1"><span className="mb-1 block text-sm font-medium text-heading">Start date (UTC)</span><input type="date" className={REPORT_CONTROL} value={selection.time.from?.slice(0, 10) ?? ''} onChange={event => onSelectionChange({ measurementFrom: event.target.value ? `${event.target.value}T00:00:00.000Z` : undefined })} /></label>
@@ -268,10 +271,17 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
       {filterSelect('Results from', 'measurementRunId', selection.run.explicit ? selection.run.id ?? '' : '', [{ value: '', label: 'Latest saved sweep' }, ...[...report.populations[0]!.trend].reverse().map(point => ({ value: point.runId, label: new Date(point.createdAt).toLocaleString() }))], 'Choose a saved AI sweep to view its results. No new sweep starts.')}
     </div></details>
     {report.populations.map(population => {
+      // Simple history can predate query labels. In the all-query view, lead
+      // with its saved results instead of empty classes that never had queries.
+      // Retain historical populations and any explicitly requested class.
+      if (selection.mode === 'simple' && selection.queryClass === 'all'
+        && population.summary.queryCount === 0 && !population.trend.some(point => point.queryCount > 0)
+        && !(queryKey && answerClasses.includes(population.queryClass))
+        && report.populations.some(other => other.summary.queryCount > 0 || other.trend.some(point => point.queryCount > 0))) return null
       const queryGroups = groupVisibilityQueryRows(population.queries.items)
       const queryColumnCount = selection.mode === 'advanced' ? 7 : 6
       return <section key={population.queryClass} aria-label={REPORT_CLASS_LABEL[population.queryClass]} className="py-4">
-      <div className="section-head"><h2>{REPORT_CLASS_LABEL[population.queryClass]}</h2><InfoTooltip text={population.queryClass === 'non-brand' ? 'Queries that do not name the measured identity. Geography alone is not a brand.' : population.queryClass === 'branded' ? 'Queries that name the measured identity.' : 'The measured definition could not establish a query class. These answers are not included in branded or non-brand rates.'} /></div>
+      <div className="section-head"><h2>{REPORT_CLASS_LABEL[population.queryClass]}</h2><InfoTooltip text={population.queryClass === 'non-brand' ? 'Queries that do not name the measured identity. Geography alone is not a brand.' : population.queryClass === 'branded' ? 'Queries that name the measured identity.' : 'These queries were not labeled as branded or non-brand when measured. Their saved results remain available here, separate from branded and non-brand rates.'} /></div>
       <div className="flex flex-wrap gap-x-8 gap-y-4 border-y border-default py-4">
         <div><div className="mb-2 flex items-center gap-1 text-sm text-secondary"><span>{selection.mode === 'advanced' && selection.scope.kind !== 'property' ? 'Answers mentioning a property' : 'Mentioned answers'}</span>{selection.mode === 'advanced' ? <InfoTooltip text="An answer counts when it mentions any assigned property. This does not mean every property was mentioned." /> : null}</div><ReportRate value={population.summary.mentionCoverage} unit="answers" /></div>
         <div><div className="mb-2 flex items-center gap-1 text-sm text-secondary"><span>{selection.mode === 'advanced' && selection.scope.kind !== 'property' ? 'Answers citing a property' : 'Cited answers'}</span>{selection.mode === 'advanced' ? <InfoTooltip text="An answer counts when it cites a matching URL for any assigned property. This does not mean every property was cited." /> : null}</div><ReportRate value={population.summary.citationCoverage} unit="answers" /></div>

--- a/apps/web/src/lib/measurement-view-url.ts
+++ b/apps/web/src/lib/measurement-view-url.ts
@@ -134,7 +134,7 @@ export function parseVisibilitySelection(search: Record<string, unknown>): Visib
   const queryClass = string('queryClass') ?? string('class')
   const result: VisibilitySelectionState = {
     measurementScope: key && (scope === 'group' || scope === 'market' || scope === 'property') ? scope : 'project',
-    queryClass: queryClass === 'all' || queryClass === 'branded' || queryClass === 'unknown' ? queryClass : 'non-brand',
+    queryClass: queryClass === 'unknown' || isQueryClass(queryClass) ? queryClass : DEFAULT_MEASUREMENT_VIEW.queryClass,
   }
   if (result.measurementScope !== 'project') result.measurementScopeKey = key
   for (const [urlKey, field] of [

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -2702,7 +2702,7 @@ function ProjectPageContent({
             selection={visibilitySelection}
             showUnmeasuredFallback={!activeMeasurementPlan && !hasVisibilityBaseline
               && visibilitySelection.measurementScope === 'project'
-              && visibilitySelection.queryClass === 'non-brand'
+              && visibilitySelection.queryClass === 'all'
               && !visibilitySelection.provider && !visibilitySelection.model && !visibilitySelection.location
               && !visibilitySelection.from && !visibilitySelection.to && !visibilitySelection.revision
               && !visibilitySelection.measurementRunId && !visibilitySelection.queryKey}

--- a/apps/web/test/measurement-view-url.test.ts
+++ b/apps/web/test/measurement-view-url.test.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_MEASUREMENT_VIEW,
   measurementViewSearch,
   parseMeasurementViewSearch,
+  parseVisibilitySelection,
+  patchVisibilitySelection,
   shouldResetMeasurementView,
 } from '../src/lib/measurement-view-url.js'
 
@@ -100,4 +102,20 @@ test('the default view is all queries', () => {
   expect(measurementViewSearch(DEFAULT_MEASUREMENT_VIEW).class).toBeUndefined()
   // And an explicit narrower choice still round-trips.
   expect(parseMeasurementViewSearch({ class: 'branded' }).queryClass).toBe('branded')
+})
+
+test('the shared visibility workspace opens all query types for clean and malformed URLs', () => {
+  for (const search of [{}, { queryClass: '' }, { queryClass: 'invalid' }, { class: 'invalid' }]) {
+    expect(parseVisibilitySelection(search)).toEqual({ measurementScope: 'project', queryClass: 'all' })
+  }
+})
+
+test('explicit query types survive navigation and reload without losing unrelated URL state', () => {
+  for (const queryClass of ['all', 'branded', 'non-brand', 'unknown'] as const) {
+    expect(parseVisibilitySelection({ queryClass }).queryClass).toBe(queryClass)
+    expect(parseVisibilitySelection({ class: queryClass }).queryClass).toBe(queryClass)
+    const next = patchVisibilitySelection({ class: 'branded', runId: 'drawer-run', measurementProvider: 'gemini' }, { queryClass })
+    expect(parseVisibilitySelection(next)).toEqual({ measurementScope: 'project', queryClass, provider: 'gemini' })
+    expect(next.runId).toBe('drawer-run')
+  }
 })

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -182,10 +182,10 @@ async function renderAt(
   if (measurement?.competitorLandscape) {
     const q = {
       window: measurement.competitorLandscapeKey?.window ?? '30d',
-      // Simple projects have no class control, so the card always asks for the
-      // one class a share of voice can be built on.
+      // Advanced history follows the shared query-type selection. Simple
+      // history retains its separate non-brand share-of-voice scope.
       queryClass: measurement.plan.active?.plan.schemaVersion === 2
-        ? measurement.competitorLandscapeKey?.queryClass ?? 'non-brand'
+        ? measurement.competitorLandscapeKey?.queryClass ?? 'all'
         : 'non-brand',
       ...(measurement.competitorLandscapeKey?.groupKey ? { groupKey: measurement.competitorLandscapeKey.groupKey } : {}),
       ...(measurement.competitorLandscapeKey?.scope ? { scope: measurement.competitorLandscapeKey.scope } : {}),
@@ -756,6 +756,27 @@ test.each([false, true])('Simple query results remain available behind disclosur
   expect(section!.querySelector('.evidence-table')).not.toBeNull()
 })
 
+test.each([false, true])('a clean Simple dashboard shows older saved results immediately (embed: %s)', async embed => {
+  const report = visibilityReportResponse({ mode: 'simple', queryClass: 'all', label: 'Older saved query' })
+  report.selection.provenance = { kind: 'legacy-simple', definitionRevision: null }
+  for (const population of report.populations.filter(population => population.queryClass !== 'unknown')) {
+    population.summary.queryCount = 0
+    population.summary.answerCount = 0
+    population.trend = []
+    population.queries = { items: [], total: 0, nextCursor: null }
+  }
+  const html = await renderAt('/projects/project_citypoint', embed ? { enabled: true } : undefined, {
+    plan: { active: null }, visibilityReport: report,
+  })
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  expect(doc.querySelector<HTMLSelectElement>('select[aria-label="Query type"]')?.value).toBe('all')
+  expect(doc.querySelector('[aria-label="Unclassified queries"]')?.textContent).toContain('1 of 1')
+  expect(doc.querySelector('[aria-label="Branded queries"]')).toBeNull()
+  expect(doc.querySelector('[aria-label="Non-brand queries"]')).toBeNull()
+  expect(doc.querySelector('[data-query-results="unknown"]')?.textContent).toContain('Older saved query')
+  expect(html).not.toContain('frozen query classification')
+})
+
 test('a Simple project loads pinned and historical competitors from the stored-evidence read', async () => {
   const html = await renderAt('/projects/project_citypoint', undefined, {
     plan: { active: null },
@@ -928,7 +949,7 @@ test('the unified visibility report owns scope, class, paging, search, and answe
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   // Global runId belongs to the run drawer. It must not silently pin this
   // report; only measurementRunId is a visibility-report filter.
-  const router = createAppRouter(queryClient, { initialEntries: ['/projects/project_citypoint?runId=drawer-run'] })
+  const router = createAppRouter(queryClient, { initialEntries: ['/projects/project_citypoint?runId=drawer-run&queryClass=non-brand'] })
   await router.load()
   const page = render(
     <QueryClientProvider client={queryClient}>
@@ -2276,7 +2297,7 @@ test('switching query class refetches the competitor landscape under the matchin
     if (path.endsWith('/measurement-plan')) return jsonResponse(measurementPlanV2Response(4))
     if (path.endsWith('/measurement-setup')) return jsonResponse(activeMeasurementSetupResponse(4))
     if (url.pathname.endsWith('/visibility-report')) {
-      const queryClass = url.searchParams.get('queryClass') === 'branded' ? 'branded' as const : 'non-brand' as const
+      const queryClass = url.searchParams.get('queryClass') === 'branded' ? 'branded' as const : 'all' as const
       return jsonResponse(visibilityReportResponse({ mode: 'advanced', queryClass }))
     }
     if (url.pathname.endsWith('/measurement-overview')) {
@@ -2318,7 +2339,7 @@ test('switching query class refetches the competitor landscape under the matchin
   expect(observed.some(path => (
     path.includes('/analytics/competitors?')
     && path.includes('scope=all-markets')
-    && path.includes('queryClass=non-brand')
+    && path.includes('queryClass=all')
   ))).toBe(true)
 
   fireEvent.change(page.getByLabelText('Query type'), { target: { value: 'branded' } })

--- a/apps/web/test/visibility-report-view.test.tsx
+++ b/apps/web/test/visibility-report-view.test.tsx
@@ -63,7 +63,124 @@ function reportWithAnswer(queryKey: string, answerText: string): VisibilityRepor
   return report
 }
 
+function legacyReportFixture(): VisibilityReportResponse {
+  const report = reportWithAnswer('query-context', 'A saved answer from an older sweep.')
+  report.selection.mode = 'simple'
+  report.selection.queryClass = 'all'
+  report.selection.provenance = { kind: 'legacy-simple', definitionRevision: null }
+  report.selection.revision = null
+  report.selection.measurement = { ...report.selection.measurement, activeRevision: null, measuredRevision: null, awaitingSweep: false, pendingAssignmentCount: 0 }
+  report.selection.scope = { ...report.selection.scope, targetCount: 1 }
+  report.scopeOptions = [report.selection.scope]
+  const saved = report.populations[0]!
+  const missing = { numerator: null, denominator: null, rate: null, reason: 'no-population' as const }
+  report.populations = (['branded', 'non-brand', 'unknown'] as const).map(queryClass => {
+    const summary = queryClass === 'unknown' ? saved.summary : { ...saved.summary, queryCount: 0, answerCount: 0, mentionCoverage: missing, citationCoverage: missing }
+    return {
+      ...saved, queryClass, summary,
+      trend: [{ runId: 'run-2', createdAt: '2026-09-01T10:00:00Z', revision: null, provenance: report.selection.provenance, queryCount: summary.queryCount, answerCount: summary.answerCount, mentionCoverage: summary.mentionCoverage, citationCoverage: summary.citationCoverage, continuity: { state: 'first' } }],
+      queries: queryClass === 'unknown' ? saved.queries : { items: [], total: 0, nextCursor: null },
+      evidence: queryClass === 'unknown' ? saved.evidence : { items: [], total: 0, nextCursor: null },
+    }
+  })
+  return report
+}
+
 describe('shared production visibility view', () => {
+  it('shows older simple results on a clean URL and opens their saved answers without a filter rescue', async () => {
+    const requests: URL[] = []
+    onTestFinished(mockFetch(url => {
+      const request = new URL(url)
+      requests.push(request)
+      const report = legacyReportFixture()
+      const queryClass = request.searchParams.get('queryClass') ?? 'non-brand'
+      report.selection.queryClass = queryClass as VisibilityReportResponse['selection']['queryClass']
+      if (queryClass !== 'all') report.populations = report.populations.filter(population => population.queryClass === queryClass)
+      return jsonResponse(report)
+    }))
+    function Workspace() {
+      const [search, setSearch] = useState<Record<string, unknown>>({})
+      return <VisibilityWorkspace projectName="demo" selection={parseVisibilitySelection(search)} onSelectionChange={patch => setSearch(previous => patchVisibilitySelection(previous, patch))} />
+    }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(<QueryClientProvider client={queryClient}><Workspace /></QueryClientProvider>)
+    const population = await screen.findByRole('region', { name: 'Unclassified queries', exact: true })
+    expect(requests[0]!.searchParams.get('queryClass')).toBe('all')
+    expect((screen.getByRole('combobox', { name: 'Query type' }) as HTMLSelectElement).value).toBe('all')
+    expect(within(population).getByText('Queries measured').nextElementSibling?.textContent).toBe('1')
+    expect(within(population).getAllByText('43%').length).toBeGreaterThan(0)
+    expect(screen.queryByRole('heading', { name: 'Branded queries', exact: true })).toBeNull()
+    expect(screen.queryByRole('heading', { name: 'Non-brand queries', exact: true })).toBeNull()
+    expect(screen.queryByText(/frozen query classification/)).toBeNull()
+    fireEvent.click(within(population).getByText('Query results', { selector: 'span' }).closest('summary')!)
+    fireEvent.click(within(population).getByRole('button', { name: /View answers for/ }))
+    expect(await screen.findByText('A saved answer from an older sweep.')).toBeTruthy()
+    expect(requests.at(-1)!.searchParams.get('queryClass')).toBe('unknown')
+    expect(requests.at(-1)!.searchParams.get('runId')).toBe('run-2')
+  })
+
+  it.each(['simple', 'advanced'] as const)('keeps historical classes visible when the latest %s sweep has no queries in that class', mode => {
+    const report = legacyReportFixture()
+    report.selection.mode = mode
+    report.populations[0]!.trend[0] = { ...report.populations[2]!.trend[0]!, provenance: { kind: 'frozen-simple', definitionRevision: null } }
+    render(<VisibilityReportView report={report} onSelectionChange={() => {}} />)
+    expect(screen.getByRole('region', { name: 'Branded queries', exact: true })).toBeTruthy()
+    expect(screen.getByRole('region', { name: 'Unclassified queries', exact: true })).toBeTruthy()
+    if (mode === 'advanced') expect(screen.getByRole('region', { name: 'Non-brand queries', exact: true })).toBeTruthy()
+  })
+
+  it('keeps populated simple classes separate even while query search has no matches', () => {
+    const report = legacyReportFixture()
+    for (const population of report.populations) {
+      population.summary = report.populations[2]!.summary
+      population.queries = { items: [], total: 0, nextCursor: null }
+    }
+    render(<VisibilityReportView report={report} search="no match" onSelectionChange={() => {}} />)
+    for (const name of ['Branded queries', 'Non-brand queries', 'Unclassified queries']) {
+      const population = screen.getByRole('region', { name, exact: true })
+      expect(within(population).getAllByText('43%').length).toBeGreaterThan(0)
+    }
+  })
+
+  it.each(['simple', 'advanced'] as const)('replaces unavailable %s trend plots with an explicit empty state', mode => {
+    const report = legacyReportFixture()
+    report.selection.mode = mode
+    report.selection.queryClass = 'non-brand'
+    report.populations = [report.populations[1]!]
+    render(<VisibilityReportView report={report} onSelectionChange={() => {}} />)
+    expect(screen.getByRole('heading', { name: 'Non-brand queries', exact: true })).toBeTruthy()
+    expect(screen.getByText('No measured trend for this selection.')).toBeTruthy()
+    expect(screen.queryByRole('img', { name: /mention and citation trend/ })).toBeNull()
+  })
+
+  it.each(['simple', 'advanced'] as const)('retains %s partial-sweep dates and model changes when no rates can be plotted', mode => {
+    const report = reportFixture()
+    report.selection.mode = mode
+    report.selection.measurement.state = 'partial'
+    const population = report.populations[0]!
+    const unavailable = { numerator: null, denominator: null, rate: null, reason: 'evidence-incomplete' as const }
+    population.summary = { ...population.summary, queryCount: 2, answerCount: 1, mentionCoverage: unavailable, citationCoverage: unavailable }
+    population.trend = ['2026-09-03T12:00:00Z', '2026-09-04T12:00:00Z'].map((createdAt, index) => ({
+      runId: `partial-${index}`, createdAt, revision: report.selection.revision,
+      provenance: report.selection.provenance, queryCount: 2, answerCount: 1,
+      mentionCoverage: unavailable, citationCoverage: unavailable,
+      continuity: index === 0 ? { state: 'first', comparedRunId: null } : { state: 'model-changed', comparedRunId: 'partial-0' },
+    }))
+    render(<VisibilityReportView report={report} onSelectionChange={() => {}} />)
+
+    const disclosure = screen.getByText('Trend data and comparability').closest('details')!
+    fireEvent.click(within(disclosure).getByText('Trend data and comparability'))
+    const table = within(disclosure).getByRole('table')
+    expect(within(table).getAllByRole('row')).toHaveLength(3)
+    for (const point of population.trend) {
+      expect(within(table).getByText(new Date(point.createdAt).toLocaleDateString())).toBeTruthy()
+    }
+    expect(within(table).getByText('model changed')).toBeTruthy()
+    expect(within(table).getAllByText('Not measured')).toHaveLength(4)
+    expect(screen.queryByRole('img', { name: /mention and citation trend/ })).toBeNull()
+    expect(screen.queryByRole('list', { name: 'Trend legend' })).toBeNull()
+  })
+
   it.each([
     { mode: 'simple' as const, showUnmeasuredFallback: true, expectsFallback: true },
     { mode: 'simple' as const, showUnmeasuredFallback: false, expectsFallback: false },
@@ -240,8 +357,9 @@ describe('shared production visibility view', () => {
     report.selection.provenance = { kind: 'legacy-simple', definitionRevision: null }
     const select = vi.fn()
     render(<VisibilityReportView report={report} onSelectionChange={select} />)
-    fireEvent.click(screen.getByRole('button', { name: 'View unclassified results' }))
-    expect(select).toHaveBeenCalledWith({ queryClass: 'unknown', measurementQueryKey: undefined })
+    expect(screen.getByText("These saved results aren't separated by query type.")).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'View all saved results' }))
+    expect(select).toHaveBeenCalledWith({ queryClass: 'all', measurementQueryKey: undefined })
   })
 
   it('keeps observed competitor names separate from unavailable historical rates', () => {

--- a/apps/web/test/visibility-selection-url.test.ts
+++ b/apps/web/test/visibility-selection-url.test.ts
@@ -3,8 +3,8 @@ import { parseVisibilitySelection, patchVisibilitySelection } from '../src/lib/m
 import { rootRoute } from '../src/router/routes.js'
 
 describe('shared visibility selection URL', () => {
-  it('defaults to non-brand for simple and advanced projects', () => {
-    expect(parseVisibilitySelection({})).toEqual({ measurementScope: 'project', queryClass: 'non-brand' })
+  it('defaults to all queries for simple and advanced projects', () => {
+    expect(parseVisibilitySelection({})).toEqual({ measurementScope: 'project', queryClass: 'all' })
   })
 
   it('preserves the legacy group bookmark without widening it', () => {
@@ -55,6 +55,6 @@ describe('shared visibility selection URL', () => {
     ].map(patch => JSON.stringify({ queryKey: 'query-1', queryClass: 'non-brand', provider: 'gemini', model: null, location: null, runId: 'run-2', revision: 2, ...patch })),
   ])('ignores invalid or mismatched answer context while keeping a legacy query link: %s', measurementAnswer => {
     expect(parseVisibilitySelection({ measurementQueryKey: 'query-1', measurementAnswer }))
-      .toEqual({ measurementScope: 'project', queryClass: 'non-brand', queryKey: 'query-1' })
+      .toEqual({ measurementScope: 'project', queryClass: 'all', queryKey: 'query-1' })
   })
 })


### PR DESCRIPTION
- Default to all query types so Simple dashboards show older unclassified results immediately, with separate rates for each query type.
- Preserve explicit filters and first-sweep onboarding. Hide empty charts while retaining saved dates and comparison markers for partial sweeps.
- Add Simple, Advanced, and embed regressions. Validated with all 1,519 web tests, 22 visibility API tests, lint, web typecheck/build, visual checks, and pre-push drift checks.