### PR TITLE
perf(web): load project tabs independently

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -470,22 +470,13 @@ export function RootLayout() {
         : undefined)
     : undefined
 
-  // Evidence lookup spans two data sources because `useDashboard()` here is
-  // the slim portfolio hook — its per-project `visibilityEvidence` is
-  // intentionally empty (see use-dashboard-overview.ts). The full evidence
-  // list is only built by `useProjectDashboard`, which the ProjectPage uses
-  // to render the table whose "View" button writes `?evidenceId=…` into the
-  // URL. Without this second lookup the modal silently never opens on a
-  // project route.
-  //
-  // Subscribing to `useProjectDashboard` here is free in steady state — its
-  // query keys overlap with ProjectPage's, so React Query dedupes the
-  // fetches via the shared cache.
+  // The slim portfolio model has no answer evidence. Load it only while a
+  // drawer is requested; an idle shell must not start the full history read.
   const currentProjectName = useMemo(
     () => resolveProjectNameFromPathname(location.pathname, safeDashboard),
     [location.pathname, safeDashboard],
   )
-  const { commandCenter: currentProjectCommandCenter } = useProjectDashboard(currentProjectName)
+  const { commandCenter: currentProjectCommandCenter, evidenceLoading, evidenceError, isError: evidenceProjectError, refetch: refetchEvidence } = useProjectDashboard(evidenceId ? currentProjectName : null, { evidence: true })
 
   const selectedEvidenceContext = useMemo(() => {
     if (!evidenceId) return undefined
@@ -1063,6 +1054,18 @@ export function RootLayout() {
         </Drawer>
       ) : null}
 
+      {evidenceId && !selectedEvidenceContext ? (
+        <Drawer open title={evidenceLoading ? 'Loading answer' : 'Answer unavailable'} subtitle="Query evidence" onClose={closeDrawer}>
+          {evidenceLoading ? (
+            <p role="status" className="text-sm text-secondary">Loading answer…</p>
+          ) : (
+            <>
+              <p role="alert" className="text-sm text-secondary">{evidenceError || evidenceProjectError ? 'Could not load this answer.' : 'This answer is not in the available query evidence.'}</p>
+              <Button type="button" variant="outline" onClick={() => { void refetchEvidence() }}>Retry</Button>
+            </>
+          )}
+        </Drawer>
+      ) : null}
       {selectedEvidenceContext ? (
         <EvidenceDetailModal evidence={selectedEvidenceContext.evidence} project={selectedEvidenceContext.project} onClose={closeDrawer} />
       ) : null}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -315,6 +315,8 @@ export function RootLayout() {
   // ── Data fetching via TanStack Query ──
   const { dashboard, isLoading, refetch: refreshData } = useDashboard(undefined, {
     includeSettings: !embed,
+    // The sidebar needs project identities; each page owns its analytics.
+    includeOverviews: false,
     pauseProjectPolling: location.pathname === '/setup',
   })
   const enableLiveStatus = !contextDashboard

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -3031,11 +3031,20 @@ function ProjectPageContent({
           />)}
           {!isSimpleOverview && visibilitySelection.measurementScope === 'project' ? <details className="page-section-divider">
             <summary className="min-h-11 cursor-pointer py-3 text-sm font-medium text-heading">Project signals</summary>
-            <OverviewSignals
-              insights={model.insights}
-              suggestedQueries={model.suggestedQueries}
-              onManageQueries={!isEmbed() ? () => { void navigate({ to: '/projects/$projectName/queries', params: { projectName }, search: previous => ({ ...previous, queryWorkspace: 'tracked', trackingQueryId: undefined }) }) } : undefined}
-            />
+            {overviewLoading ? (
+              <p role="status" className="text-sm text-secondary">Loading project signals…</p>
+            ) : overviewError ? (
+              <div role="alert" className="text-sm text-secondary">
+                <p>Could not load project signals.</p>
+                <Button type="button" variant="outline" onClick={() => { void refetch() }}>Retry</Button>
+              </div>
+            ) : (
+              <OverviewSignals
+                insights={model.insights}
+                suggestedQueries={model.suggestedQueries}
+                onManageQueries={!isEmbed() ? () => { void navigate({ to: '/projects/$projectName/queries', params: { projectName }, search: previous => ({ ...previous, queryWorkspace: 'tracked', trackingQueryId: undefined }) }) } : undefined}
+              />
+            )}
           </details> : null}
           {competitorLandscapeReadEnabled ? (
             <details className="page-section-divider">

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -113,6 +113,7 @@ import { invalidateProjectQueryDomain } from '../queries/query-invalidation.js'
 import { keepPreviousData, useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query'
 import { getApiV1ProjectsOptions } from '@ainyc/canonry-api-client/react-query'
 import { useProjectDashboard } from '../queries/use-project-dashboard.js'
+import { STATIC_VISIBILITY_STALE_MS } from '../queries/query-client.js'
 import { useCompetitorLandscapeRefresh } from '../queries/competitor-landscape-refresh.js'
 import { useInitialDashboard } from '../contexts/dashboard-context.js'
 import { useAccount } from '../contexts/account-context.js'
@@ -1440,13 +1441,18 @@ export function ProjectPage(props: { tab: ProjectPageTab }) {
   const lookupProjectName = nameFromContext
     ?? projectsListQuery.data?.find(p => p.name === routeIdentifier || p.id === routeIdentifier)?.name
     ?? null
+  const embed = getEmbedConfig()
+  const resolvedTab = resolveEmbedProjectTab(props.tab, embed ? filterEmbedProjectTabs(embed.projectTabs) : undefined)
   const {
     commandCenter: model,
     isLoading: dashboardLoading,
+    overviewLoading,
+    overviewError,
+    isError: dashboardError,
     latestVisibilityRevision,
     competitorHistoryRevision,
     refetch,
-  } = useProjectDashboard(lookupProjectName)
+  } = useProjectDashboard(lookupProjectName, { overview: resolvedTab === 'overview' })
   const isLoading = (!nameFromContext && projectsListQuery.isLoading) || dashboardLoading
 
   // Not-found state: both context and the projects-list query resolved
@@ -1470,6 +1476,13 @@ export function ProjectPage(props: { tab: ProjectPageTab }) {
         </Card>
       </div>
     )
+  }
+
+  if (!model && (dashboardError || projectsListQuery.isError)) {
+    return <div className="page-container" role="alert">
+      <p>Could not load this project.</p>
+      <Button type="button" variant="outline" onClick={() => { void Promise.all([projectsListQuery.refetch(), refetch()]) }}>Retry</Button>
+    </div>
   }
 
   if (!model || isLoading) {
@@ -1504,6 +1517,8 @@ export function ProjectPage(props: { tab: ProjectPageTab }) {
     refetch={refetch}
     latestVisibilityRevision={latestVisibilityRevision}
     competitorHistoryRevision={competitorHistoryRevision}
+    overviewLoading={overviewLoading}
+    overviewError={overviewError}
     {...props}
   />
 }
@@ -1718,12 +1733,16 @@ function ProjectPageContent({
   refetch,
   latestVisibilityRevision,
   competitorHistoryRevision,
+  overviewLoading,
+  overviewError,
 }: {
   tab: ProjectPageTab
   model: ProjectCommandCenterVm
   refetch: () => Promise<void>
   latestVisibilityRevision: string
   competitorHistoryRevision: string
+  overviewLoading: boolean
+  overviewError: boolean
 }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
@@ -1856,7 +1875,6 @@ function ProjectPageContent({
   }, [navigate])
   const [hasExpandedAdvancedProperty, setHasExpandedAdvancedProperty] = useState(false)
 
-  const visibilityEvidence = model?.visibilityEvidence ?? []
   const projectLabel = model?.project.displayName || model?.project.name || projectName
   const triggerRunMutation = useTriggerRun()
   const portfolioQueriesQuery = useQuery({
@@ -2004,6 +2022,18 @@ function ProjectPageContent({
     measurementSetupQuery.data === undefined
     && activeMeasurementPlanQuery.data === undefined
     && (activeMeasurementPlanQuery.isLoading || measurementSetupQuery.isLoading)
+  const needsSimpleEvidence = tab === 'overview' && isSimpleOverview && !isMeasurementModeUnresolved
+  const evidenceDashboard = useProjectDashboard(projectName, { evidence: needsSimpleEvidence })
+  const visibilityEvidence = evidenceDashboard.commandCenter?.visibilityEvidence ?? model.visibilityEvidence
+  // Other tabs still expose the admin sweep control. Its readiness needs the
+  // tracked basket, but never answer bodies or historical run detail.
+  const needsHeaderQueries = canWrite && !isEmbed() && !isDashboardManagedSweeps() && tab !== 'overview'
+  const headerQueriesQuery = useQuery({
+    ...getApiV1ProjectsByNameQueriesOptions({ client: heyClient, path: { name: projectName } }),
+    enabled: needsHeaderQueries,
+    staleTime: STATIC_VISIBILITY_STALE_MS,
+    refetchOnWindowFocus: 'always',
+  })
   // Advanced competitor reads are explicit. A market keeps its frozen market
   // identities AND the project pins that the stored-evidence API unions into
   // its denominator. All markets is a separate raw-evidence aggregate, never
@@ -2207,16 +2237,17 @@ function ProjectPageContent({
     () => [...new Set(visibilityEvidence.map(e => e.query))].sort((a, b) => a.localeCompare(b)),
     [visibilityEvidence],
   )
-  const hasTrackedQueries = trackedQueries.length > 0 || model.queryCounts.total > 0
+  const hasTrackedQueries = trackedQueries.length > 0 || model.queryCounts.total > 0 || (headerQueriesQuery.data?.length ?? 0) > 0
   const hasMeasurementPlanQueries = activeMeasurementPlan !== null
   const hasVisibilityInputs = hasTrackedQueries || hasMeasurementPlanQueries
   const visibilityInputsPending = canWrite
-    && !hasTrackedQueries
-    && activeMeasurementPlanQuery.data === undefined
-    && activeMeasurementPlanQuery.isPending
-  const providerReadinessFailed = canWrite
-    && measurementSetupQuery.isError
-    && !measurementSetupQuery.isFetching
+    && !hasVisibilityInputs
+    && ((activeMeasurementPlanQuery.data === undefined && activeMeasurementPlanQuery.isPending)
+      || headerQueriesQuery.isLoading || (needsSimpleEvidence && evidenceDashboard.evidenceLoading))
+  const providerReadinessFailed = canWrite && (
+    (measurementSetupQuery.isError && !measurementSetupQuery.isFetching)
+    || (needsHeaderQueries && headerQueriesQuery.isError && !headerQueriesQuery.isFetching)
+  )
   const sweepReadinessPending = canWrite
     && !providerReadinessFailed
     && (visibilityInputsPending
@@ -2256,7 +2287,7 @@ function ProjectPageContent({
   }, [locationLabelsInEvidence, configuredLocationLabels])
 
   useEffect(() => {
-    if (locationFilter === undefined || locationFilter === '' || !projectName) {
+    if (!needsSimpleEvidence || locationFilter === undefined || locationFilter === '' || !projectName) {
       setLocationTimeline(null)
       setLocationTimelineLoading(false)
       return
@@ -2265,7 +2296,7 @@ function ProjectPageContent({
     fetchTimeline(projectName, locationFilter, 20)
       .then(tl => { setLocationTimeline(tl); setLocationTimelineLoading(false) })
       .catch(() => { setLocationTimeline(null); setLocationTimelineLoading(false) })
-  }, [locationFilter, projectName])
+  }, [locationFilter, projectName, needsSimpleEvidence])
 
   // Build a runHistory override map keyed by query::provider from the location-scoped timeline
   const locationRunHistoryMap = useMemo<Map<string, RunHistoryPoint[]> | null>(() => {
@@ -2609,7 +2640,7 @@ function ProjectPageContent({
           )}
         </div>
         <div className={isDashboardManagedSweeps() ? 'page-header-right min-w-0 flex-wrap sm:shrink sm:justify-end' : 'page-header-right'}>
-          <p className="text-sm text-muted">{tab === 'overview' && !isSimpleOverview ? visibilitySelection.from || visibilitySelection.to ? `${visibilitySelection.from?.slice(0, 10) ?? 'First measurement'} to ${visibilitySelection.to?.slice(0, 10) ?? 'Latest measurement'}` : 'Recent measurements' : model.dateRangeLabel}</p>
+          {tab === 'overview' ? <p className="text-sm text-muted">{!isSimpleOverview ? visibilitySelection.from || visibilitySelection.to ? `${visibilitySelection.from?.slice(0, 10) ?? 'First measurement'} to ${visibilitySelection.to?.slice(0, 10) ?? 'Latest measurement'}` : 'Recent measurements' : model.dateRangeLabel}</p> : null}
           {!isEmbed() && (isDashboardManagedSweeps() ? (
             <ManagedSweepStatus projectName={projectName} running={hasActiveVisibilitySweep} />
           ) : (
@@ -2625,7 +2656,7 @@ function ProjectPageContent({
                 variant="outline"
                 disabled={triggerRunMutation.isPending || hasActiveVisibilitySweep || sweepReadinessPending}
                 onClick={providerReadinessFailed
-                  ? () => { void measurementSetupQuery.refetch() }
+                  ? () => { void Promise.all([measurementSetupQuery.refetch(), ...(needsHeaderQueries ? [headerQueriesQuery.refetch()] : [])]) }
                   : sweepSetupRequired
                     ? openAiVisibilitySetup
                     : event => { sweepOpener.current = event.currentTarget; setSweepConfirmationProject(projectName) }}
@@ -2706,10 +2737,15 @@ function ProjectPageContent({
           }}
         />
       ) : tab === 'overview' ? (
-        isMeasurementModeUnresolved ? (
+        isMeasurementModeUnresolved || (isSimpleOverview && overviewLoading) ? (
           <div role="status" aria-live="polite">
             <span className="sr-only">Loading project overview</span>
             <div className="h-32 animate-pulse rounded-md bg-surface-subtle" aria-hidden="true" />
+          </div>
+        ) : isSimpleOverview && overviewError ? (
+          <div role="alert" className="page-section-divider">
+            <p>Could not load AI visibility.</p>
+            <Button type="button" variant="outline" onClick={() => { void refetch() }}>Retry</Button>
           </div>
         ) : (
         <>
@@ -2882,10 +2918,16 @@ function ProjectPageContent({
                 )}
               </div>
             )}
-            <EvidenceTable
-              evidence={filteredEvidence}
-              compareLocations={compareLocations}
-            />
+            {evidenceDashboard.evidenceLoading ? (
+              <p role="status" className="text-sm text-secondary">Loading query evidence…</p>
+            ) : evidenceDashboard.evidenceError ? (
+              <div role="alert" className="text-sm text-secondary">
+                <p>Could not load query evidence.</p>
+                <Button type="button" variant="outline" onClick={() => { void evidenceDashboard.refetch() }}>Retry</Button>
+              </div>
+            ) : (
+              <EvidenceTable evidence={filteredEvidence} compareLocations={compareLocations} />
+            )}
           </OverviewDisclosure>
 
           <OverviewDisclosure eyebrow="Analysis" title="Citation and engine diagnostics" meta="Deep dive" defaultOpen={isEmbed()}>

--- a/apps/web/src/queries/use-dashboard-overview.ts
+++ b/apps/web/src/queries/use-dashboard-overview.ts
@@ -17,36 +17,18 @@ import { useAccount } from '../contexts/account-context.js'
 import { useInitialDashboard } from '../contexts/dashboard-context.js'
 
 /**
- * Slim dashboard hook for the portfolio surface (overview, projects list,
- * runs, setup, settings, sidebar). Fetches the absolute minimum needed to
- * render multi-project widgets: one `/overview` per project instead of the
- * 9-endpoint fan-out the project page needs.
+ * Portfolio pages load one summary per project. The application shell opts
+ * out with `includeOverviews: false` and builds navigation from project/run
+ * metadata, using cached summaries when available. Project tabs own their
+ * analytics and answer evidence through `useProjectDashboard`.
  *
- * Replaces `useDashboard` for every consumer except ProjectPage, which
- * needs the heavy fan-out (timeline, latestRunDetails, GSC/Bing coverage,
- * DB insights) to render evidence tables and the full command center.
- *
- * The per-project queryFn populates only the `overview` field on
- * `ProjectData`. `buildDashboard` already tolerates the rest being empty —
- * the resulting `ProjectCommandCenterVm` has empty `visibilityEvidence`
- * (the timeline-derived table that only ProjectPage renders), but
- * `mentionSummary`, `recentRuns`, `competitors`, `providerScores`, and
- * everything else the overview surfaces are populated from `/overview`
- * alone.
- *
- * Cost comparison on a 5-project portfolio:
- *   - `useDashboard`         → 1 + 1 + 1 + (9 × 5)  = 48 requests on cold load
- *   - `useDashboardOverview` → 1 + 1 + 1 + (1 × 5)  =  8 requests on cold load
- *
- * Side effect: client-side attention items derived from `visibilityEvidence`
- * (lost-citation alerts) won't fire on the overview because evidence is
- * empty. Server-side `overview.attentionItems` (the canonical source per
- * AGENTS.md "no UI-only calculations") continues to surface every real
- * signal. The duplicated client derivation in `buildAttentionItems` is
- * tracked for removal in a follow-up.
+ * Overview attention items come from the server summary; this hook does not
+ * fetch answer bodies or derive evidence-based alerts in the browser.
  */
 interface DashboardOverviewOptions {
   includeSettings?: boolean
+  /** Keep project/run metadata available without starting per-project `/overview` reads. */
+  includeOverviews?: boolean
   /** Setup owns project creation and invalidates this query explicitly. */
   pauseProjectPolling?: boolean
 }
@@ -55,6 +37,7 @@ export function useDashboardOverview(initialDashboard?: DashboardVm | null, opti
   const contextDashboard = useInitialDashboard()
   const effectiveInitial = initialDashboard ?? contextDashboard?.dashboard ?? null
   const includeSettings = options.includeSettings ?? true
+  const includeOverviews = options.includeOverviews ?? true
   const pauseProjectPolling = options.pauseProjectPolling ?? false
   const { isAdmin } = useAccount()
 
@@ -99,10 +82,8 @@ export function useDashboardOverview(initialDashboard?: DashboardVm | null, opti
   const projects = projectsQuery.data ?? []
   const allRuns = runsQuery.data ?? []
 
-  // Per-project: ONLY /overview. The other 8 endpoints `useDashboard`
-  // fetches (timeline, queries, competitors, latestRunDetails × N,
-  // previousRunDetails × N, gscCoverage, bingCoverage, dbInsights) are
-  // only consumed by ProjectPage and live in `useProjectDashboard`.
+  // Optional summaries are shared with portfolio-page consumers. Disabled
+  // shell observers can use their cached results without starting requests.
   const projectOverviewQueries = useQueries({
     queries: projects.map((project) => {
       const projectRuns = allRuns.filter(r => r.projectId === project.id)
@@ -134,34 +115,51 @@ export function useDashboardOverview(initialDashboard?: DashboardVm | null, opti
             overview,
           }
         },
-        enabled: !effectiveInitial && projectsQuery.isSuccess && runsQuery.isSuccess,
+        enabled: !effectiveInitial && includeOverviews && projectsQuery.isSuccess && runsQuery.isSuccess,
         staleTime: STATIC_VISIBILITY_STALE_MS,
       }
     }),
   })
 
-  const allProjectOverviewsLoaded = projectOverviewQueries.every(q => q.isSuccess)
+  const allProjectOverviewsLoaded = !includeOverviews || projectOverviewQueries.every(q => q.isSuccess)
 
   const dashboard = useMemo(() => {
     if (effectiveInitial) return effectiveInitial
     if (!projectsQuery.data || !runsQuery.data) return null
     if (projects.length > 0 && !allProjectOverviewsLoaded) return null
 
-    const projectDataList: ProjectData[] = projectOverviewQueries
-      .map((q) => {
-        if (!q.data) return null
-        // Re-project runs through the fresh allRuns array so in-progress
-        // sweeps (queued / running, started after the overview was cached)
-        // surface in the run badges. Same pattern as `useDashboard`.
+    const projectDataList: ProjectData[] = includeOverviews
+      ? projectOverviewQueries
+        .map((q) => {
+          if (!q.data) return null
+          // Re-project runs through the fresh allRuns array so in-progress
+          // sweeps (queued / running, started after the overview was cached)
+          // surface in the run badges. Same pattern as `useDashboard`.
+          return {
+            ...q.data,
+            runs: allRuns.filter((r) => r.projectId === q.data!.project.id),
+          }
+        })
+        .filter((d): d is ProjectData => d != null)
+      : projects.map((project, index) => {
+        const cached = projectOverviewQueries[index]?.data
         return {
-          ...q.data,
-          runs: allRuns.filter((r) => r.projectId === q.data!.project.id),
+          project,
+          runs: allRuns.filter((r) => r.projectId === project.id),
+          queries: [],
+          competitors: [],
+          timeline: [],
+          latestRunDetails: [],
+          previousRunDetails: [],
+          gscCoverage: null,
+          bingCoverage: null,
+          dbInsights: null,
+          overview: cached?.overview ?? null,
         }
       })
-      .filter((d): d is ProjectData => d != null)
 
     return buildDashboard(projectDataList, settingsQuery.data ?? null)
-  }, [effectiveInitial, projectsQuery.data, runsQuery.data, settingsQuery.data, allProjectOverviewsLoaded, projectOverviewQueries, projects.length, allRuns])
+  }, [effectiveInitial, projectsQuery.data, runsQuery.data, settingsQuery.data, includeOverviews, allProjectOverviewsLoaded, projectOverviewQueries, projects, allRuns])
 
   const isError = !effectiveInitial && (projectsQuery.isError || runsQuery.isError)
   const isLoading = !effectiveInitial && !dashboard && !isError
@@ -170,7 +168,7 @@ export function useDashboardOverview(initialDashboard?: DashboardVm | null, opti
     const queries: Array<Promise<unknown>> = [
       projectsQuery.refetch(),
       runsQuery.refetch(),
-      ...projectOverviewQueries.map(query => query.refetch()),
+      ...(includeOverviews ? projectOverviewQueries.map(query => query.refetch()) : []),
     ]
     if (includeSettings) {
       queries.push(settingsQuery.refetch())
@@ -178,6 +176,7 @@ export function useDashboardOverview(initialDashboard?: DashboardVm | null, opti
     await Promise.all(queries)
   }, [
     includeSettings,
+    includeOverviews,
     projectOverviewQueries,
     projectsQuery.refetch,
     runsQuery.refetch,

--- a/apps/web/src/queries/use-project-dashboard.ts
+++ b/apps/web/src/queries/use-project-dashboard.ts
@@ -1,17 +1,11 @@
 import { useCallback, useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   fetchQueries,
-  fetchCompetitors,
-  fetchGscCoverage,
   fetchTimeline,
   fetchRunDetail,
-  fetchBingCoverage,
-  fetchConnectedBingCoverage,
-  fetchInsights,
   fetchProjectOverview,
   heyClient,
-  isEmbed,
 } from '../api.js'
 import {
   getApiV1ProjectsByNameOptions,
@@ -26,22 +20,19 @@ import { competitorEvidenceRevision } from './competitor-landscape-refresh.js'
 
 const DASHBOARD_TIMELINE_RUN_LIMIT = 20
 
-/**
- * Heavy dashboard hook scoped to a single project. Fetches everything
- * `ProjectPage` needs to render the full command center: project metadata,
- * runs, timeline, latest + previous run details (for evidence + diffs),
- * GSC / Bing coverage, DB-backed insights, and the server overview
- * composite.
- *
- * Pairs with `useDashboardOverview`, which is the slim portfolio-shaped
- * counterpart used by every other page. The split fixes the per-project
- * fan-out tax that `useDashboard` paid on every dashboard mount across
- * all projects regardless of which one the user navigated to.
- *
- * Cost: 9 endpoints for the requested project only — never fans out
- * across other projects.
- */
-export function useProjectDashboard(projectName: string | null | undefined) {
+interface ProjectDashboardOptions {
+  /** Summary metrics are only consumed by AI Visibility. */
+  overview?: boolean
+  /** Full answer history is needed by Simple evidence and the answer drawer. */
+  evidence?: boolean
+}
+
+/** Project identity loads independently of optional summary and evidence reads. */
+export function useProjectDashboard(
+  projectName: string | null | undefined,
+  options: ProjectDashboardOptions = {},
+) {
+  const queryClient = useQueryClient()
   // First-paint / SSR fallback: when the DashboardProvider has injected a
   // pre-built fixture (used by tests and the SSR shell), prefer the
   // matching `ProjectCommandCenterVm` from there until the per-project
@@ -57,7 +48,7 @@ export function useProjectDashboard(projectName: string | null | undefined) {
     ) ?? null
   }, [contextDashboard, projectName])
 
-  // The three project-page queries below all override the global
+  // The active project-page queries below override the global
   // `refetchOnWindowFocus: false` default. Rationale: CLI-driven
   // mutations (`cnry query add`, `cnry competitor add`, `cnry project
   // create`, etc.) bypass React Query entirely — the dashboard's cache
@@ -106,7 +97,7 @@ export function useProjectDashboard(projectName: string | null | undefined) {
   // Mirror the multi-location run-grouping logic from `useDashboard`:
   // pick all sibling runs with the same `createdAt` as the latest, so
   // every location's snapshot lands in `latestRunDetails`.
-  const { latestRunIds, previousRunIds, latestRunIdsKey, latestVisibilityRevision } = useMemo(() => {
+  const { latestRunIds, latestRunIdsKey, latestVisibilityRevision } = useMemo(() => {
     const completed = projectRuns
       .filter(r =>
         (r.status === 'completed' || r.status === 'partial')
@@ -117,13 +108,8 @@ export function useProjectDashboard(projectName: string | null | undefined) {
     const latestIds = latestCreatedAt
       ? completed.filter(r => r.createdAt === latestCreatedAt).map(r => r.id)
       : []
-    const previousCreatedAt = completed.find(r => r.createdAt !== latestCreatedAt)?.createdAt ?? null
-    const previousIds = previousCreatedAt
-      ? completed.filter(r => r.createdAt === previousCreatedAt).map(r => r.id)
-      : []
     return {
       latestRunIds: latestIds,
-      previousRunIds: previousIds,
       latestRunIdsKey: [...latestIds].sort().join(','),
       // The trend response depends on the same completed logical sweep as the
       // evidence/dashboard detail. Include both timestamp and sibling ids so a
@@ -135,83 +121,80 @@ export function useProjectDashboard(projectName: string | null | undefined) {
     }
   }, [projectRuns])
 
-  const detailQuery = useQuery({
-    queryKey: ['project-dashboard-full', project?.id ?? null, latestRunIdsKey || 'none'] as const,
-    queryFn: async (): Promise<ProjectData | null> => {
-      if (!project || !projectName) return null
-      const [qs, comps, timeline, latestRunDetails, previousRunDetails, gscCoverage, bingCoverage, dbInsights, overview] = await Promise.all([
-        fetchQueries(projectName).catch(() => []),
-        fetchCompetitors(projectName).catch(() => []),
-        fetchTimeline(projectName, undefined, DASHBOARD_TIMELINE_RUN_LIMIT).catch(() => []),
-        latestRunIds.length
-          ? Promise.all(latestRunIds.map(id => fetchRunDetail(id).catch(() => null)))
-              .then(results => results.filter((r): r is NonNullable<typeof r> => r != null))
-          : Promise.resolve([]),
-        previousRunIds.length
-          ? Promise.all(previousRunIds.map(id => fetchRunDetail(id).catch(() => null)))
-              .then(results => results.filter((r): r is NonNullable<typeof r> => r != null))
-          : Promise.resolve([]),
-        fetchGscCoverage(projectName).catch(() => null),
-        (isEmbed() ? fetchBingCoverage(projectName) : fetchConnectedBingCoverage(projectName)).catch(() => null),
-        fetchInsights(projectName).catch(() => null),
-        fetchProjectOverview(projectName).catch(() => null),
-      ])
-      return {
-        project,
-        runs: projectRuns,
-        queries: qs,
-        competitors: comps,
-        timeline,
-        latestRunDetails,
-        previousRunDetails,
-        gscCoverage,
-        bingCoverage,
-        dbInsights,
-        overview,
-      }
-    },
-    enabled: !!project && !!projectName && runsQuery.isSuccess,
+  const ready = !!project && !!projectName && runsQuery.isSuccess
+  // Keep the shared prefix so query publication, identity edits, and run
+  // completion invalidate both projections without refetching inactive tabs.
+  const overviewQuery = useQuery({
+    queryKey: ['project-dashboard-full', project?.id ?? null, latestRunIdsKey || 'none', 'overview'] as const,
+    queryFn: async () => ({ project: project!, overview: await fetchProjectOverview(projectName!) }),
+    enabled: ready && options.overview === true,
     staleTime: STATIC_VISIBILITY_STALE_MS,
     refetchOnWindowFocus: 'always',
-    // This is a nine-endpoint fan-out, including evidence snapshots and
-    // integration summaries. Refetch on focus and when the latest run id
-    // changes; do not poll the full historical payload on a timer.
+  })
+  const evidenceQuery = useQuery({
+    queryKey: ['project-dashboard-full', project?.id ?? null, latestRunIdsKey || 'none', 'evidence'] as const,
+    queryFn: async () => {
+      const [queries, timeline, latestRunDetails] = await Promise.all([
+        fetchQueries(projectName!),
+        fetchTimeline(projectName!, undefined, DASHBOARD_TIMELINE_RUN_LIMIT),
+        Promise.all(latestRunIds.map(id => fetchRunDetail(id))),
+      ])
+      return { project: project!, queries, timeline, latestRunDetails }
+    },
+    enabled: ready && options.evidence === true,
+    staleTime: STATIC_VISIBILITY_STALE_MS,
+    refetchOnWindowFocus: 'always',
   })
 
   const commandCenter = useMemo<ProjectCommandCenterVm | null>(() => {
-    if (detailQuery.data) {
-      // Re-project runs through the fresh runsQuery so queued/running runs
-      // that started after the detail query cached still surface in badges.
-      return buildProjectCommandCenter({
-        ...detailQuery.data,
-        runs: projectRuns,
-      })
+    if (!project || !runsQuery.data) return initialCommandCenter
+    const evidence = options.evidence ? evidenceQuery.data : undefined
+    const data: ProjectData = {
+      project,
+      runs: projectRuns,
+      queries: evidence?.queries ?? [],
+      timeline: evidence?.timeline ?? [],
+      latestRunDetails: evidence?.latestRunDetails ?? [],
+      previousRunDetails: [],
+      competitors: [],
+      overview: options.overview ? overviewQuery.data?.overview ?? null : null,
     }
-    // SSR / test fallback (see initialCommandCenter rationale above).
-    if (initialCommandCenter) return initialCommandCenter
-    return null
-  }, [detailQuery.data, projectRuns, initialCommandCenter])
+    const built = buildProjectCommandCenter(data)
+    // Keep injected first-paint metrics while only project metadata refreshes.
+    // A settings save must not turn a known baseline into an empty shell.
+    if (initialCommandCenter && !(options.overview && overviewQuery.data)) {
+      return {
+        ...initialCommandCenter,
+        project: built.project,
+        recentRuns: runsQuery.data ? built.recentRuns : initialCommandCenter.recentRuns,
+        visibilityEvidence: evidence ? built.visibilityEvidence : initialCommandCenter.visibilityEvidence,
+      }
+    }
+    return built
+  }, [project, projectRuns, evidenceQuery.data, overviewQuery.data, initialCommandCenter, options.evidence, options.overview, runsQuery.data])
 
   const refetch = useCallback(async () => {
     await Promise.all([
       projectQuery.refetch(),
       runsQuery.refetch(),
-      detailQuery.refetch(),
+      queryClient.invalidateQueries({ queryKey: ['project-dashboard-full', project?.id ?? null] }),
     ])
-  }, [projectQuery.refetch, runsQuery.refetch, detailQuery.refetch])
+  }, [projectQuery.refetch, runsQuery.refetch, queryClient, project?.id])
 
-  // Once we have a renderable commandCenter — from either the live query
-  // or the SSR fixture — stop reporting `isLoading`. Background refetches
-  // (runs polling, etc.) shouldn't put the page back into the loading
-  // skeleton state.
-  const isLoading = !commandCenter
-    && (projectQuery.isLoading || runsQuery.isLoading || detailQuery.isLoading)
+  const isError = projectQuery.isError || runsQuery.isError
+  const isLoading = !initialCommandCenter && (projectQuery.isLoading || runsQuery.isLoading)
+  const overviewLoading = !!projectName && options.overview === true && !initialCommandCenter && !isError && overviewQuery.isPending
+  const evidenceLoading = !!projectName && options.evidence === true && !initialCommandCenter && !isError && evidenceQuery.isPending
 
   return {
     commandCenter,
     project,
     isLoading,
-    isError: projectQuery.isError || runsQuery.isError || detailQuery.isError,
+    isError,
+    overviewLoading,
+    overviewError: options.overview === true && overviewQuery.isError && !overviewQuery.data,
+    evidenceLoading,
+    evidenceError: options.evidence === true && evidenceQuery.isError && !evidenceQuery.data,
     latestVisibilityRevision,
     competitorHistoryRevision: competitorEvidenceRevision(projectRuns),
     refetch,

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -1900,6 +1900,7 @@ test('saving the project provider allowlist refreshes server-owned sweep readine
       return jsonResponse(updatedProject)
     }
     if (path.endsWith('/projects')) return jsonResponse([updatedProject])
+    if (path.endsWith('/queries')) return jsonResponse([{ id: 'tracked-query', query: 'places to rent' }])
     if (path.endsWith('/measurement-plan')) return jsonResponse({ active: null })
     if (path.endsWith('/runs?kind=answer-visibility')) return jsonResponse([])
     if (path.endsWith('/schedules') || path.endsWith('/notifications')) return jsonResponse([])

--- a/apps/web/test/project-detail-invalidation.test.ts
+++ b/apps/web/test/project-detail-invalidation.test.ts
@@ -27,6 +27,8 @@ describe('isProjectDetailQuery', () => {
   it('matches the per-project dashboard key (current — useProjectDashboard)', () => {
     expect(isProjectDetailQuery(q(['project-dashboard-full', 'project-id', 'run-ids-key']))).toBe(true)
     expect(isProjectDetailQuery(q(['project-dashboard-full', null, 'none']))).toBe(true)
+    expect(isProjectDetailQuery(q(['project-dashboard-full', 'project-id', 'run-ids-key', 'overview']))).toBe(true)
+    expect(isProjectDetailQuery(q(['project-dashboard-full', 'project-id', 'run-ids-key', 'evidence']))).toBe(true)
   })
 
   it('matches the legacy portfolio-wide key (useDashboard)', () => {

--- a/apps/web/test/use-dashboard-overview.test.tsx
+++ b/apps/web/test/use-dashboard-overview.test.tsx
@@ -31,6 +31,14 @@ function wrapper({ children }: { children: ReactNode }) {
   return createElement(QueryClientProvider, { client }, children)
 }
 
+const metadataProject = {
+  id: 'alpha-id', name: 'alpha', displayName: 'Alpha', canonicalDomain: 'alpha.example',
+  ownedDomains: [], aliases: [], country: 'US', language: 'en', tags: [], labels: [],
+  providers: [], providerModels: {}, measurement: null, locations: [], defaultLocation: null,
+  autoExtractBacklinks: false, configSource: 'config', configRevision: 1,
+  createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
 afterEach(() => {
   delete window.__CANONRY_CONFIG__
 })
@@ -81,5 +89,27 @@ describe('useDashboardOverview', () => {
     await vi.waitFor(() => { expect(projectReads).toBe(1) })
     await vi.advanceTimersByTimeAsync(10_000)
     expect(projectReads).toBe(1)
+  })
+
+  test('builds the metadata dashboard without fetching or refetching project overviews', async () => {
+    const paths: string[] = []
+    const restoreFetch = mockFetch((path) => {
+      paths.push(path)
+      if (path.startsWith('/api/v1/projects')) return jsonResponse([metadataProject])
+      if (path.startsWith('/api/v1/runs')) return jsonResponse([])
+      return jsonResponse({ error: `unexpected ${path}` }, 404)
+    })
+    onTestFinished(restoreFetch)
+
+    const { result } = renderHook(
+      () => useDashboardOverview(null, { includeSettings: false, includeOverviews: false }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.dashboard?.projects.map(project => project.project.name)).toEqual(['alpha']))
+    expect(paths.some(path => /\/overview(?:\?|$)/.test(path))).toBe(false)
+
+    await result.current.refetch()
+    expect(paths.some(path => /\/overview(?:\?|$)/.test(path))).toBe(false)
   })
 })

--- a/apps/web/test/use-project-dashboard.test.tsx
+++ b/apps/web/test/use-project-dashboard.test.tsx
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, onTestFinished, test } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement, type ReactNode } from 'react'
+
+import { useProjectDashboard } from '../src/queries/use-project-dashboard.js'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function project(name: string) {
+  return {
+    id: `${name}-id`, name, displayName: name, canonicalDomain: `${name}.example`,
+    ownedDomains: [], aliases: [], country: 'US', language: 'en', tags: [], labels: [],
+    providers: [], providerModels: {}, measurement: null, locations: [], defaultLocation: null,
+    autoExtractBacklinks: false, configSource: 'config', configRevision: 1,
+    createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+function run(id: string, projectName: string, createdAt: string, trigger = 'manual') {
+  return {
+    id, projectId: `${projectName}-id`, kind: 'answer-visibility', status: 'completed', trigger,
+    createdAt, startedAt: createdAt, finishedAt: createdAt, location: null, error: null,
+  }
+}
+
+function pathOf(input: RequestInfo | URL): string {
+  const url = input instanceof Request ? input.url : String(input)
+  return url.replace(/^https?:\/\/[^/]+/, '') || url
+}
+
+function installFetch(handler: (path: string) => Response | Promise<Response>) {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => handler(pathOf(input))) as typeof fetch
+  return () => { globalThis.fetch = realFetch }
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children)
+  }
+  return { Wrapper, client }
+}
+
+function projectNameFrom(path: string): string {
+  return path.match(/^\/api\/v1\/projects\/([^/?]+)/)?.[1] ?? 'alpha'
+}
+
+function standardResponse(path: string, runs = [run('run-1', 'alpha', '2026-01-01T00:00:00.000Z')]): Response {
+  if (/^\/api\/v1\/projects\/[^/]+\/runs/.test(path)) return jsonResponse(runs)
+  if (/^\/api\/v1\/projects\/[^/]+\/overview/.test(path)) return jsonResponse(null)
+  if (/^\/api\/v1\/projects\/[^/]+\/queries/.test(path)) return jsonResponse([])
+  if (/^\/api\/v1\/projects\/[^/]+\/timeline/.test(path)) return jsonResponse([])
+  if (/^\/api\/v1\/runs\//.test(path)) return jsonResponse({ id: path.split('/').at(-1), snapshots: [] })
+  if (/^\/api\/v1\/projects\/[^/?]+/.test(path)) return jsonResponse(project(projectNameFrom(path)))
+  return jsonResponse({ error: `unexpected ${path}` }, 404)
+}
+
+afterEach(() => {
+  delete window.__CANONRY_CONFIG__
+})
+
+describe('useProjectDashboard', () => {
+  test('loads only project metadata and project-scoped runs by default', async () => {
+    const paths: string[] = []
+    const restoreFetch = installFetch(path => {
+      paths.push(path)
+      return standardResponse(path)
+    })
+    onTestFinished(restoreFetch)
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+
+    const { result } = renderHook(() => useProjectDashboard('alpha'), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.project?.name).toBe('alpha'))
+    expect(paths.some(path => /\/overview(?:\?|$)/.test(path))).toBe(false)
+    expect(paths.some(path => /\/(?:queries|timeline)(?:\?|$)/.test(path))).toBe(false)
+    expect(paths.some(path => /^\/api\/v1\/runs\//.test(path))).toBe(false)
+    expect(paths.some(path => /\/(?:competitors|insights)(?:\?|$)|\/google\/gsc\/coverage|\/bing\/coverage/.test(path))).toBe(false)
+  })
+
+  test('keeps core metadata and overview usable while evidence is stalled', async () => {
+    let releaseEvidence: (() => void) | undefined
+    const stalledEvidence = new Promise<Response>(resolve => { releaseEvidence = () => resolve(jsonResponse([])) })
+    const restoreFetch = installFetch(path => {
+      if (/\/(?:queries|timeline)(?:\?|$)/.test(path)) return stalledEvidence
+      return standardResponse(path)
+    })
+    onTestFinished(() => { releaseEvidence?.(); restoreFetch() })
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+
+    const { result } = renderHook(
+      () => useProjectDashboard('alpha', { overview: true, evidence: true }),
+      { wrapper: Wrapper },
+    )
+
+    await waitFor(() => {
+      expect(result.current.project?.name).toBe('alpha')
+      expect(result.current.overviewLoading).toBe(false)
+    })
+    expect(result.current.evidenceLoading).toBe(true)
+  })
+
+  test('starts and stops evidence reads only when evidence is enabled', async () => {
+    const paths: string[] = []
+    const restoreFetch = installFetch(path => {
+      paths.push(path)
+      return standardResponse(path)
+    })
+    onTestFinished(restoreFetch)
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+
+    const { result, rerender } = renderHook(
+      ({ evidence }: { evidence: boolean }) => useProjectDashboard('alpha', { evidence }),
+      { initialProps: { evidence: false }, wrapper: Wrapper },
+    )
+    await waitFor(() => expect(result.current.project?.name).toBe('alpha'))
+    expect(paths.some(path => /\/(?:queries|timeline)(?:\?|$)/.test(path))).toBe(false)
+
+    rerender({ evidence: true })
+    await waitFor(() => expect(result.current.evidenceLoading).toBe(false))
+    expect(paths.some(path => /\/queries(?:\?|$)/.test(path))).toBe(true)
+    expect(paths.some(path => /\/timeline(?:\?|$)/.test(path))).toBe(true)
+    expect(paths.some(path => /^\/api\/v1\/runs\/run-1(?:\?|$)/.test(path))).toBe(true)
+
+    const evidenceReads = paths.filter(path => /\/(?:queries|timeline)(?:\?|$)/.test(path)).length
+    rerender({ evidence: false })
+    expect(paths.filter(path => /\/(?:queries|timeline)(?:\?|$)/.test(path)).length).toBe(evidenceReads)
+  })
+
+  test('rotates evidence to the latest completed sibling group and excludes probes', async () => {
+    let generation = 0
+    const paths: string[] = []
+    const restoreFetch = installFetch(path => {
+      paths.push(path)
+      if (/^\/api\/v1\/projects\/alpha\/runs/.test(path)) {
+        return jsonResponse(generation === 0
+          ? [
+              run('old', 'alpha', '2026-01-01T00:00:00.000Z'),
+              run('probe', 'alpha', '2026-02-01T00:00:00.000Z', 'probe'),
+            ]
+          : [
+              run('new-a', 'alpha', '2026-03-01T00:00:00.000Z'),
+              run('new-b', 'alpha', '2026-03-01T00:00:00.000Z'),
+              run('probe', 'alpha', '2026-04-01T00:00:00.000Z', 'probe'),
+            ])
+      }
+      return standardResponse(path)
+    })
+    onTestFinished(restoreFetch)
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+    const { result } = renderHook(() => useProjectDashboard('alpha', { evidence: true }), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.latestVisibilityRevision).toBe('2026-01-01T00:00:00.000Z:old'))
+    await waitFor(() => expect(paths.some(path => /\/runs\/old(?:\?|$)/.test(path))).toBe(true))
+    generation = 1
+    await act(async () => { await result.current.refetch() })
+
+    await waitFor(() => expect(result.current.latestVisibilityRevision).toBe('2026-03-01T00:00:00.000Z:new-a,new-b'))
+    await waitFor(() => {
+      expect(paths.some(path => /\/runs\/new-a(?:\?|$)/.test(path))).toBe(true)
+      expect(paths.some(path => /\/runs\/new-b(?:\?|$)/.test(path))).toBe(true)
+    })
+    expect(paths.some(path => /\/runs\/probe(?:\?|$)/.test(path))).toBe(false)
+  })
+
+  test('refetching core state does not activate disabled optional queries', async () => {
+    const paths: string[] = []
+    const restoreFetch = installFetch(path => {
+      paths.push(path)
+      return standardResponse(path)
+    })
+    onTestFinished(restoreFetch)
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+    const { result } = renderHook(() => useProjectDashboard('alpha'), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.project?.name).toBe('alpha'))
+    await act(async () => { await result.current.refetch() })
+    expect(paths.some(path => /\/(?:overview|queries|timeline)(?:\?|$)/.test(path))).toBe(false)
+    expect(paths.some(path => /^\/api\/v1\/runs\//.test(path))).toBe(false)
+  })
+
+  test('isolates optional data when the project changes', async () => {
+    const paths: string[] = []
+    const restoreFetch = installFetch(path => {
+      paths.push(path)
+      return standardResponse(path, [run(`${projectNameFrom(path)}-run`, projectNameFrom(path), '2026-01-01T00:00:00.000Z')])
+    })
+    onTestFinished(restoreFetch)
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+    const { result, rerender } = renderHook(
+      ({ name }: { name: string }) => useProjectDashboard(name, { overview: true }),
+      { initialProps: { name: 'alpha' }, wrapper: Wrapper },
+    )
+    await waitFor(() => expect(result.current.project?.name).toBe('alpha'))
+
+    rerender({ name: 'beta' })
+    await waitFor(() => expect(result.current.project?.name).toBe('beta'))
+    await waitFor(() => expect(paths.some(path => /^\/api\/v1\/projects\/beta\/overview/.test(path))).toBe(true))
+    expect(result.current.latestVisibilityRevision).toBe('2026-01-01T00:00:00.000Z:beta-run')
+  })
+
+  test.each(['project', 'runs'])('stops the answer loading state when %s fails', async (failedRequest) => {
+    const restoreFetch = installFetch(path => {
+      const isFailedRequest = failedRequest === 'project'
+        ? path === '/api/v1/projects/alpha'
+        : path.startsWith('/api/v1/projects/alpha/runs')
+      return isFailedRequest
+        ? jsonResponse({ error: { code: 'INTERNAL_ERROR', message: 'try again' } }, 500)
+        : standardResponse(path)
+    })
+    onTestFinished(restoreFetch)
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+    const { result } = renderHook(() => useProjectDashboard('alpha', { evidence: true }), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.evidenceLoading).toBe(false)
+    expect(result.current.commandCenter).toBeNull()
+  })
+
+  test('keeps cached optional results visible when a background refresh fails', async () => {
+    let failRefresh = false
+    const restoreFetch = installFetch(path => {
+      if (failRefresh && /\/(?:overview|timeline)(?:\?|$)/.test(path)) {
+        return jsonResponse({ error: { code: 'INTERNAL_ERROR', message: 'try again' } }, 500)
+      }
+      return standardResponse(path)
+    })
+    onTestFinished(restoreFetch)
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+    const { result } = renderHook(
+      () => useProjectDashboard('alpha', { overview: true, evidence: true }),
+      { wrapper: Wrapper },
+    )
+    await waitFor(() => {
+      expect(result.current.overviewLoading).toBe(false)
+      expect(result.current.evidenceLoading).toBe(false)
+    })
+    failRefresh = true
+    await act(async () => { await result.current.refetch() })
+
+    expect(client.getQueryState(['project-dashboard-full', 'alpha-id', 'run-1', 'overview'])?.status).toBe('error')
+    expect(client.getQueryState(['project-dashboard-full', 'alpha-id', 'run-1', 'evidence'])?.status).toBe('error')
+    expect(result.current.overviewError).toBe(false)
+    expect(result.current.evidenceError).toBe(false)
+    expect(result.current.commandCenter?.project.name).toBe('alpha')
+  })
+
+  test('exposes optional failures and retries the active optional query', async () => {
+    let overviewAttempts = 0
+    const restoreFetch = installFetch(path => {
+      if (/\/overview(?:\?|$)/.test(path)) {
+        overviewAttempts += 1
+        return overviewAttempts === 1
+          ? jsonResponse({ error: { code: 'INTERNAL_ERROR', message: 'try again' } }, 500)
+          : jsonResponse(null)
+      }
+      return standardResponse(path)
+    })
+    onTestFinished(restoreFetch)
+    const { Wrapper, client } = makeWrapper()
+    onTestFinished(() => client.clear())
+    const { result } = renderHook(() => useProjectDashboard('alpha', { overview: true }), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.overviewError).toBe(true))
+    await act(async () => { await result.current.refetch() })
+    await waitFor(() => expect(result.current.overviewError).toBe(false))
+    expect(overviewAttempts).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.188.3",
+  "version": "4.188.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.188.3",
+  "version": "4.188.4",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.188.3",
+  "version": "4.188.4",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.188.3",
+  "version": "4.188.4",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.188.3",
+  "version": "4.188.4",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Project tabs waited for a shared batch of analytics and full answer-history requests, including several responses the page never used. The shell now loads project metadata independently, the active tab owns its data, and full answer history loads only for the Simple evidence table or an open answer drawer. The sidebar uses project identities without starting portfolio-summary requests.

Loading and retry states stay local to the affected report or drawer. Cached results remain visible after a failed refresh; existing scope filters, sweep-readiness controls, probe exclusions, and query invalidation remain intact.

Validation: focused web tests, web typecheck, changed-file lint, production dashboard build, and browser request checks against existing data. No provider jobs were triggered. Patch release 4.188.4.

