### PR TITLE
fix(dashboard): show baseline sparklines and speed up report reads

### DIFF
--- a/apps/web/src/components/shared/Sparkline.tsx
+++ b/apps/web/src/components/shared/Sparkline.tsx
@@ -36,12 +36,9 @@ export function Sparkline({ points, tone }: { points: number[]; tone: MetricTone
   const plotHeight = innerHeight - GUIDE_GAP
   const xOf = (index: number): number => padding + (index / Math.max(points.length - 1, 1)) * innerWidth
 
-  // Below the meaningful-sample floor the line is still DRAWN — a portfolio row
-  // without a chart loses the shape a reader scans for — but drawn dashed, so
-  // the sample size is visible in the mark itself rather than only in a caption
-  // nobody reads. Suppressing it entirely was the first attempt and it removed
-  // the graph, which is the wrong trade: the honest fix for an over-dramatic
-  // line is scaling it truthfully, not deleting it.
+  // Below the meaningful-sample floor the graph stays visible. A single
+  // baseline is a point; otherwise the line is dashed, so a reader does not
+  // mistake the first measurement for a trend.
   const provisional = isTrendBaseline(points)
 
   const min = Math.min(...points)
@@ -50,9 +47,10 @@ export function Sparkline({ points, tone }: { points: number[]; tone: MetricTone
   // of the box rather than being stretched across it.
   const span = Math.max(max - min, MIN_SPAN)
   const low = (max + min) / 2 - span / 2
-  const coordinates = points
-    .map((point, index) => `${xOf(index)},${padding + (1 - (point - low) / span) * plotHeight}`)
-    .join(' ')
+  const coordinates = points.map((point, index) => ({
+    x: xOf(index),
+    y: padding + (1 - (point - low) / span) * plotHeight,
+  }))
 
   return (
     <svg
@@ -66,7 +64,20 @@ export function Sparkline({ points, tone }: { points: number[]; tone: MetricTone
         </clipPath>
       </defs>
       <line className="sparkline-guide" x1={padding} x2={width - padding} y1={height - padding} y2={height - padding} />
-      <polyline clipPath={`url(#${clipId})`} points={coordinates} vectorEffect="non-scaling-stroke" />
+      {coordinates.length === 1 ? (
+        <circle
+          className="sparkline-point"
+          cx={coordinates[0]!.x}
+          cy={coordinates[0]!.y}
+          r="3"
+        />
+      ) : (
+        <polyline
+          clipPath={`url(#${clipId})`}
+          points={coordinates.map(point => `${point.x},${point.y}`).join(' ')}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
     </svg>
   )
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2003,10 +2003,25 @@
     stroke: var(--chart-tone-neutral);
   }
 
+  .sparkline-positive .sparkline-point {
+    fill: var(--chart-tone-positive);
+  }
+
+  .sparkline-caution .sparkline-point {
+    fill: var(--chart-tone-caution);
+  }
+
+  .sparkline-negative .sparkline-point {
+    fill: var(--chart-tone-negative);
+  }
+
+  .sparkline-neutral .sparkline-point {
+    fill: var(--chart-tone-neutral);
+  }
+
   /*
-   * Fewer readings than a trend needs. The line is still drawn — a portfolio row
-   * without a chart loses the shape a reader scans for — but dashed, so the
-   * sample size shows in the mark instead of only in a caption.
+   * Fewer readings than a trend needs. A single reading is a point; otherwise
+   * the line is dashed so the mark does not imply a fuller sample.
    */
   .sparkline-provisional polyline {
     stroke-dasharray: 3 3;

--- a/apps/web/test/sparkline.test.tsx
+++ b/apps/web/test/sparkline.test.tsx
@@ -18,6 +18,16 @@ function pointsOf(html: string): Array<{ x: number; y: number }> {
 }
 
 describe('Sparkline', () => {
+  it('renders one baseline measurement as a visible point, not a trend line', () => {
+    const html = renderToStaticMarkup(<Sparkline points={[73]} tone="positive" />)
+
+    expect(html).toContain('sparkline-provisional')
+    expect(html).toContain('<circle')
+    expect(html).toContain('class="sparkline-point"')
+    expect(html).not.toMatch(/<circle[^>]*clip-path=/)
+    expect(html).not.toContain('<polyline')
+  })
+
   it('still draws the line below the sample floor, but marks it provisional', () => {
     // The real series that prompted this: three runs, 11 of 16 queries mentioned
     // becoming 10. Suppressing the line entirely was the first attempt and it

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.188.2",
+  "version": "4.188.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/composites.ts
+++ b/packages/api-routes/src/composites.ts
@@ -47,6 +47,7 @@ import {
   type RunHistoryPointDto,
   type ScoreSummaryDto,
   escapeLikePattern,
+  extractDomainsFromText,
   normalizeQueryText,
   validationError,
 } from '@ainyc/canonry-contracts'
@@ -226,11 +227,21 @@ export async function compositeRoutes(app: FastifyInstance) {
 
     // Branded and non-brand never share a denominator: `buildMentionShare`
     // headlines the non-brand class and keeps branded beside it.
+    // The overview reads each stored answer for both current project identity
+    // and competitor signals. Keep prose-domain parsing local to this request
+    // and share it across those independent readers.
+    const answerDomainsByText = new Map<string, readonly string[]>()
+    for (const snapshot of trackedLatest) {
+      if (snapshot.answerText && !answerDomainsByText.has(snapshot.answerText)) {
+        answerDomainsByText.set(snapshot.answerText, extractDomainsFromText(snapshot.answerText))
+      }
+    }
     const mentionShareInputs = buildMentionShareInputs({
       project,
       competitorDomains: competitorRows.map(c => c.domain),
       snapshots: trackedLatest,
       queryTextById: queryLookup.byId,
+      answerDomainsByText,
     })
     const competitiveSignalResolver = compileCompetitiveSignalResolver(
       competitorRows.map(c => c.domain),
@@ -241,6 +252,7 @@ export async function compositeRoutes(app: FastifyInstance) {
         citedDomains: snapshot.citedDomains,
         groundingSources: snapshot.groundingSources,
         answerText: snapshot.answerText,
+        answerDomains: snapshot.answerText ? answerDomainsByText.get(snapshot.answerText) : undefined,
       }),
     }))
 

--- a/packages/api-routes/src/measurement-report.ts
+++ b/packages/api-routes/src/measurement-report.ts
@@ -421,27 +421,42 @@ function ownedBy(host: string, roots: readonly string[]): boolean {
   return roots.some(root => host === root || host.endsWith(`.${root}`))
 }
 
+interface CompiledTargetRoute {
+  targetId: string
+  url: MeasurementTargetUrlInput
+  path: string
+}
+
+function compiledTargetRoutes(targets: readonly MeasurementTargetInput[]): ReadonlyMap<string, CompiledTargetRoute[]> {
+  const routes = new Map<string, CompiledTargetRoute[]>()
+  for (const target of targets) {
+    for (const url of target.urls) {
+      const host = normalizedHost(url.host)
+      const path = url.mode === 'host' ? '' : normalizedPath(url.path)
+      const rows = routes.get(host) ?? []
+      rows.push({ targetId: target.id, url, path: url.pathCase === 'insensitive' ? path.toLocaleLowerCase('en') : path })
+      routes.set(host, rows)
+    }
+  }
+  return routes
+}
+
 function routeClaim(
   source: ParsedSourceUrl,
-  target: MeasurementTargetInput,
-  url: MeasurementTargetUrlInput,
+  route: CompiledTargetRoute,
 ): RouteClaim | null {
-  if (source.host !== normalizedHost(url.host)) return null
-  if (url.mode === 'host') return { targetId: target.id, urlId: url.id, modeRank: 1, pathLength: 0 }
+  const { targetId, url, path: matcherPath } = route
+  if (url.mode === 'host') return { targetId, urlId: url.id, modeRank: 1, pathLength: 0 }
 
-  const configuredPath = normalizedPath(url.path)
   const sourcePath = url.pathCase === 'insensitive'
     ? source.path.toLocaleLowerCase('en')
     : source.path
-  const matcherPath = url.pathCase === 'insensitive'
-    ? configuredPath.toLocaleLowerCase('en')
-    : configuredPath
   const matches = url.mode === 'exact'
     ? sourcePath === matcherPath
     : matcherPath === '/' || sourcePath === matcherPath || sourcePath.startsWith(`${matcherPath}/`)
   if (!matches) return null
   return {
-    targetId: target.id,
+    targetId,
     urlId: url.id,
     modeRank: url.mode === 'exact' ? 3 : 2,
     pathLength: matcherPath.length,
@@ -450,7 +465,7 @@ function routeClaim(
 
 function classifySourceAttribution(
   value: string,
-  targets: readonly MeasurementTargetInput[],
+  routes: ReadonlyMap<string, readonly CompiledTargetRoute[]>,
   normalizedOwnedHosts: readonly string[],
 ): SourceAttribution {
   const source = parseSourceUrl(value)
@@ -459,11 +474,9 @@ function classifySourceAttribution(
   }
 
   const claims: RouteClaim[] = []
-  for (const target of targets) {
-    for (const url of target.urls) {
-      const claim = routeClaim(source, target, url)
-      if (claim) claims.push(claim)
-    }
+  for (const route of routes.get(source.host) ?? []) {
+    const claim = routeClaim(source, route)
+    if (claim) claims.push(claim)
   }
   claims.sort((left, right) => (
     right.modeRank - left.modeRank
@@ -525,7 +538,7 @@ export function classifyCitedUrl(
   usageEdge: MeasurementUsageEdgeInput,
 ): MeasurementAttributionResult {
   return classifySourceForUsageEdge(
-    classifySourceAttribution(value, targets, ownedHosts.map(normalizedHost)),
+    classifySourceAttribution(value, compiledTargetRoutes(targets), ownedHosts.map(normalizedHost)),
     usageEdge,
   )
 }
@@ -572,16 +585,27 @@ function compiledMentionAliases(targets: readonly MeasurementTargetInput[]): Men
     .filter(alias => alias.words.length > 0)
 }
 
+function indexMentionAliases(aliases: readonly MentionAlias[]): ReadonlyMap<string, MentionAlias[]> {
+  const byFirstWord = new Map<string, MentionAlias[]>()
+  for (const alias of aliases) {
+    const firstWord = alias.words[0]!
+    const rows = byFirstWord.get(firstWord) ?? []
+    rows.push(alias)
+    byFirstWord.set(firstWord, rows)
+  }
+  return byFirstWord
+}
+
 function mentionedTargetsForAliases(
   answerText: string | null,
-  aliases: readonly MentionAlias[],
+  aliases: ReadonlyMap<string, readonly MentionAlias[]>,
 ): ReadonlySet<string> {
   const result = new Set<string>()
   if (answerText === null) return result
   const textWords = words(answerText)
 
   for (let start = 0; start < textWords.length;) {
-    const matches = aliases.filter(alias => aliasMatchesAt(textWords, alias.words, start))
+    const matches = (aliases.get(textWords[start]!) ?? []).filter(alias => aliasMatchesAt(textWords, alias.words, start))
     if (matches.length === 0) {
       start++
       continue
@@ -595,7 +619,7 @@ function mentionedTargetsForAliases(
 }
 
 function mentionedTargets(answerText: string | null, targets: readonly MeasurementTargetInput[]): ReadonlySet<string> {
-  return mentionedTargetsForAliases(answerText, compiledMentionAliases(targets))
+  return mentionedTargetsForAliases(answerText, indexMentionAliases(compiledMentionAliases(targets)))
 }
 
 /**
@@ -646,6 +670,7 @@ function prepareReport(
   // once avoids rescanning hundreds of Property names for every provider
   // answer while preserving the same longest/ambiguous matching algorithm.
   const mentionAliases = compiledMentionAliases(input.targets)
+  const aliasesByFirstWord = indexMentionAliases(mentionAliases)
 
   for (const observation of input.observations) {
     const slots = observation.executionId !== null
@@ -692,7 +717,7 @@ function prepareReport(
       historical: source.historical,
       sourceComplete: source.complete,
       sourceUrls: source.urls,
-      mentionedTargetIds: mentionedTargetsForAliases(observation.answerText, mentionAliases),
+      mentionedTargetIds: mentionedTargetsForAliases(observation.answerText, aliasesByFirstWord),
     })
   }
 
@@ -712,11 +737,13 @@ function prepareReport(
   // O(edges × targets × sources) read. The winners below are edge-independent;
   // only assigned vs sibling is projected per edge.
   const normalizedOwnedHosts = input.ownedHosts.map(normalizedHost)
+  // Host/path normalization belongs to the frozen definition, not each source.
+  const targetRoutes = compiledTargetRoutes(input.targets)
   const sourceAttributions = new Map<string, SourceAttribution>()
   const sourceAttribution = (sourceUrl: string): SourceAttribution => {
     const cached = sourceAttributions.get(sourceUrl)
     if (cached !== undefined) return cached
-    const resolved = classifySourceAttribution(sourceUrl, input.targets, normalizedOwnedHosts)
+    const resolved = classifySourceAttribution(sourceUrl, targetRoutes, normalizedOwnedHosts)
     sourceAttributions.set(sourceUrl, resolved)
     return resolved
   }

--- a/packages/api-routes/src/mention-share-inputs.ts
+++ b/packages/api-routes/src/mention-share-inputs.ts
@@ -5,6 +5,7 @@ import {
   determineAnswerMentioned,
   effectiveBrandNames,
   effectiveDomains,
+  extractDomainsFromText,
   hostOf,
   surfaceClassFromCompetitorType,
   MIN_DOMAIN_BRAND_KEY_LENGTH,
@@ -128,6 +129,8 @@ export function buildMentionShareInputs(opts: {
   competitorDomains: readonly string[]
   snapshots: readonly MentionShareSnapshotRow[]
   queryTextById?: ReadonlyMap<string, string>
+  /** Request-scoped cache shared with other answer-prose readers. */
+  answerDomainsByText?: Map<string, readonly string[]>
 }): MentionShareInputs {
   const classify = projectQueryClassifier(opts.project)
   const projectBrandNames = effectiveBrandNames({
@@ -145,12 +148,19 @@ export function buildMentionShareInputs(opts: {
     competitors: mentionShareCompetitorsFromDomains(opts.competitorDomains),
     snapshots: opts.snapshots.map(snap => {
       const queryText = (snap.queryId ? opts.queryTextById?.get(snap.queryId) : undefined) ?? snap.queryText ?? null
+      const cachedAnswerDomains = !snap.answerText || !opts.answerDomainsByText
+        ? undefined
+        : opts.answerDomainsByText.get(snap.answerText) ?? (() => {
+            const domains = extractDomainsFromText(snap.answerText)
+            opts.answerDomainsByText!.set(snap.answerText!, domains)
+            return domains
+          })()
       return {
         // Mention share is a current-identity metric. Recompute stored answer
         // text after an alias/domain rename; only text-less legacy rows need
         // the persisted run-time boolean as a fallback.
         projectMentioned: snap.answerText
-          ? determineAnswerMentioned(snap.answerText, projectBrandNames, projectDomains)
+          ? determineAnswerMentioned(snap.answerText, projectBrandNames, projectDomains, cachedAnswerDomains)
           : snap.answerMentioned === true,
         answerText: snap.answerText,
         queryClass: classify ? classify(queryText) : null,

--- a/packages/api-routes/src/visibility-report.ts
+++ b/packages/api-routes/src/visibility-report.ts
@@ -20,6 +20,7 @@ import {
   measurementV2UsageEdgeKey,
   normalizeMeasurementHost,
   parseStoredMeasurementPlanAnyVersion,
+  prepareBrandMatchText,
   validationError,
   visibilityReportQuerySchema,
   visibilityReportResponseSchema,
@@ -170,10 +171,11 @@ function exactCompetitorMatchers(plan: MeasurementPlanV2): Map<string, ReturnTyp
 function competitorSignals(
   snapshot: Pick<VisibilitySnapshot, 'answerText' | 'citedDomains'>,
   matchers: ReadonlyMap<string, ReturnType<typeof compileBrandAliases>>,
+  preparedAnswerText = prepareBrandMatchText(snapshot.answerText),
 ): { mentioned: string[]; cited: string[] } {
-  const mentioned = snapshot.answerText === null
+  const mentioned = preparedAnswerText === null
     ? []
-    : [...matchers].filter(([, matcher]) => matcherMatchesText(matcher, snapshot.answerText)).map(([domain]) => domain)
+    : [...matchers].filter(([, matcher]) => matcherMatchesText(matcher, preparedAnswerText)).map(([domain]) => domain)
   const citedDomains = new Set(snapshot.citedDomains.map(value => {
     try {
       return normalizeMeasurementHost(value)
@@ -459,12 +461,13 @@ function frozenSimpleRun(
     }
     const slotId = `slot:simple:${query.queryId}:${provider}`
     if (!slotKeys.has(slotId)) throw new Error(`Frozen simple definition has no slot for stored snapshot ${snapshot.id}`)
+    const preparedAnswerText = prepareBrandMatchText(snapshot.answerText)
     const mentioned = snapshot.answerText !== null
-      ? matcherMatchesText(matcher, snapshot.answerText)
+      ? matcherMatchesText(matcher, preparedAnswerText)
       : snapshot.answerMentioned === true
     const competitorSignalsForSnapshot = competitors === null
       ? { mentioned: [], cited: [] }
-      : competitorSignals(snapshot, competitors)
+      : competitorSignals(snapshot, competitors, preparedAnswerText)
     observations.push({
       slotId,
       answerId: snapshot.id,

--- a/packages/api-routes/test/measurement-report.test.ts
+++ b/packages/api-routes/test/measurement-report.test.ts
@@ -5,6 +5,7 @@ import {
   buildMeasurementReport,
   classifyCitedUrl,
   normalizeMeasurementLocation,
+  targetMentionedInAnswer,
   type MeasurementOverviewBuildOptions,
   type MeasurementOverviewInput,
   type MeasurementReportInput,
@@ -418,6 +419,36 @@ describe('report kernel', () => {
     expect(report.targets.find(target => target.id === 'north')?.mentionCoverage).toEqual({ numerator: 1, denominator: 1, rate: 1 })
     expect(report.targets.find(target => target.id === 'aliasless')?.mentionCoverage)
       .toEqual({ numerator: null, denominator: null, rate: null, reason: 'aliasless' })
+  })
+
+  it('keeps shared first-word aliases longest, Unicode-normalized, and ambiguity-aware', () => {
+    const mentionTargets: MeasurementTargetInput[] = [
+      { id: 'short', label: 'Short', aliases: ['Northstar'], urls: [] },
+      { id: 'long-a', label: 'Long A', aliases: ['Northstar Harbor'], urls: [] },
+      { id: 'long-b', label: 'Long B', aliases: ['NORTHSTAR-HARBOR'], urls: [] },
+      { id: 'inner', label: 'Inner', aliases: ['Harbor'], urls: [] },
+      { id: 'unique', label: 'Unique', aliases: ['Northstar North', 'northstar north'], urls: [] },
+    ]
+    const answer = 'Ｎｏｒｔｈｓｔａｒ Harbor and Northstar North.'
+    expect(mentionTargets.map(target => targetMentionedInAnswer(answer, target.id, mentionTargets)))
+      .toEqual([false, false, false, false, true])
+    expect(targetMentionedInAnswer('Northstar Harbor. Harbor.', 'inner', mentionTargets)).toBe(true)
+  })
+
+  it('rebuilds alias and route indexes for each frozen definition', () => {
+    const input = baseInput()
+    const original = buildMeasurementReport(input)
+    const changed = buildMeasurementReport({
+      ...input,
+      targets: input.targets.map(target => ({
+        ...target,
+        aliases: ['Unmentioned replacement'],
+        urls: target.urls.map(url => ({ ...url, host: 'replacement.example' })),
+      })),
+    })
+    expect(changed.targets.find(target => target.id === 'harbor')?.mentionCoverage.rate).toBe(0)
+    expect(changed.targets.find(target => target.id === 'harbor')?.citationCoverage.rate).toBe(0)
+    expect(buildMeasurementReport(input)).toEqual(original)
   })
 
   it('is deterministic when plan and observation collections are reordered', () => {

--- a/packages/api-routes/test/mention-share-inputs.test.ts
+++ b/packages/api-routes/test/mention-share-inputs.test.ts
@@ -17,6 +17,20 @@ describe('mention-share input identity', () => {
     expect(inputs.snapshots.map(snapshot => snapshot.projectMentioned)).toEqual([true, false, true])
   })
 
+  it('accepts request-scoped prose domains without changing project mentions', () => {
+    const answerDomainsByText = new Map<string, readonly string[]>()
+    const answerText = 'See https://www.acme.com/pricing for details.'
+    const inputs = buildMentionShareInputs({
+      project: { displayName: 'Acme', canonicalDomain: 'acme.com' },
+      competitorDomains: [],
+      snapshots: [{ queryText: 'pricing', answerMentioned: false, answerText }],
+      answerDomainsByText,
+    })
+
+    expect(inputs.snapshots[0]!.projectMentioned).toBe(true)
+    expect(answerDomainsByText.get(answerText)).toEqual(['acme.com'])
+  })
+
   it('counts an exact short competitor domain without counting its bare label', () => {
     const competitors = mentionShareCompetitorsFromDomains(['https://www.ai.com/pricing'])
     expect(competitors[0]!.brandTokens).toEqual(['ai.com'])

--- a/packages/api-routes/test/visibility-report.test.ts
+++ b/packages/api-routes/test/visibility-report.test.ts
@@ -349,6 +349,17 @@ describe('visibility report route', () => {
     expect(unknown.observedCompetitors).toEqual([{ name: 'Observed Alternative', answerCount: 1 }])
   })
 
+  it('treats an empty frozen Simple answer as a measured non-mention', async () => {
+    seedSimpleRun('simple-empty-answer', SECOND, true)
+    db.update(querySnapshots).set({ answerText: '', answerMentioned: true })
+      .where(eq(querySnapshots.runId, 'simple-empty-answer')).run()
+
+    const result = await report('mode=simple&runId=simple-empty-answer&queryClass=non-brand')
+    expect(result.status).toBe(200)
+    expect((result.body as VisibilityReportResponse).populations[0]!.summary.mentionCoverage)
+      .toEqual({ numerator: 0, denominator: 1, rate: 0 })
+  })
+
   it('compares semantically identical frozen simple captures and breaks only at a requested-model change', async () => {
     seedSimpleRun('simple-first', FIRST, true)
     seedSimpleRun('simple-second', SECOND, true)

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.188.2",
+  "version": "4.188.3",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/answer-visibility.ts
+++ b/packages/contracts/src/answer-visibility.ts
@@ -19,17 +19,18 @@ export function extractAnswerMentions(
   answerText: string | null | undefined,
   brandNames: string[],
   domains: string[],
+  answerDomains?: readonly string[],
 ): AnswerMentionResult {
   if (!answerText) return { mentioned: false, matchedTerms: [] }
 
   const matchedTerms: string[] = []
   const matchedDomainTerms = new Set<string>()
-  const answerDomains = extractDomainsFromText(answerText)
+  const extractedAnswerDomains = answerDomains ?? extractDomainsFromText(answerText)
 
   for (const domain of domains) {
     const normalizedDomain = hostOf(domain)
     if (!normalizedDomain || !normalizedDomain.includes('.')) continue
-    if (answerDomains.some(candidate => hostMatchesDomain(candidate, normalizedDomain))) {
+    if (extractedAnswerDomains.some(candidate => hostMatchesDomain(candidate, normalizedDomain))) {
       matchedTerms.push(normalizedDomain)
       matchedDomainTerms.add(normalizedDomain)
     }
@@ -85,8 +86,9 @@ export function determineAnswerMentioned(
   answerText: string | null | undefined,
   brandNames: string[],
   domains: string[],
+  answerDomains?: readonly string[],
 ): boolean {
-  return extractAnswerMentions(answerText, brandNames, domains).mentioned
+  return extractAnswerMentions(answerText, brandNames, domains, answerDomains).mentioned
 }
 
 export function visibilityStateFromAnswerMentioned(answerMentioned: boolean | null | undefined): VisibilityState {

--- a/packages/contracts/src/brand-matching.ts
+++ b/packages/contracts/src/brand-matching.ts
@@ -120,6 +120,35 @@ export interface BrandAliasMatcher {
 }
 
 /**
+ * One answer's normalized representation, reusable across brand matchers.
+ *
+ * Competitor reporting checks the same answer against several independently
+ * compiled identities. Keep the normalization and word walk with the answer,
+ * while each matcher retains its own exact alias set.
+ */
+export interface PreparedBrandMatchText {
+  readonly normalized: string
+  readonly stripped: string
+}
+
+const wordsByPreparedText = new WeakMap<PreparedBrandMatchText, string[]>()
+
+/** Normalize an answer once before checking it against several matchers. */
+export function prepareBrandMatchText(text: string | null | undefined): PreparedBrandMatchText | null {
+  if (!text) return null
+  const normalized = normalizeForMatch(text)
+  return { normalized, stripped: normalized.replace(NON_WORD, '') }
+}
+
+function wordsOfPreparedText(prepared: PreparedBrandMatchText): string[] {
+  const cached = wordsByPreparedText.get(prepared)
+  if (cached) return cached
+  const words = wordsOfNormalized(prepared.normalized)
+  wordsByPreparedText.set(prepared, words)
+  return words
+}
+
+/**
  * Compile approved aliases into a reusable matcher.
  *
  * Exposed rather than hidden because the shape of the work is one alias list
@@ -160,22 +189,22 @@ export function compileBrandAliases(aliases: readonly string[]): BrandAliasMatch
  */
 export function matcherMatchesText(
   matcher: BrandAliasMatcher,
-  text: string | null | undefined,
+  text: string | PreparedBrandMatchText | null | undefined,
 ): boolean {
   if (!text || matcher.keys.size === 0) return false
-  const normalized = normalizeForMatch(text)
+  const prepared = typeof text === 'string' ? prepareBrandMatchText(text) : text
+  if (!prepared) return false
 
-  const stripped = normalized.replace(NON_WORD, '')
   let possible = false
   for (const key of matcher.keys) {
-    if (stripped.includes(key)) {
+    if (prepared.stripped.includes(key)) {
       possible = true
       break
     }
   }
   if (!possible) return false
 
-  const words = wordsOfNormalized(normalized)
+  const words = wordsOfPreparedText(prepared)
   for (let start = 0; start < words.length; start++) {
     let candidate = ''
     for (let end = start; end < words.length; end++) {
@@ -196,16 +225,16 @@ export function matcherMatchesText(
  */
 export function matchedAliasKeys(
   matcher: BrandAliasMatcher,
-  text: string | null | undefined,
+  text: string | PreparedBrandMatchText | null | undefined,
 ): Set<string> {
   const found = new Set<string>()
   if (!text || matcher.keys.size === 0) return found
-  const normalized = normalizeForMatch(text)
-  const stripped = normalized.replace(NON_WORD, '')
-  const reachable = [...matcher.keys].filter(key => stripped.includes(key))
+  const prepared = typeof text === 'string' ? prepareBrandMatchText(text) : text
+  if (!prepared) return found
+  const reachable = [...matcher.keys].filter(key => prepared.stripped.includes(key))
   if (reachable.length === 0) return found
 
-  const words = wordsOfNormalized(normalized)
+  const words = wordsOfPreparedText(prepared)
   for (let start = 0; start < words.length; start++) {
     let candidate = ''
     for (let end = start; end < words.length; end++) {

--- a/packages/contracts/test/brand-matching.test.ts
+++ b/packages/contracts/test/brand-matching.test.ts
@@ -5,6 +5,7 @@ import {
   compileBrandAliases,
   matchedAliasKeys,
   matcherMatchesText,
+  prepareBrandMatchText,
   textContainsBrandAlias,
   textContainsAnyBrandAlias,
 } from '../src/brand-matching.js'
@@ -73,6 +74,21 @@ describe('one segmentation for the whole alias set', () => {
     for (const text of ['Demand IQ rocks', 'nothing', 'the Gjelina Hotel']) {
       expect(matcherMatchesText(matcher, text)).toBe(textContainsAnyBrandAlias(text, aliases))
     }
+  })
+
+  it('reuses one prepared answer across competitor matchers without changing matches', () => {
+    const answer = 'Totême works with Demand-IQ; acmeology is unrelated.'
+    const prepared = prepareBrandMatchText(answer)
+    const matchers = [
+      compileBrandAliases(['Toteme']),
+      compileBrandAliases(['Demand IQ']),
+      compileBrandAliases(['Acme']),
+    ]
+
+    expect(prepared).not.toBeNull()
+    expect(matchers.map(matcher => matcherMatchesText(matcher, prepared)))
+      .toEqual(matchers.map(matcher => matcherMatchesText(matcher, answer)))
+    expect(matchers.map(matcher => matcherMatchesText(matcher, prepared))).toEqual([true, true, false])
   })
 
   it('reports every alias that matched, not just the first', () => {

--- a/packages/intelligence/src/competitive-signals.ts
+++ b/packages/intelligence/src/competitive-signals.ts
@@ -17,6 +17,8 @@ export interface CompetitiveSignalEvidence {
   citedDomains?: readonly string[]
   groundingSources?: readonly CompetitiveSignalSource[]
   answerText?: string | null
+  /** Request-scoped prose-domain result, when another reader already has it. */
+  answerDomains?: readonly string[]
 }
 
 /**
@@ -78,7 +80,7 @@ export function compileCompetitiveSignalResolver(
         ...(evidence.citedDomains ?? []),
         ...(evidence.groundingSources ?? []).map(source => source.uri),
       ]
-      const answerDomains = extractDomainsFromText(evidence.answerText)
+      const answerDomains = evidence.answerDomains ?? extractDomainsFromText(evidence.answerText)
       const mentionedBrandKeys = matchedAliasKeys(domainBrandMatcher, evidence.answerText)
       const citedCompetitorDomains: string[] = []
       const mentionedCompetitorDomains: string[] = []

--- a/packages/intelligence/test/competitive-signals.test.ts
+++ b/packages/intelligence/test/competitive-signals.test.ts
@@ -31,6 +31,14 @@ describe('compileCompetitiveSignalResolver', () => {
     })
   })
 
+  it('keeps supplied prose domains equivalent to ordinary extraction', () => {
+    const answerText = 'Read https://www.rival.com/review before deciding.'
+    const ordinary = resolver.resolve({ answerText })
+    const reused = resolver.resolve({ answerText, answerDomains: ['www.rival.com'] })
+
+    expect(reused).toEqual(ordinary)
+  })
+
   it('recognizes an exact short domain without treating its generic label as identity', () => {
     const short = compileCompetitiveSignalResolver(['ai.com'])
 

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.188.2",
+  "version": "4.188.3",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.188.2",
+  "version": "4.188.3",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.188.2",
+  "version": "4.188.3",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Context

A project with one completed sweep displayed an empty sparkline because a single SVG polyline coordinate has no visible segment. Portfolio report reads also repeatedly normalized answer text and target URL rules across thousands of observations, delaying both initial loading and filter changes.

Render a single measurement as a fully visible semantic-color point. Reuse prepared answer text and extracted domains within each request, index property aliases by their first word, and compile normalized URL routes once per frozen report definition. Existing matching, ambiguity, null evidence, and frozen-definition semantics are preserved. Release version: 4.188.3.

## Validation

- A read-only local replay of 932 queries across three providers produced identical full JSON responses for overview, branded, non-brand, and subgroup reports before and after the change.
- Across three passes, median overview latency fell from 7.60s to 1.90s; report medians fell from 6.20–10.52s to 1.10–1.21s. These are local measurements, not deployment latency guarantees.
- 110 focused API tests, 1,189 contracts tests, 6 competitive-signal tests, and 6 sparkline tests passed. Regression coverage includes Unicode/ambiguous aliases, per-definition index rebuilding, reusable domain matching, and empty saved answers with a legacy positive flag.
- Changed-file lint, all four affected package typechecks, production web build, and generated-artifact checks passed.
- Browser checked the built UI at desktop and mobile sizes: visible baseline point, no clipping, no JavaScript errors.

No provider jobs or measurement-data changes were needed.
