### PR TITLE
fix: show one visibility report for the selected query type

### DIFF
--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -19,6 +19,7 @@ import {
   CHART_NEUTRAL,
   CHART_SERIES_COLORS,
   CHART_TONE,
+  CHART_TOOLTIP_STYLE,
   ComposedChart,
   formatObservedInstantLabel,
   Line,
@@ -193,7 +194,7 @@ function ReportTrend({ population }: { population: VisibilityReportPopulation })
             <CartesianGrid stroke={CHART_GRID_STROKE} vertical={false} />
             <XAxis dataKey="createdAt" type="number" scale="time" domain={['dataMin', 'dataMax']} tick={CHART_AXIS_TICK} tickLine={false} axisLine={{ stroke: CHART_AXIS_STROKE }} tickFormatter={value => new Date(Number(value)).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} minTickGap={24} />
             <YAxis domain={[0, 1]} tick={CHART_AXIS_TICK} tickLine={false} axisLine={false} width={48} tickFormatter={value => reportPercent.format(Number(value))} />
-            <RechartsTooltip formatter={value => typeof value === 'number' ? reportPercent.format(value) : 'Not measured'} labelFormatter={value => new Date(Number(value)).toLocaleString()} />
+            <RechartsTooltip {...CHART_TOOLTIP_STYLE} formatter={value => typeof value === 'number' ? reportPercent.format(value) : 'Not measured'} labelFormatter={value => new Date(Number(value)).toLocaleString()} />
             {segments.map(index => <Fragment key={index}>
               <Line type="linear" dataKey={`mentioned-${index}`} name="Mentioned" stroke={CHART_SERIES_COLORS[1]} strokeWidth={2} connectNulls={false} isAnimationActive={false} dot={{ r: 3 }} />
               <Line type="linear" dataKey={`cited-${index}`} name="Cited" stroke={CHART_TONE.positive} strokeWidth={2} connectNulls={false} isAnimationActive={false} dot={{ r: 3 }} />
@@ -227,8 +228,22 @@ export interface VisibilityReportViewProps {
   onEvidencePage?: (cursor: string) => void
 }
 
+function selectedReportPopulation(report: VisibilityReportResponse, queryKey?: string, answerSelection?: VisibilityAnswerSelection) {
+  const requested = report.selection.queryClass === 'all' ? answerSelection?.queryClass : report.selection.queryClass
+  const explicit = report.populations.find(population => population.queryClass === requested)
+  if (explicit) return explicit
+  const matching = queryKey ? report.populations.find(population => [...population.queries.items, ...population.evidence.items].some(row => row.queryKey === queryKey)) : undefined
+  if (matching) return matching
+  // Clean URLs request all classes so older, unclassified history remains
+  // discoverable. Display a single population without combining its rates.
+  const ordered = (['non-brand', 'branded', 'unknown'] as const).map(queryClass => report.populations.find(population => population.queryClass === queryClass))
+  return ordered.find(population => population && (population.summary.queryCount > 0 || population.trend.some(point => point.queryCount > 0)))
+    ?? ordered.find(population => population !== undefined)
+    ?? report.populations[0]!
+}
+
 /** Shared by the live report and the isolated overview review. No metric changes. */
-export function VisibilityReportFilters({ report, onSelectionChange }: Pick<VisibilityReportViewProps, 'report' | 'onSelectionChange'>) {
+export function VisibilityReportFilters({ report, onSelectionChange, queryClass = selectedReportPopulation(report).queryClass }: Pick<VisibilityReportViewProps, 'report' | 'onSelectionChange'> & { queryClass?: VisibilityReportPopulation['queryClass'] }) {
   const [scopeSearch, setScopeSearch] = useState('')
   const picker = useRef<HTMLDetailsElement>(null)
   const searchInput = useRef<HTMLInputElement>(null)
@@ -272,7 +287,7 @@ export function VisibilityReportFilters({ report, onSelectionChange }: Pick<Visi
         </div>
       </details>
     </div> : null}
-    {select('Query type', 'queryClass', selection.queryClass, [{ value: 'all', label: 'All queries' }, { value: 'non-brand', label: 'Non-brand' }, { value: 'branded', label: 'Branded' }, { value: 'unknown', label: 'Unclassified' }])}
+    {select('Query type', 'queryClass', queryClass, [{ value: 'non-brand', label: 'Non-brand' }, { value: 'branded', label: 'Branded' }, { value: 'unknown', label: 'Unclassified' }])}
     {select('Answer engine', 'measurementProvider', selection.provider ?? '', [{ value: '', label: 'All engines' }, ...filterOptions.providers.map(provider => ({ value: provider, label: provider }))])}
     {select('Search location', 'measurementLocation', selection.location.kind === 'exact' ? selection.location.value : selection.location.kind === 'none' ? 'none' : '', [{ value: '', label: 'All locations' }, ...filterOptions.locations.filter(location => location.kind !== 'all').map(location => ({ value: location.kind === 'exact' ? location.value : 'none', label: location.kind === 'exact' ? location.value : 'No location' }))])}
   </div></div>
@@ -282,9 +297,10 @@ export function VisibilityReportFilters({ report, onSelectionChange }: Pick<Visi
 export function VisibilityReportView({ report, isRefreshing = false, onSelectionChange, onManageQueries, onPage, onSearch, search = '', queryKey, answerSelection, evidenceReport, isEvidenceLoading = false, evidenceError, onRetryEvidence, onEvidencePage }: VisibilityReportViewProps) {
   const reportElement = useRef<HTMLElement>(null)
   const focusedQueryKey = useRef<string | undefined>(undefined)
+  const selectedPopulation = selectedReportPopulation(report, queryKey, answerSelection)
   const answerReport = evidenceReport ?? report
   const matchingPopulations = answerReport.populations.filter(population => [...population.queries.items, ...population.evidence.items].some(row => row.queryKey === queryKey))
-  const answerClasses = answerSelection ? [answerSelection.queryClass] : (matchingPopulations.length ? matchingPopulations : isEvidenceLoading ? [] : report.populations.slice(0, 1)).map(population => population.queryClass)
+  const answerClasses = answerSelection ? [answerSelection.queryClass] : (matchingPopulations.length ? matchingPopulations : isEvidenceLoading ? [] : [selectedPopulation]).map(population => population.queryClass)
   const answerFocusKey = queryKey ? JSON.stringify([answerSelection ?? queryKey, answerClasses]) : undefined
   const filterId = useId()
   useEffect(() => {
@@ -331,21 +347,14 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
       {onManageQueries ? <Button variant="outline" onClick={onManageQueries}>Manage queries</Button> : null}
     </div>
     {selection.provenance.kind === 'legacy-simple' && selection.queryClass !== 'unknown' && selection.queryClass !== 'all' ? <div className="flex flex-wrap items-center justify-between gap-3 border-b border-default py-3 text-sm text-secondary"><p>These saved results aren't separated by query type.</p><Button variant="outline" onClick={() => onSelectionChange({ queryClass: 'all', measurementQueryKey: undefined })}>View all saved results</Button></div> : null}
-    <VisibilityReportFilters report={report} onSelectionChange={onSelectionChange} />
+    <VisibilityReportFilters report={report} queryClass={selectedPopulation.queryClass} onSelectionChange={onSelectionChange} />
     <details className="border-b border-default text-sm text-secondary"><summary className="min-h-11 cursor-pointer py-3">More filters</summary><div className="flex flex-wrap gap-4 pb-3">
       <label className="min-w-40 flex-1"><span className="mb-1 block text-sm font-medium text-heading">Start date (UTC)</span><input type="date" className={REPORT_CONTROL} value={selection.time.from?.slice(0, 10) ?? ''} onChange={event => onSelectionChange({ measurementFrom: event.target.value ? `${event.target.value}T00:00:00.000Z` : undefined })} /></label>
       <label className="min-w-40 flex-1"><span className="mb-1 block text-sm font-medium text-heading">End date (UTC)</span><input type="date" className={REPORT_CONTROL} value={selection.time.to?.slice(0, 10) ?? ''} onChange={event => onSelectionChange({ measurementTo: event.target.value ? `${event.target.value}T23:59:59.999Z` : undefined })} /></label>
       {filterSelect('AI model', 'measurementModel', selection.model ?? '', [{ value: '', label: 'All models' }, ...Array.from(new Set(filterOptions.models.filter(model => !selection.provider || model.provider === selection.provider).map(model => model.model))).map(model => ({ value: model, label: model }))], 'Filter by the AI model recorded with each answer. This does not change the model used by future sweeps.')}
-      {filterSelect('Results from', 'measurementRunId', selection.run.explicit ? selection.run.id ?? '' : '', [{ value: '', label: 'Latest saved sweep' }, ...[...report.populations[0]!.trend].reverse().map(point => ({ value: point.runId, label: new Date(point.createdAt).toLocaleString() }))], 'Choose a saved AI sweep to view its results. No new sweep starts.')}
+      {filterSelect('Results from', 'measurementRunId', selection.run.explicit ? selection.run.id ?? '' : '', [{ value: '', label: 'Latest saved sweep' }, ...[...selectedPopulation.trend].reverse().map(point => ({ value: point.runId, label: new Date(point.createdAt).toLocaleString() }))], 'Choose a saved AI sweep to view its results. No new sweep starts.')}
     </div></details>
-    {report.populations.map(population => {
-      // Simple history can predate query labels. In the all-query view, lead
-      // with its saved results instead of empty classes that never had queries.
-      // Retain historical populations and any explicitly requested class.
-      if (selection.mode === 'simple' && selection.queryClass === 'all'
-        && population.summary.queryCount === 0 && !population.trend.some(point => point.queryCount > 0)
-        && !(queryKey && answerClasses.includes(population.queryClass))
-        && report.populations.some(other => other.summary.queryCount > 0 || other.trend.some(point => point.queryCount > 0))) return null
+    {[selectedPopulation].map(population => {
       const queryGroups = groupVisibilityQueryRows(population.queries.items)
       return <section key={population.queryClass} aria-label={REPORT_CLASS_LABEL[population.queryClass]} className="py-4">
       <div className="section-head"><h2>{REPORT_CLASS_LABEL[population.queryClass]}</h2><InfoTooltip text={population.queryClass === 'non-brand' ? 'Queries that do not name the measured identity. Geography alone is not a brand.' : population.queryClass === 'branded' ? 'Queries that name the measured identity.' : 'These queries were not labeled as branded or non-brand when measured. Their saved results remain available here, separate from branded and non-brand rates.'} /></div>
@@ -452,6 +461,11 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
     enabled: Boolean(selection.queryKey) && Boolean(reportQuery.data) && !reportQuery.isPlaceholderData,
     retry: false,
   })
+  useEffect(() => {
+    if (selection.queryClass !== 'all' || !reportQuery.data || reportQuery.isPlaceholderData
+      || reportQuery.data.selection.availability.state === 'unsupported') return
+    onSelectionChange({ queryClass: selectedReportPopulation(reportQuery.data, selection.queryKey, selection.answer).queryClass })
+  }, [selection.queryClass, selection.queryKey, selection.answer, reportQuery.data, reportQuery.isPlaceholderData, onSelectionChange])
   if (reportQuery.data?.selection.availability.state === 'unsupported') return <>{fallback}</>
   if (showUnmeasuredFallback && reportQuery.data?.selection.mode === 'simple' && reportQuery.data.selection.measurement.state === 'not-measured') return <>{fallback}</>
   if (reportQuery.error) {

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -228,12 +228,17 @@ export interface VisibilityReportViewProps {
   onEvidencePage?: (cursor: string) => void
 }
 
-function selectedReportPopulation(report: VisibilityReportResponse, queryKey?: string, answerSelection?: VisibilityAnswerSelection) {
+function matchingReportPopulation(report: VisibilityReportResponse | undefined, queryKey?: string) {
+  return queryKey ? report?.populations.find(population => [...population.queries.items, ...population.evidence.items].some(row => row.queryKey === queryKey)) : undefined
+}
+
+function selectedReportPopulation(report: VisibilityReportResponse, queryKey?: string, answerSelection?: VisibilityAnswerSelection, evidenceReport?: VisibilityReportResponse) {
   const requested = report.selection.queryClass === 'all' ? answerSelection?.queryClass : report.selection.queryClass
   const explicit = report.populations.find(population => population.queryClass === requested)
   if (explicit) return explicit
-  const matching = queryKey ? report.populations.find(population => [...population.queries.items, ...population.evidence.items].some(row => row.queryKey === queryKey)) : undefined
-  if (matching) return matching
+  const matching = matchingReportPopulation(evidenceReport, queryKey) ?? matchingReportPopulation(report, queryKey)
+  const matchingAggregate = report.populations.find(population => population.queryClass === matching?.queryClass)
+  if (matchingAggregate) return matchingAggregate
   // Clean URLs request all classes so older, unclassified history remains
   // discoverable. Display a single population without combining its rates.
   const ordered = (['non-brand', 'branded', 'unknown'] as const).map(queryClass => report.populations.find(population => population.queryClass === queryClass))
@@ -297,7 +302,7 @@ export function VisibilityReportFilters({ report, onSelectionChange, queryClass 
 export function VisibilityReportView({ report, isRefreshing = false, onSelectionChange, onManageQueries, onPage, onSearch, search = '', queryKey, answerSelection, evidenceReport, isEvidenceLoading = false, evidenceError, onRetryEvidence, onEvidencePage }: VisibilityReportViewProps) {
   const reportElement = useRef<HTMLElement>(null)
   const focusedQueryKey = useRef<string | undefined>(undefined)
-  const selectedPopulation = selectedReportPopulation(report, queryKey, answerSelection)
+  const selectedPopulation = selectedReportPopulation(report, queryKey, answerSelection, evidenceReport)
   const answerReport = evidenceReport ?? report
   const matchingPopulations = answerReport.populations.filter(population => [...population.queries.items, ...population.evidence.items].some(row => row.queryKey === queryKey))
   const answerClasses = answerSelection ? [answerSelection.queryClass] : (matchingPopulations.length ? matchingPopulations : isEvidenceLoading ? [] : [selectedPopulation]).map(population => population.queryClass)
@@ -463,9 +468,15 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
   })
   useEffect(() => {
     if (selection.queryClass !== 'all' || !reportQuery.data || reportQuery.isPlaceholderData
-      || reportQuery.data.selection.availability.state === 'unsupported') return
-    onSelectionChange({ queryClass: selectedReportPopulation(reportQuery.data, selection.queryKey, selection.answer).queryClass })
-  }, [selection.queryClass, selection.queryKey, selection.answer, reportQuery.data, reportQuery.isPlaceholderData, onSelectionChange])
+      || reportQuery.data.selection.availability.state === 'unsupported' || reportQuery.data.populations.length === 0) return
+    // Older links carry only a query key. Wait for its evidence when it is
+    // outside the aggregate page, including across a failed request and retry.
+    if (selection.queryKey && !selection.answer && !matchingReportPopulation(reportQuery.data, selection.queryKey) && !evidenceQuery.data) return
+    onSelectionChange({
+      queryClass: selectedReportPopulation(reportQuery.data, selection.queryKey, selection.answer, evidenceQuery.data).queryClass,
+      ...(selection.queryKey ? { measurementQueryKey: selection.queryKey, measurementAnswer: selection.answer ? JSON.stringify(selection.answer) : undefined } : {}),
+    })
+  }, [selection.queryClass, selection.queryKey, selection.answer, reportQuery.data, reportQuery.isPlaceholderData, evidenceQuery.data, onSelectionChange])
   if (reportQuery.data?.selection.availability.state === 'unsupported') return <>{fallback}</>
   if (showUnmeasuredFallback && reportQuery.data?.selection.mode === 'simple' && reportQuery.data.selection.measurement.state === 'not-measured') return <>{fallback}</>
   if (reportQuery.error) {

--- a/apps/web/src/lib/measurement-view-url.ts
+++ b/apps/web/src/lib/measurement-view-url.ts
@@ -160,8 +160,10 @@ export function patchVisibilitySelection(
     'measurementScope', 'measurementScopeKey', 'queryClass', 'measurementProvider', 'measurementModel',
     'measurementLocation', 'measurementFrom', 'measurementTo', 'measurementRevision', 'measurementRunId',
   ].some(key => key in patch)) {
-    next.measurementQueryKey = undefined
-    next.measurementAnswer = undefined
+    // Filter changes close answers unless the caller explicitly carries an
+    // answer link forward while resolving its query class.
+    next.measurementQueryKey = patch.measurementQueryKey
+    next.measurementAnswer = patch.measurementAnswer
   } else if ('measurementQueryKey' in patch && !('measurementAnswer' in patch)) {
     next.measurementAnswer = undefined
   }

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -769,7 +769,7 @@ test.each([false, true])('a clean Simple dashboard shows older saved results imm
     plan: { active: null }, visibilityReport: report,
   })
   const doc = new DOMParser().parseFromString(html, 'text/html')
-  expect(doc.querySelector<HTMLSelectElement>('select[aria-label="Query type"]')?.value).toBe('all')
+  expect(doc.querySelector<HTMLSelectElement>('select[aria-label="Query type"]')?.value).toBe('unknown')
   expect(doc.querySelector('[aria-label="Unclassified queries"]')?.textContent).toContain('1 of 1')
   expect(doc.querySelector('[aria-label="Branded queries"]')).toBeNull()
   expect(doc.querySelector('[aria-label="Non-brand queries"]')).toBeNull()

--- a/apps/web/test/visibility-report-view.test.tsx
+++ b/apps/web/test/visibility-report-view.test.tsx
@@ -87,7 +87,7 @@ function legacyReportFixture(): VisibilityReportResponse {
 }
 
 describe('shared production visibility view', () => {
-  it('shows older simple results on a clean URL and opens their saved answers without a filter rescue', async () => {
+  it('loads legacy simple history as all classes once, then normalizes a clean URL to its saved unclassified population', async () => {
     const requests: URL[] = []
     onTestFinished(mockFetch(url => {
       const request = new URL(url)
@@ -106,12 +106,12 @@ describe('shared production visibility view', () => {
     render(<QueryClientProvider client={queryClient}><Workspace /></QueryClientProvider>)
     const population = await screen.findByRole('region', { name: 'Unclassified queries', exact: true })
     expect(requests[0]!.searchParams.get('queryClass')).toBe('all')
-    expect((screen.getByRole('combobox', { name: 'Query type' }) as HTMLSelectElement).value).toBe('all')
+    await waitFor(() => expect(requests.at(-1)!.searchParams.get('queryClass')).toBe('unknown'))
+    expect((screen.getByRole('combobox', { name: 'Query type' }) as HTMLSelectElement).value).toBe('unknown')
+    expect([...((screen.getByRole('combobox', { name: 'Query type' }) as HTMLSelectElement).options)].map(option => option.value)).not.toContain('all')
     expect(within(population).getByText('Queries measured').nextElementSibling?.textContent).toBe('1')
-    expect(within(population).getAllByText('43%').length).toBeGreaterThan(0)
-    expect(screen.queryByRole('heading', { name: 'Branded queries', exact: true })).toBeNull()
-    expect(screen.queryByRole('heading', { name: 'Non-brand queries', exact: true })).toBeNull()
-    expect(screen.queryByText(/frozen query classification/)).toBeNull()
+    expect(screen.queryByRole('region', { name: 'Branded queries', exact: true })).toBeNull()
+    expect(screen.queryByRole('region', { name: 'Non-brand queries', exact: true })).toBeNull()
     fireEvent.click(within(population).getByText('Query results', { selector: 'span' }).closest('summary')!)
     fireEvent.click(within(population).getByRole('button', { name: /View answers for/ }))
     expect(await screen.findByText('A saved answer from an older sweep.')).toBeTruthy()
@@ -119,27 +119,41 @@ describe('shared production visibility view', () => {
     expect(requests.at(-1)!.searchParams.get('runId')).toBe('run-2')
   })
 
-  it.each(['simple', 'advanced'] as const)('keeps historical classes visible when the latest %s sweep has no queries in that class', mode => {
+  it('renders one explicitly selected class, including its empty state, instead of stacking report populations', () => {
     const report = legacyReportFixture()
-    report.selection.mode = mode
-    report.populations[0]!.trend[0] = { ...report.populations[2]!.trend[0]!, provenance: { kind: 'frozen-simple', definitionRevision: null } }
+    report.selection.queryClass = 'branded'
     render(<VisibilityReportView report={report} onSelectionChange={() => {}} />)
     expect(screen.getByRole('region', { name: 'Branded queries', exact: true })).toBeTruthy()
-    expect(screen.getByRole('region', { name: 'Unclassified queries', exact: true })).toBeTruthy()
-    if (mode === 'advanced') expect(screen.getByRole('region', { name: 'Non-brand queries', exact: true })).toBeTruthy()
+    expect(screen.queryByRole('region', { name: 'Non-brand queries', exact: true })).toBeNull()
+    expect(screen.queryByRole('region', { name: 'Unclassified queries', exact: true })).toBeNull()
+    expect(screen.getAllByRole('region').filter(region => /queries$/.test(region.getAttribute('aria-label') ?? ''))).toHaveLength(1)
+    expect(document.querySelectorAll('details[data-query-results]')).toHaveLength(1)
+    expect(screen.queryByRole('img', { name: /mention and citation trend/ })).toBeNull()
   })
 
-  it('keeps populated simple classes separate even while query search has no matches', () => {
-    const report = legacyReportFixture()
-    for (const population of report.populations) {
-      population.summary = report.populations[2]!.summary
-      population.queries = { items: [], total: 0, nextCursor: null }
+  it('switches the one report population through the existing query-type dropdown', async () => {
+    const requests: URL[] = []
+    onTestFinished(mockFetch(url => {
+      const request = new URL(url)
+      requests.push(request)
+      const report = legacyReportFixture()
+      const queryClass = request.searchParams.get('queryClass') ?? 'all'
+      report.selection.queryClass = queryClass as VisibilityReportResponse['selection']['queryClass']
+      if (queryClass !== 'all') report.populations = report.populations.filter(population => population.queryClass === queryClass)
+      return jsonResponse(report)
+    }))
+    function Workspace() {
+      const [search, setSearch] = useState<Record<string, unknown>>({ queryClass: 'non-brand' })
+      return <VisibilityWorkspace projectName="demo" selection={parseVisibilitySelection(search)} onSelectionChange={patch => setSearch(previous => patchVisibilitySelection(previous, patch))} />
     }
-    render(<VisibilityReportView report={report} search="no match" onSelectionChange={() => {}} />)
-    for (const name of ['Branded queries', 'Non-brand queries', 'Unclassified queries']) {
-      const population = screen.getByRole('region', { name, exact: true })
-      expect(within(population).getAllByText('43%').length).toBeGreaterThan(0)
-    }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(<QueryClientProvider client={queryClient}><Workspace /></QueryClientProvider>)
+    await screen.findByRole('region', { name: 'Non-brand queries', exact: true })
+    fireEvent.change(screen.getByRole('combobox', { name: 'Query type' }), { target: { value: 'unknown' } })
+    await waitFor(() => expect(requests.at(-1)!.searchParams.get('queryClass')).toBe('unknown'))
+    expect(screen.getByRole('region', { name: 'Unclassified queries', exact: true })).toBeTruthy()
+    expect(screen.queryByRole('region', { name: 'Non-brand queries', exact: true })).toBeNull()
+    expect(screen.getAllByRole('img', { name: /mention and citation trend/ })).toHaveLength(1)
   })
 
   it.each(['simple', 'advanced'] as const)('replaces unavailable %s trend plots with an explicit empty state', mode => {
@@ -331,14 +345,56 @@ describe('shared production visibility view', () => {
     expect(html).not.toContain('Published revision 4')
   })
 
-  it('keeps all classes as separate report sections and offers searchable scope', () => {
+  it('resolves an all-class response to historical non-brand data before current branded data, then to branded when non-brand has no history', () => {
+    const historicalNonBrand = legacyReportFixture()
+    historicalNonBrand.selection.queryClass = 'all'
+    historicalNonBrand.populations[1]!.trend[0] = { ...historicalNonBrand.populations[2]!.trend[0]!, queryCount: 1 }
+    historicalNonBrand.populations[2]!.summary = { ...historicalNonBrand.populations[2]!.summary, queryCount: 0, answerCount: 0 }
+    render(<VisibilityReportView report={historicalNonBrand} onSelectionChange={() => {}} />)
+    expect(screen.getByRole('region', { name: 'Non-brand queries', exact: true })).toBeTruthy()
+    expect(screen.queryByRole('region', { name: 'Branded queries', exact: true })).toBeNull()
+    cleanup()
+
+    const brandedOnly = legacyReportFixture()
+    brandedOnly.selection.queryClass = 'all'
+    brandedOnly.populations[0]!.summary = brandedOnly.populations[2]!.summary
+    brandedOnly.populations[0]!.queries = brandedOnly.populations[2]!.queries
+    brandedOnly.populations[1]!.summary = { ...brandedOnly.populations[1]!.summary, queryCount: 0, answerCount: 0 }
+    brandedOnly.populations[1]!.trend = []
+    brandedOnly.populations[2]!.summary = { ...brandedOnly.populations[2]!.summary, queryCount: 0, answerCount: 0 }
+    brandedOnly.populations[2]!.trend = []
+    render(<VisibilityReportView report={brandedOnly} onSelectionChange={() => {}} />)
+    expect(screen.getByRole('region', { name: 'Branded queries', exact: true })).toBeTruthy()
+    expect(screen.queryByRole('region', { name: 'Non-brand queries', exact: true })).toBeNull()
+  })
+
+  it('keeps a branded answer deep link in its branded population when the aggregate selection is all', async () => {
+    const report = reportWithAnswer('branded-query', 'Saved branded answer.')
+    report.selection.queryClass = 'all'
+    report.populations[0]!.queryClass = 'branded'
+    const requests: URL[] = []
+    onTestFinished(mockFetch(url => {
+      requests.push(new URL(url))
+      return jsonResponse(report)
+    }))
+    const answer = { queryKey: 'branded-query', queryClass: 'branded' as const, provider: 'gemini', model: null, location: null, runId: 'run-2', revision: 2 }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(<QueryClientProvider client={queryClient}><VisibilityWorkspace projectName="demo" selection={parseVisibilitySelection({ queryClass: 'all', measurementQueryKey: answer.queryKey, measurementAnswer: JSON.stringify(answer) })} onSelectionChange={() => {}} /></QueryClientProvider>)
+    expect(await screen.findByText('Saved branded answer.')).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Query type' })).toHaveProperty('value', 'branded')
+    expect(screen.getByRole('region', { name: 'Branded queries', exact: true })).toBeTruthy()
+    expect(screen.queryByRole('region', { name: 'Non-brand queries', exact: true })).toBeNull()
+    expect(requests.find(request => request.searchParams.has('queryKey'))?.searchParams.get('queryClass')).toBe('branded')
+  })
+
+  it('uses the resolved non-brand population for an all-class report response', () => {
     const report = reportFixture()
     report.selection.queryClass = 'all'
     report.populations = ['branded', 'non-brand', 'unknown'].map(queryClass => ({ ...report.populations[0]!, queryClass: queryClass as 'branded' | 'non-brand' | 'unknown' }))
     const html = renderToStaticMarkup(<VisibilityReportView report={report} onSelectionChange={() => {}} />)
-    expect(html).toContain('Branded queries')
+    expect(html).not.toContain('Branded queries')
     expect(html).toContain('Non-brand queries')
-    expect(html).toContain('Unclassified queries')
+    expect(html).not.toContain('Unclassified queries')
     expect(html).toContain('Search scopes')
     expect(html).not.toContain('Pooled')
   })
@@ -503,7 +559,7 @@ describe('shared production visibility view', () => {
     const view = render(<VisibilityReportView report={report} queryKey="query-context" onSelectionChange={() => {}} />)
     const disclosures = [...view.container.querySelectorAll<HTMLDetailsElement>('details[data-query-results]')]
     expect(disclosures.map(details => [details.dataset.queryResults, details.open])).toEqual([
-      ['branded', false], ['non-brand', true], ['unknown', false],
+      ['non-brand', true],
     ])
     expect(screen.getAllByRole('region', { name: 'Measured answers' })).toHaveLength(1)
     expect(document.activeElement?.textContent).toContain('Saved non-brand answer.')
@@ -670,17 +726,18 @@ describe('shared production visibility view', () => {
     const client = () => new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
     const view = render(<QueryClientProvider client={client()}><Harness startingSearch={initialSearch} /></QueryClientProvider>)
     await screen.findByRole('combobox', { name: 'Answer engine' })
-    fireEvent.click(screen.getAllByText('Query results', { selector: 'span' })[1]!.closest('summary')!)
+    fireEvent.click(screen.getByText('Query results', { selector: 'span' }).closest('summary')!)
     fireEvent.click(screen.getByRole('button', { name: 'View answers for apartments near transit · gemini' }))
     expect(await screen.findByText('Stored negative evidence for this exact context.')).toBeTruthy()
     expect(screen.getByText('Not mentioned')).toBeTruthy()
     expect(screen.getByText('Not cited')).toBeTruthy()
-    expect(screen.getByRole('combobox', { name: 'Query type' })).toHaveProperty('value', 'all')
+    expect(screen.getByRole('combobox', { name: 'Query type' })).toHaveProperty('value', 'non-brand')
     expect(screen.getByRole('combobox', { name: 'Answer engine' })).toHaveProperty('value', '')
     expect(screen.getByRole('combobox', { name: 'Search location' })).toHaveProperty('value', '')
     expect(screen.queryByText('0%')).toBeNull()
     expect(screen.getByRole('button', { name: 'View answers for apartments near transit · openai' })).toBeTruthy()
-    for (const key of ['queryClass', 'measurementScope', 'measurementScopeKey', 'measurementProvider', 'measurementModel', 'measurementLocation', 'measurementRevision', 'measurementFrom', 'measurementTo', 'measurementRunId', 'runId', 'evidenceId']) {
+    expect(currentSearch.queryClass).toBe('non-brand')
+    for (const key of ['measurementScope', 'measurementScopeKey', 'measurementProvider', 'measurementModel', 'measurementLocation', 'measurementRevision', 'measurementFrom', 'measurementTo', 'measurementRunId', 'runId', 'evidenceId']) {
       expect(currentSearch[key]).toEqual(initialSearch[key])
     }
     const expectedDetailParams = {
@@ -697,10 +754,10 @@ describe('shared production visibility view', () => {
     expect(Object.fromEntries(detailRequests[1]!.searchParams)).toMatchObject(expectedDetailParams)
     fireEvent.click(screen.getByRole('button', { name: 'Close answers' }))
     expect(screen.queryByRole('region', { name: 'Measured answers' })).toBeNull()
-    expect(screen.getByRole('combobox', { name: 'Query type' })).toHaveProperty('value', 'all')
+    expect(screen.getByRole('combobox', { name: 'Query type' })).toHaveProperty('value', 'non-brand')
     expect(screen.getByRole('combobox', { name: 'Answer engine' })).toHaveProperty('value', '')
     expect(screen.queryByText('0%')).toBeNull()
-    expect(Object.fromEntries(Object.entries(currentSearch).filter(([, value]) => value !== undefined))).toEqual(initialSearch)
+    expect(Object.fromEntries(Object.entries(currentSearch).filter(([, value]) => value !== undefined))).toEqual({ ...initialSearch, queryClass: 'non-brand' })
   })
 
   it('keeps an undisclosed-model drilldown exact while paging without paging the aggregate', async () => {
@@ -745,7 +802,7 @@ describe('shared production visibility view', () => {
     expect(await screen.findByText('Saved answer from beyond the first query page.')).toBeTruthy()
     const disclosures = [...view.container.querySelectorAll<HTMLDetailsElement>('details[data-query-results]')]
     expect(disclosures.map(details => [details.dataset.queryResults, details.open])).toEqual([
-      ['branded', false], ['non-brand', true], ['unknown', false],
+      ['non-brand', true],
     ])
     expect(document.activeElement?.textContent).toContain('Saved answer from beyond the first query page.')
   })

--- a/apps/web/test/visibility-report-view.test.tsx
+++ b/apps/web/test/visibility-report-view.test.tsx
@@ -807,6 +807,51 @@ describe('shared production visibility view', () => {
     expect(document.activeElement?.textContent).toContain('Saved answer from beyond the first query page.')
   })
 
+  it('waits for delayed branded evidence before normalizing an off-page query-only all-class link', async () => {
+    const aggregate = reportFixture()
+    aggregate.selection.queryClass = 'all'
+    aggregate.populations = (['branded', 'non-brand', 'unknown'] as const).map(queryClass => ({
+      ...aggregate.populations[0]!, queryClass,
+      queries: { items: [], total: 100, nextCursor: 'next-query-page' },
+      evidence: { items: [], total: 0, nextCursor: null },
+    }))
+    const brandedEvidence = reportWithAnswer('branded-off-page', 'Saved branded answer beyond the aggregate page.')
+    brandedEvidence.selection.queryClass = 'branded'
+    brandedEvidence.populations[0]!.queryClass = 'branded'
+    const requests: URL[] = []
+    let releaseEvidence: ((response: Response) => void) | undefined
+    const restore = mockFetch(url => {
+      const request = new URL(url)
+      requests.push(request)
+      if (!request.searchParams.has('queryKey')) {
+        const report = structuredClone(aggregate)
+        const queryClass = request.searchParams.get('queryClass') ?? 'all'
+        report.selection.queryClass = queryClass as VisibilityReportResponse['selection']['queryClass']
+        if (queryClass !== 'all') report.populations = report.populations.filter(population => population.queryClass === queryClass)
+        return jsonResponse(report)
+      }
+      if (request.searchParams.get('queryClass') === 'all') return new Promise<Response>(resolve => { releaseEvidence = resolve })
+      return jsonResponse(brandedEvidence)
+    })
+    onTestFinished(() => { releaseEvidence?.(jsonResponse(brandedEvidence)); restore() })
+    function Harness() {
+      const [search, setSearch] = useState<Record<string, unknown>>({ queryClass: 'all', measurementQueryKey: 'branded-off-page' })
+      return <VisibilityWorkspace key={String(search.queryClass ?? 'all')} projectName="demo" selection={parseVisibilitySelection(search)} onSelectionChange={patch => setSearch(previous => patchVisibilitySelection(previous, patch))} />
+    }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(<QueryClientProvider client={queryClient}><Harness /></QueryClientProvider>)
+    await waitFor(() => expect(requests.some(request => request.searchParams.has('queryKey') && request.searchParams.get('queryClass') === 'all')).toBe(true))
+    await new Promise(resolve => setTimeout(resolve, 25))
+    expect(requests.filter(request => !request.searchParams.has('queryKey')).map(request => request.searchParams.get('queryClass'))).toEqual(['all'])
+
+    releaseEvidence!(jsonResponse(brandedEvidence))
+    await waitFor(() => expect(requests.filter(request => !request.searchParams.has('queryKey')).map(request => request.searchParams.get('queryClass'))).toEqual(['all', 'branded']))
+    expect(await screen.findByRole('region', { name: 'Branded queries', exact: true })).toBeTruthy()
+    await waitFor(() => expect(requests.some(request => request.searchParams.has('queryKey') && request.searchParams.get('queryClass') === 'branded')).toBe(true))
+    expect(await screen.findByText('Saved branded answer beyond the aggregate page.')).toBeTruthy()
+    expect(screen.queryByRole('region', { name: 'Non-brand queries', exact: true })).toBeNull()
+  })
+
   it('keeps the report available when an answer request fails and retries only the detail', async () => {
     const requests: URL[] = []
     let failEvidence = true

--- a/apps/web/test/visibility-selection-url.test.ts
+++ b/apps/web/test/visibility-selection-url.test.ts
@@ -47,6 +47,17 @@ describe('shared visibility selection URL', () => {
     expect(parseVisibilitySelection(validateSearch(search))).toMatchObject({ queryClass: 'all', provider: 'openai', queryKey: 'query-1', answer })
   })
 
+  it('retains an exact answer context when class normalization supplies it, while an ordinary class change clears it', () => {
+    const answer = { queryKey: 'query-1', queryClass: 'branded', provider: 'gemini', model: null, location: null, runId: 'run-2', revision: 2 }
+    const search = { queryClass: 'all', measurementQueryKey: 'query-1', measurementAnswer: JSON.stringify(answer) }
+    expect(patchVisibilitySelection(search, {
+      queryClass: 'branded', measurementQueryKey: 'query-1', measurementAnswer: JSON.stringify(answer),
+    })).toMatchObject({ queryClass: 'branded', measurementQueryKey: 'query-1', measurementAnswer: JSON.stringify(answer) })
+    expect(patchVisibilitySelection(search, { queryClass: 'non-brand' })).toMatchObject({
+      queryClass: 'non-brand', measurementQueryKey: undefined, measurementAnswer: undefined,
+    })
+  })
+
   it.each([
     '{', 'null', '[]', JSON.stringify({ queryKey: 'other' }),
     ...[

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.188.0",
+  "version": "4.188.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.188.0",
+  "version": "4.188.1",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.188.0",
+  "version": "4.188.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.188.0",
+  "version": "4.188.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.188.0",
+  "version": "4.188.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Context
The AI visibility overview rendered three complete reports when Query type was All queries. This made the page look duplicated even though each section represented a different query class.

## Changes
Use the existing Query type dropdown to display one report at a time. Default to Non-brand when measured history exists, with Branded and older Unclassified history remaining accessible. Preserve saved-answer links, including older query-only links outside the first page, and align the URL and competitor filters with the displayed class. Apply the shared chart tooltip theme so dates remain readable. Release version: 4.188.1.

## Validation
144 focused report, URL, and project-route tests pass; trend tests also pass, along with web typecheck, changed-file lint, and generated-client/plugin drift checks. Browser verification against a local copy of saved data confirms one report, working Branded/Non-brand switching, a readable dark tooltip, and a 390px page without horizontal overflow on mobile load. No measurement jobs were started.
