### PR TITLE
fix: speed up portfolio summaries and simplify sweep header

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,6 +34,7 @@ each choice.
 - Empty and error states may contain the minimum copy needed to recover.
 - Avoid acronyms until the expanded product name has established the context.
 - Do not use em dashes in UI copy.
+- Status headers show only decision-relevant state. Next-run headers use the schedule-local calendar date; keep time, weekday, year, team ownership, and explanatory prose out of the header.
 
 ## Typography and contrast
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -183,7 +183,11 @@ Base path comes from `window.__CANONRY_CONFIG__.basePath`. Never hardcode `/api/
 replace answer-visibility launch controls and empty-state launch instructions
 for every dashboard role, including admins. `ManagedSweepStatus` reads
 `GET /projects/:name/schedule?kind=answer-visibility`; only an enabled schedule
-with a valid `nextRunAt` gets a UTC date. The component accepts a schedule kind.
+with a valid `nextRunAt` gets a calendar date in the schedule timezone. The
+answer-visibility header shows `Next sweep: Sep 23` or a concise running or
+unavailable state, without a tooltip, time, or team-ownership copy. Omit the
+Advanced default `Recent measurements` label; preserve explicit historical
+ranges. The component accepts a schedule kind.
 Managed `site-audit` hides viewer scan controls and next-scan settings; admins
 retain them. Gate `startScan` and `startAudit` themselves, including recovery
 callbacks, and keep all progress, score, map, page, failure, partial and dead-link

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -340,6 +340,12 @@ Token migration guardrails:
   `canWrite && !isEmbed()`; market pins create/update a draft and never publish.
 - History fallback pins show unavailable metrics, never latest-only counts under
   a historical window.
+
+### UI tests
+
+Use semantic selectors and exported UI copy constants for text assertions.
+Keep fixture dates and behavior checks independent of display wording.
+
 ## Common Mistakes
 
 - **Importing `recharts` directly** — use `ChartPrimitives.tsx` exports.

--- a/apps/web/src/components/project/ManagedSweepStatus.tsx
+++ b/apps/web/src/components/project/ManagedSweepStatus.tsx
@@ -1,12 +1,24 @@
 import { useQuery } from '@tanstack/react-query'
 import { getApiV1ProjectsByNameScheduleOptions } from '@ainyc/canonry-api-client/react-query'
-import { formatZonedTimestamp, RunKinds, type SchedulableRunKind } from '@ainyc/canonry-contracts'
+import { RunKinds, type SchedulableRunKind } from '@ainyc/canonry-contracts'
 import { ApiError, heyClient } from '../../api.js'
-import { InfoTooltip } from '../shared/InfoTooltip.js'
 
 export const MANAGED_SWEEPS_COPY = 'Sweeps are run by your Canonry team'
 
 export const MANAGED_SCANS_COPY = 'Scans are run by your Canonry team'
+export const MANAGED_SWEEPS_UNAVAILABLE_COPY = 'Next sweep unavailable'
+
+function managedSweepDate(iso: string, timezone: string | undefined): string | null {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      timeZone: timezone ?? 'UTC',
+    }).format(new Date(iso))
+  } catch {
+    return null
+  }
+}
 
 export function ManagedSweepStatus({ projectName, kind = RunKinds['answer-visibility'], running = false }: {
   projectName: string
@@ -29,28 +41,24 @@ export function ManagedSweepStatus({ projectName, kind = RunKinds['answer-visibi
     ? scan ? nextRun.toLocaleString('en-GB', {
         weekday: 'long', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
         timeZone: 'UTC', hourCycle: 'h23',
-      }) : formatZonedTimestamp(nextRun.toISOString(), schedule?.timezone)
+      }) : managedSweepDate(nextRun.toISOString(), schedule?.timezone)
     : null
 
   const errorCode = scheduleQuery.error instanceof ApiError ? scheduleQuery.error.code
     : (scheduleQuery.error as { error?: { code?: string } } | null)?.error?.code
   const missingSchedule = errorCode === 'NOT_FOUND'
-  const scheduleHelp = scheduleQuery.isPending ? 'Checking the next scheduled time.'
-    : scheduleQuery.isError && !missingSchedule ? 'The next scheduled time could not be loaded.'
-    : !schedule ? 'No automatic sweep is currently scheduled.'
-    : !schedule.enabled ? 'Automatic sweeps are paused.'
-    : nextSync ? `The next AI Visibility sweep is scheduled to start ${nextSync}. Results update after the sweep finishes.`
-    : 'The next scheduled time has not been set.'
+  const unavailableSweep = !nextSync || missingSchedule || !schedule?.enabled
 
   return (
-    <div className="inline-flex items-center gap-1">
     <p className="text-sm text-secondary" role="status">
-      {running && <span className="text-neutral">{scan ? 'Scan running…' : 'AI sweep running…'} · </span>}
-      {nextSync && nextRun ? <>
-        Next {scan ? 'scan' : 'scheduled sweep'} <time dateTime={nextRun.toISOString()}>{nextSync}{scan ? ' UTC' : ''}</time> · managed by your Canonry team
-      </> : scan ? MANAGED_SCANS_COPY : MANAGED_SWEEPS_COPY}
+      {scan ? <>
+        {running && <span className="text-neutral">Scan running… · </span>}
+        {nextSync && nextRun ? <>
+          Next scan <time dateTime={nextRun.toISOString()}>{nextSync} UTC</time> · managed by your Canonry team
+        </> : MANAGED_SCANS_COPY}
+      </> : running ? 'Sweep running…' : unavailableSweep ? MANAGED_SWEEPS_UNAVAILABLE_COPY : nextSync && nextRun ? <>
+        Next sweep: <time dateTime={nextRun.toISOString()}>{nextSync}</time>
+      </> : MANAGED_SWEEPS_UNAVAILABLE_COPY}
     </p>
-    {!scan && <InfoTooltip text={`${MANAGED_SWEEPS_COPY}. ${scheduleHelp}`} />}
-    </div>
   )
 }

--- a/apps/web/src/components/project/ManagedSweepStatus.tsx
+++ b/apps/web/src/components/project/ManagedSweepStatus.tsx
@@ -7,6 +7,8 @@ export const MANAGED_SWEEPS_COPY = 'Sweeps are run by your Canonry team'
 
 export const MANAGED_SCANS_COPY = 'Scans are run by your Canonry team'
 export const MANAGED_SWEEPS_UNAVAILABLE_COPY = 'Next sweep unavailable'
+export const MANAGED_SWEEPS_RUNNING_COPY = 'Sweep running…'
+export const MANAGED_SWEEPS_NEXT_LABEL = 'Next sweep:'
 
 function managedSweepDate(iso: string, timezone: string | undefined): string | null {
   try {
@@ -56,8 +58,8 @@ export function ManagedSweepStatus({ projectName, kind = RunKinds['answer-visibi
         {nextSync && nextRun ? <>
           Next scan <time dateTime={nextRun.toISOString()}>{nextSync} UTC</time> · managed by your Canonry team
         </> : MANAGED_SCANS_COPY}
-      </> : running ? 'Sweep running…' : unavailableSweep ? MANAGED_SWEEPS_UNAVAILABLE_COPY : nextSync && nextRun ? <>
-        Next sweep: <time dateTime={nextRun.toISOString()}>{nextSync}</time>
+      </> : running ? MANAGED_SWEEPS_RUNNING_COPY : unavailableSweep ? MANAGED_SWEEPS_UNAVAILABLE_COPY : nextSync && nextRun ? <>
+        {MANAGED_SWEEPS_NEXT_LABEL} <time dateTime={nextRun.toISOString()}>{nextSync}</time>
       </> : MANAGED_SWEEPS_UNAVAILABLE_COPY}
     </p>
   )

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -2668,7 +2668,7 @@ function ProjectPageContent({
           )}
         </div>
         <div className={isDashboardManagedSweeps() ? 'page-header-right min-w-0 flex-wrap sm:shrink sm:justify-end' : 'page-header-right'}>
-          {tab === 'overview' ? <p className="text-sm text-muted">{!isSimpleOverview ? visibilitySelection.from || visibilitySelection.to ? `${visibilitySelection.from?.slice(0, 10) ?? 'First measurement'} to ${visibilitySelection.to?.slice(0, 10) ?? 'Latest measurement'}` : 'Recent measurements' : model.dateRangeLabel}</p> : null}
+          {tab === 'overview' && (isSimpleOverview || visibilitySelection.from || visibilitySelection.to) ? <p className="text-sm text-muted">{isSimpleOverview ? model.dateRangeLabel : `${visibilitySelection.from?.slice(0, 10) ?? 'First measurement'} to ${visibilitySelection.to?.slice(0, 10) ?? 'Latest measurement'}`}</p> : null}
           {!isEmbed() && (isDashboardManagedSweeps() ? (
             <ManagedSweepStatus projectName={projectName} running={hasActiveVisibilitySweep} />
           ) : (

--- a/apps/web/test/aero-bar-readiness.test.tsx
+++ b/apps/web/test/aero-bar-readiness.test.tsx
@@ -1,3 +1,4 @@
+import { MANAGED_SWEEPS_COPY } from '../src/components/project/ManagedSweepStatus.js'
 import { afterEach, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -162,7 +163,7 @@ test.each([
   fireEvent.change(input, { target: { value: draft } })
   if (method === 'enter') fireEvent.keyDown(input, { key: 'Enter' })
   else fireEvent.click(screen.getByRole('button', { name: 'Send' }))
-  expect(await screen.findByText('Sweeps are run by your Canonry team')).toBeTruthy()
+  expect(await screen.findByText(MANAGED_SWEEPS_COPY)).toBeTruthy()
   expect(prompt).not.toHaveBeenCalled()
 })
 

--- a/apps/web/test/managed-sweeps.test.tsx
+++ b/apps/web/test/managed-sweeps.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, expect, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { isDashboardManagedRunKind, isDashboardManagedSweeps } from '../src/api.js'
-import { ManagedSweepStatus, MANAGED_SWEEPS_COPY, MANAGED_SCANS_COPY } from '../src/components/project/ManagedSweepStatus.js'
+import { ManagedSweepStatus, MANAGED_SWEEPS_UNAVAILABLE_COPY, MANAGED_SCANS_COPY } from '../src/components/project/ManagedSweepStatus.js'
 
 afterEach(() => {
   cleanup()
@@ -26,21 +26,21 @@ const schedule = {
   nextRunAt: '2026-09-08T06:00:00.000Z', createdAt: '2026-09-01T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z',
 }
 
-function renderSchedule(response: unknown, status = 200, kind: 'answer-visibility' | 'site-audit' = 'answer-visibility') {
+function renderSchedule(response: unknown, status = 200, kind: 'answer-visibility' | 'site-audit' = 'answer-visibility', running = false) {
   const request = vi.fn(async () => new Response(JSON.stringify(response), { status, headers: { 'content-type': 'application/json' } }))
   vi.stubGlobal('fetch', request)
   const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
-  const page = render(<QueryClientProvider client={client}><ManagedSweepStatus projectName="example" kind={kind} /></QueryClientProvider>)
+  const page = render(<QueryClientProvider client={client}><ManagedSweepStatus projectName="example" kind={kind} running={running} /></QueryClientProvider>)
   return { ...page, request, client }
 }
 
 test('reads the answer-visibility schedule and renders its real nextRunAt in the schedule timezone', async () => {
   const { request, container } = renderSchedule(schedule)
-  await screen.findByText(/Next scheduled sweep/)
+  await screen.findByText('Sep 8')
   const url = new URL((request.mock.calls[0] as unknown as [Request])[0].url)
   expect(url.pathname).toBe('/api/v1/projects/example/schedule')
   expect(url.searchParams.get('kind')).toBe('answer-visibility')
-  expect(screen.getByRole('status').textContent).toBe('Next scheduled sweep Tue, Sep 8, 2026, 2:00 AM EDT · managed by your Canonry team')
+  expect(screen.getByRole('status').textContent).toBe('Next sweep: Sep 8')
   expect(container.querySelector('time')?.dateTime).toBe(schedule.nextRunAt)
 })
 
@@ -53,9 +53,9 @@ test.each([
 ] as const)('%s shows the managed fallback without a date', async (_label, response, status) => {
   const { container, client } = renderSchedule(response, status)
   await waitFor(() => expect(client.isFetching()).toBe(0))
-  expect(screen.getByRole('status').textContent).toBe(MANAGED_SWEEPS_COPY)
+  expect(screen.getByRole('status').textContent).toBe(MANAGED_SWEEPS_UNAVAILABLE_COPY)
   expect(container.querySelector('time')).toBeNull()
-  expect(container.textContent).not.toMatch(/Next sync|2026|UTC|Invalid Date/)
+  expect(container.textContent).not.toMatch(/2026|UTC|Invalid Date|team/)
 })
 
 
@@ -99,28 +99,16 @@ test.each([
 })
 
 
-test('the schedule tooltip supports focus and Escape and explains the saved start time', async () => {
-  const nextRunAt = '2026-09-23T04:00:00.000Z'
-  const { request, container } = renderSchedule({ ...schedule, nextRunAt })
-  await screen.findByText(/Next scheduled sweep/)
-  const help = screen.getByRole('button', { name: /Sweeps are run by your Canonry team.*Sep 23, 2026, 12:00 AM EDT/ })
-  expect(help.getAttribute('aria-expanded')).toBe('false')
-  fireEvent.focus(help)
-  expect(help.getAttribute('aria-expanded')).toBe('true')
-  expect(screen.getByText(/Results update after the sweep finishes/)).toBeTruthy()
-  fireEvent.keyDown(help, { key: 'Escape' })
-  expect(help.getAttribute('aria-expanded')).toBe('false')
-  expect(container.querySelector('time')?.dateTime).toBe(nextRunAt)
-  expect(request.mock.calls.every(call => (call as unknown as [Request])[0].method === 'GET')).toBe(true)
+test('managed sweep date uses the schedule timezone at a UTC date boundary', async () => {
+  const { container } = renderSchedule({ ...schedule, nextRunAt: '2026-09-09T03:30:00.000Z' })
+  expect(await screen.findByText('Sep 8')).toBeTruthy()
+  expect(screen.getByRole('status').textContent).toBe('Next sweep: Sep 8')
+  expect(container.querySelector('time')?.dateTime).toBe('2026-09-09T03:30:00.000Z')
 })
 
-test.each([
-  [{ ...schedule, enabled: false }, 200, /Automatic sweeps are paused/],
-  [{ error: { code: 'NOT_FOUND' } }, 404, /No automatic sweep is currently scheduled/],
-  [{ error: { code: 'INTERNAL_ERROR' } }, 500, /The next scheduled time could not be loaded/],
-])('the tooltip explains unavailable schedules without promising a date: %j', async (response, status, message) => {
-  const { client, container } = renderSchedule(response, status)
-  await waitFor(() => expect(client.isFetching()).toBe(0))
-  expect(await screen.findByRole('button', { name: message })).toBeTruthy()
+test('managed sweep retains a concise running state', async () => {
+  const { container } = renderSchedule(schedule, 200, 'answer-visibility', true)
+  expect(await screen.findByText('Sweep running…')).toBeTruthy()
+  expect(screen.getByRole('status').textContent).toBe('Sweep running…')
   expect(container.querySelector('time')).toBeNull()
 })

--- a/apps/web/test/managed-sweeps.test.tsx
+++ b/apps/web/test/managed-sweeps.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, expect, test, vi } from 'vitest'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { isDashboardManagedRunKind, isDashboardManagedSweeps } from '../src/api.js'
-import { ManagedSweepStatus, MANAGED_SWEEPS_UNAVAILABLE_COPY, MANAGED_SCANS_COPY } from '../src/components/project/ManagedSweepStatus.js'
+import { ManagedSweepStatus, MANAGED_SWEEPS_UNAVAILABLE_COPY, MANAGED_SWEEPS_RUNNING_COPY, MANAGED_SWEEPS_NEXT_LABEL, MANAGED_SCANS_COPY } from '../src/components/project/ManagedSweepStatus.js'
 
 afterEach(() => {
   cleanup()
@@ -26,6 +26,11 @@ const schedule = {
   nextRunAt: '2026-09-08T06:00:00.000Z', createdAt: '2026-09-01T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z',
 }
 
+// This fixed local calendar date is independent of the scheduled UTC instant.
+const expectedLocalDate = new Date('2026-09-08T12:00:00.000Z').toLocaleDateString('en-US', {
+  month: 'short', day: 'numeric', timeZone: 'UTC',
+})
+
 function renderSchedule(response: unknown, status = 200, kind: 'answer-visibility' | 'site-audit' = 'answer-visibility', running = false) {
   const request = vi.fn(async () => new Response(JSON.stringify(response), { status, headers: { 'content-type': 'application/json' } }))
   vi.stubGlobal('fetch', request)
@@ -35,12 +40,12 @@ function renderSchedule(response: unknown, status = 200, kind: 'answer-visibilit
 }
 
 test('reads the answer-visibility schedule and renders its real nextRunAt in the schedule timezone', async () => {
-  const { request, container } = renderSchedule(schedule)
-  await screen.findByText('Sep 8')
+  const { request, container, client } = renderSchedule(schedule)
+  await waitFor(() => expect(client.isFetching()).toBe(0))
   const url = new URL((request.mock.calls[0] as unknown as [Request])[0].url)
   expect(url.pathname).toBe('/api/v1/projects/example/schedule')
   expect(url.searchParams.get('kind')).toBe('answer-visibility')
-  expect(screen.getByRole('status').textContent).toBe('Next sweep: Sep 8')
+  expect(screen.getByRole('status').textContent).toBe(`${MANAGED_SWEEPS_NEXT_LABEL} ${expectedLocalDate}`)
   expect(container.querySelector('time')?.dateTime).toBe(schedule.nextRunAt)
 })
 
@@ -55,7 +60,6 @@ test.each([
   await waitFor(() => expect(client.isFetching()).toBe(0))
   expect(screen.getByRole('status').textContent).toBe(MANAGED_SWEEPS_UNAVAILABLE_COPY)
   expect(container.querySelector('time')).toBeNull()
-  expect(container.textContent).not.toMatch(/2026|UTC|Invalid Date|team/)
 })
 
 
@@ -76,11 +80,15 @@ test('managed kinds replace the legacy sweep alias and are safe without a browse
 
 test('managed scans read the site-audit schedule and show its actual nextRunAt in UTC', async () => {
   const nextRunAt = '2026-10-01T06:00:00.000Z'
-  const { request, container } = renderSchedule({ ...schedule, kind: 'site-audit', nextRunAt }, 200, 'site-audit')
-  await screen.findByText(/Next scan/)
+  const { request, container, client } = renderSchedule({ ...schedule, kind: 'site-audit', nextRunAt }, 200, 'site-audit')
+  await waitFor(() => expect(client.isFetching()).toBe(0))
   const url = new URL((request.mock.calls[0] as unknown as [Request])[0].url)
   expect(url.searchParams.get('kind')).toBe('site-audit')
-  expect(screen.getByRole('status').textContent).toBe('Next scan Thursday 1 Oct, 06:00 UTC · managed by your Canonry team')
+  const expectedDate = new Date(nextRunAt).toLocaleString('en-GB', {
+    weekday: 'long', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
+    timeZone: 'UTC', hourCycle: 'h23',
+  })
+  expect(screen.getByRole('status').querySelector('time')?.textContent).toBe(`${expectedDate} UTC`)
   expect(container.querySelector('time')?.dateTime).toBe(nextRunAt)
 })
 
@@ -95,20 +103,18 @@ test.each([
   await waitFor(() => expect(client.isFetching()).toBe(0))
   expect(screen.getByRole('status').textContent).toBe(MANAGED_SCANS_COPY)
   expect(container.querySelector('time')).toBeNull()
-  expect(container.textContent).not.toMatch(/Next scan|UTC|\d|Invalid Date/)
 })
 
 
 test('managed sweep date uses the schedule timezone at a UTC date boundary', async () => {
-  const { container } = renderSchedule({ ...schedule, nextRunAt: '2026-09-09T03:30:00.000Z' })
-  expect(await screen.findByText('Sep 8')).toBeTruthy()
-  expect(screen.getByRole('status').textContent).toBe('Next sweep: Sep 8')
+  const { container, client } = renderSchedule({ ...schedule, nextRunAt: '2026-09-09T03:30:00.000Z' })
+  await waitFor(() => expect(client.isFetching()).toBe(0))
+  expect(screen.getByRole('status').textContent).toBe(`${MANAGED_SWEEPS_NEXT_LABEL} ${expectedLocalDate}`)
   expect(container.querySelector('time')?.dateTime).toBe('2026-09-09T03:30:00.000Z')
 })
 
 test('managed sweep retains a concise running state', async () => {
   const { container } = renderSchedule(schedule, 200, 'answer-visibility', true)
-  expect(await screen.findByText('Sweep running…')).toBeTruthy()
-  expect(screen.getByRole('status').textContent).toBe('Sweep running…')
+  expect(screen.getByRole('status').textContent).toBe(MANAGED_SWEEPS_RUNNING_COPY)
   expect(container.querySelector('time')).toBeNull()
 })

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -12,6 +12,7 @@ import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 import { AccountProvider } from '../src/contexts/account-context.js'
 import { preloadAllLazyRoutes } from '../src/router/routes.js'
 import { heyClient } from '../src/api.js'
+import { MANAGED_SWEEPS_COPY, MANAGED_SWEEPS_UNAVAILABLE_COPY, MANAGED_SWEEPS_RUNNING_COPY, MANAGED_SWEEPS_NEXT_LABEL } from '../src/components/project/ManagedSweepStatus.js'
 import { parseVisibilitySelection } from '../src/lib/measurement-view-url.js'
 import type { VisibilitySelectionState } from '../src/lib/measurement-view-url.js'
 import {
@@ -2457,20 +2458,22 @@ test('managed sweeps unset preserves the operator sweep control and identical op
   const disabled = await renderAt('/projects/project_citypoint', undefined, undefined, { ...options, managedSweeps: false })
   expect(projectHeader(original).outerHTML).toBe(projectHeader(disabled).outerHTML)
   expect(projectHeader(original).textContent).toContain('Run AI sweep')
-  expect(original).not.toContain('managed by your Canonry team')
-  expect(original).not.toContain('Sweeps are run by your Canonry team')
+  expect(original).not.toContain(MANAGED_SWEEPS_COPY)
 })
 
 test.each(['simple', 'advanced'] as const)('managed sweeps replaces the %s header control for admins and viewers', async mode => {
   for (const accountRole of ['admin', 'viewer'] as const) {
     const html = await renderAt('/projects/project_citypoint', undefined,
       mode === 'advanced' ? { plan: measurementPlanV2Response(2), overview: measurementOverviewResponse() } : undefined,
-      { managedSweeps: true, schedule: managedSchedule, accountRole },
+      { managedSweeps: true, schedule: managedSchedule, accountRole, configureFixture(dashboard) {
+        dashboard.projects.find(entry => entry.project.id === 'project_citypoint')!.recentRuns = []
+      } },
     )
     const header = projectHeader(html)
     expect(header.querySelector('button')).toBeNull()
-    expect(header.textContent).toContain('Sweep running…')
-    if (mode === 'advanced') expect(header.textContent).not.toContain('Recent measurements')
+    expect(header.querySelector('[role="status"]')?.textContent).toContain(MANAGED_SWEEPS_NEXT_LABEL)
+    expect(header.querySelector('time')?.dateTime).toBe(managedSchedule.nextRunAt)
+    if (mode === 'advanced') expect(header.querySelectorAll('.page-header-right > p:not([role="status"])')).toHaveLength(0)
     expect(html).not.toMatch(/Run AI sweep|Run measurement|Checking AI readiness|Set up AI Visibility/)
   }
 })
@@ -2481,8 +2484,9 @@ test('Advanced header keeps an explicit historical measurement range', async () 
     { managedSweeps: true, schedule: managedSchedule },
   )
   const header = projectHeader(html)
-  expect(header.textContent).toContain('2026-09-01 to 2026-09-08')
-  expect(header.textContent).not.toContain('Recent measurements')
+  const range = header.querySelector('.page-header-right > p:not([role="status"])')
+  expect(range?.textContent).toContain('2026-09-01')
+  expect(range?.textContent).toContain('2026-09-08')
 })
 
 test('managed sweeps without a schedule replaces the header action without inventing a date', async () => {
@@ -2492,10 +2496,9 @@ test('managed sweeps without a schedule replaces the header action without inven
     },
   })
   const status = projectHeader(html).querySelector('[role="status"]')!
-  expect(status.textContent).toBe('Next sweep unavailable')
+  expect(status.textContent).toBe(MANAGED_SWEEPS_UNAVAILABLE_COPY)
   expect(status.querySelector('time')).toBeNull()
   expect(projectHeader(html).querySelector('button')).toBeNull()
-  expect(status.textContent).not.toMatch(/UTC|\d/)
 })
 
 test.each(['simple', 'advanced'] as const)('managed %s project header retains queued and running sweep signals', async mode => {
@@ -2508,7 +2511,7 @@ test.each(['simple', 'advanced'] as const)('managed %s project header retains qu
       } },
     )
     const header = projectHeader(html)
-    expect(header.querySelector('[role="status"]')?.textContent).toBe('Sweep running…')
+    expect(header.querySelector('[role="status"]')?.textContent).toBe(MANAGED_SWEEPS_RUNNING_COPY)
     expect(header.querySelector('time')).toBeNull()
     expect(header.querySelector('button')).toBeNull()
   }
@@ -2522,7 +2525,7 @@ test.each(['simple', 'advanced'] as const)('managed %s settings exposes schedule
   const container = document.createElement('div')
   container.innerHTML = html
   const section = within(container).getByRole('heading', { name: 'Scheduled runs' }).closest('section')!
-  expect(section.textContent).toContain('Sweeps are run by your Canonry team')
+  expect(section.textContent).toContain(MANAGED_SWEEPS_COPY)
   expect(section.textContent).toContain('0 6 * * *')
   expect(within(section).queryByRole('button', { name: /Set schedule|Edit schedule|Pause|Resume|Remove|Save schedule/ })).toBeNull()
 })
@@ -2541,14 +2544,14 @@ test('managed sweeps removes Simple empty-state launch instructions', async () =
   const html = await renderAt('/projects/project_citypoint', undefined, undefined, {
     managedSweeps: true, configureFixture: forceNoisyFreshVisibility,
   })
-  expect(html).toContain('Sweeps are run by your Canonry team')
+  expect(html).toContain(MANAGED_SWEEPS_COPY)
   expect(html).not.toMatch(/Run another sweep|Complete your first AI Visibility sweep|Run a sweep/)
 })
 
 test('legacy managedSweeps alone still leaves Site Health scan controls available', async () => {
   const html = await renderAt('/projects/project_citypoint/technical-aeo', undefined, undefined, { managedSweeps: true })
   expect(html).toMatch(/Run scan|Checking scan/)
-  expect(projectHeader(html).textContent).toContain('Sweep running…')
+  expect(projectHeader(html).textContent).toContain(MANAGED_SWEEPS_RUNNING_COPY)
 })
 
 test('managed sweeps replaces the global batch sweep control', async () => {
@@ -2556,7 +2559,7 @@ test('managed sweeps replaces the global batch sweep control', async () => {
   expect(original).toContain('Run all projects')
   const managed = await renderAt('/runs', undefined, undefined, { managedSweeps: true })
   expect(managed).not.toContain('Run all projects')
-  expect(managed).toContain('Sweeps are run by your Canonry team')
+  expect(managed).toContain(MANAGED_SWEEPS_COPY)
 })
 
 

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -2468,12 +2468,21 @@ test.each(['simple', 'advanced'] as const)('managed sweeps replaces the %s heade
       { managedSweeps: true, schedule: managedSchedule, accountRole },
     )
     const header = projectHeader(html)
-    expect(header.querySelector('button:not(.info-tooltip-trigger)')).toBeNull()
-    expect(header.querySelector('time')?.dateTime).toBe(managedSchedule.nextRunAt)
-    expect(header.querySelector('.info-tooltip-trigger')?.getAttribute('aria-label')).toContain('Results update after the sweep finishes')
-    expect(header.textContent).toContain('Next scheduled sweep Tue, Sep 8, 2026, 6:00 AM UTC · managed by your Canonry team')
+    expect(header.querySelector('button')).toBeNull()
+    expect(header.textContent).toContain('Sweep running…')
+    if (mode === 'advanced') expect(header.textContent).not.toContain('Recent measurements')
     expect(html).not.toMatch(/Run AI sweep|Run measurement|Checking AI readiness|Set up AI Visibility/)
   }
+})
+
+test('Advanced header keeps an explicit historical measurement range', async () => {
+  const html = await renderAt('/projects/project_citypoint?measurementFrom=2026-09-01T00:00:00.000Z&measurementTo=2026-09-08T23:59:59.999Z', undefined,
+    { plan: measurementPlanV2Response(2), overview: measurementOverviewResponse() },
+    { managedSweeps: true, schedule: managedSchedule },
+  )
+  const header = projectHeader(html)
+  expect(header.textContent).toContain('2026-09-01 to 2026-09-08')
+  expect(header.textContent).not.toContain('Recent measurements')
 })
 
 test('managed sweeps without a schedule replaces the header action without inventing a date', async () => {
@@ -2483,10 +2492,10 @@ test('managed sweeps without a schedule replaces the header action without inven
     },
   })
   const status = projectHeader(html).querySelector('[role="status"]')!
-  expect(status.textContent).toBe('Sweeps are run by your Canonry team')
+  expect(status.textContent).toBe('Next sweep unavailable')
   expect(status.querySelector('time')).toBeNull()
-  expect(projectHeader(html).querySelector('button:not(.info-tooltip-trigger)')).toBeNull()
-  expect(status.textContent).not.toMatch(/Next sync|UTC|\d/)
+  expect(projectHeader(html).querySelector('button')).toBeNull()
+  expect(status.textContent).not.toMatch(/UTC|\d/)
 })
 
 test.each(['simple', 'advanced'] as const)('managed %s project header retains queued and running sweep signals', async mode => {
@@ -2499,10 +2508,9 @@ test.each(['simple', 'advanced'] as const)('managed %s project header retains qu
       } },
     )
     const header = projectHeader(html)
-    expect(header.querySelector('[role="status"]')?.textContent).toContain('AI sweep running…')
-    expect(header.querySelector('time')?.dateTime).toBe(managedSchedule.nextRunAt)
-    expect(header.querySelector('.info-tooltip-trigger')?.getAttribute('aria-label')).toContain('Results update after the sweep finishes')
-    expect(header.querySelector('button:not(.info-tooltip-trigger)')).toBeNull()
+    expect(header.querySelector('[role="status"]')?.textContent).toBe('Sweep running…')
+    expect(header.querySelector('time')).toBeNull()
+    expect(header.querySelector('button')).toBeNull()
   }
 })
 
@@ -2540,7 +2548,7 @@ test('managed sweeps removes Simple empty-state launch instructions', async () =
 test('legacy managedSweeps alone still leaves Site Health scan controls available', async () => {
   const html = await renderAt('/projects/project_citypoint/technical-aeo', undefined, undefined, { managedSweeps: true })
   expect(html).toMatch(/Run scan|Checking scan/)
-  expect(projectHeader(html).textContent).toContain('Sweeps are run by your Canonry team')
+  expect(projectHeader(html).textContent).toContain('Sweep running…')
 })
 
 test('managed sweeps replaces the global batch sweep control', async () => {

--- a/apps/web/test/schedule-section.test.tsx
+++ b/apps/web/test/schedule-section.test.tsx
@@ -1,3 +1,4 @@
+import { MANAGED_SWEEPS_COPY } from '../src/components/project/ManagedSweepStatus.js'
 import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider, focusManager } from '@tanstack/react-query'
@@ -45,7 +46,7 @@ test.each(['absent', 'active', 'paused'] as const)('managed %s schedule stays re
     expect(await screen.findByText('0 6 * * *')).toBeTruthy()
     expect(screen.getByText(state === 'active' ? 'Active' : 'Paused')).toBeTruthy()
   }
-  expect(await screen.findByText('Sweeps are run by your Canonry team')).toBeTruthy()
+  expect(await screen.findByText(MANAGED_SWEEPS_COPY)).toBeTruthy()
   expect(screen.queryByRole('button', { name: /Set schedule|Edit schedule|Pause|Resume|Remove|Save schedule/ })).toBeNull()
   expect(screen.queryByText(/Set one to automatically trigger/)).toBeNull()
   expect(screen.queryByRole('combobox')).toBeNull()

--- a/apps/web/test/setup-ai-visibility-onboarding.test.tsx
+++ b/apps/web/test/setup-ai-visibility-onboarding.test.tsx
@@ -10,6 +10,7 @@ import { heyClient } from '../src/api.js'
 import { createDashboardFixture } from '../src/mock-data.js'
 import { clearOnboardingRunLaunched } from '../src/lib/onboarding-telemetry.js'
 import { SetupPage } from '../src/pages/SetupPage.js'
+import { MANAGED_SWEEPS_COPY, MANAGED_SWEEPS_UNAVAILABLE_COPY } from '../src/components/project/ManagedSweepStatus.js'
 import { jsonResponse, mockFetch, pathOf } from './mock-fetch.js'
 
 const navigate = vi.hoisted(() => vi.fn())
@@ -369,7 +370,7 @@ test.each([
   fireEvent.click(await screen.findByRole('button', { name: 'Continue' }))
 
   expect(await screen.findByText(expected)).toBeTruthy()
-  expect(screen.getByText(managedSweeps ? 'Sweeps are run by your Canonry team' : 'Ask an administrator to review the provider and query configuration.')).toBeTruthy()
+  expect(screen.getByText(managedSweeps ? MANAGED_SWEEPS_COPY : 'Ask an administrator to review the provider and query configuration.')).toBeTruthy()
   expect(screen.queryByText('Fix provider or query configuration if needed, then retry without leaving setup.')).toBeNull()
   expect(screen.queryByRole('link', { name: 'Configure providers' })).toBeNull()
   expect(screen.queryByRole('button', { name: 'Retry visibility sweep' })).toBeNull()
@@ -673,7 +674,9 @@ test('managed sweeps finishes setup without offering to launch or retry a sweep'
   window.__CANONRY_CONFIG__ = { dashboard: { managedSweeps: true } }
   const { requests } = renderColdScopedSetup(() => jsonResponse({ answerVisibilityProviderReady: true }))
   fireEvent.click(await screen.findByRole('button', { name: 'Continue' }))
-  expect(await screen.findByText('Sweeps are run by your Canonry team')).toBeTruthy()
+  const scheduleStatus = await screen.findByText(MANAGED_SWEEPS_UNAVAILABLE_COPY)
+  expect(scheduleStatus.closest('[role="status"]')).toBeTruthy()
+  expect(scheduleStatus.querySelector('time')).toBeNull()
   expect(screen.queryByRole('button', { name: /Launch visibility sweep|Retry visibility sweep/ })).toBeNull()
   expect(screen.queryByText(/Run a first sweep/)).toBeNull()
   fireEvent.click(screen.getByRole('button', { name: 'Open project dashboard →' }))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.190.0",
+  "version": "4.190.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/AGENTS.md
+++ b/packages/api-routes/AGENTS.md
@@ -115,6 +115,16 @@ Groups select properties. Markets select frozen `reportingScopes` execution edge
 Label-only revisions use the comparable chain. Material changes read prior evidence through its own frozen plan.
 Never infer a market from a group label or reuse the browser's global run drawer parameter.
 
+### Portfolio summary aggregation
+
+Prepare the filtered run once with `createMeasurementOverviewEvaluator` and reuse
+its attribution indexes for the portfolio and every group. Each group aggregates
+its unique answer slots; overlapping property memberships must not multiply the
+denominator. Rank all eligible properties before applying `limit`, then calculate
+recommendations only for the returned properties. The limit does not truncate
+market rollups or change portfolio totals. Keep the evaluator request-local so
+run, revision, provider, location, and query-class selections cannot share stale data.
+
 ### Route file structure
 
 Each file exports an async Fastify plugin function:

--- a/packages/api-routes/src/measurement-portfolio-reads.ts
+++ b/packages/api-routes/src/measurement-portfolio-reads.ts
@@ -46,10 +46,11 @@ import {
   type ActiveMeasurementPlan,
 } from './measurement-overview.js'
 import {
-  buildMeasurementOverview,
+  createMeasurementOverviewEvaluator,
   normalizeMeasurementLocation,
   targetMentionedInAnswer,
   type MeasurementOverview,
+  type MeasurementOverviewEvaluator,
   type MeasurementRate,
 } from './measurement-report.js'
 import {
@@ -179,9 +180,8 @@ function filteredOverviewWithDb(
 ): {
   materialized: MaterializedRun
   overview: MeasurementOverview
-  /** The filtered inputs, exposed so a caller can re-scope them without re-reading the database. */
-  expectedSlots: MaterializedRun['input']['expectedSlots']
-  usageEdges: MaterializedRun['input']['usageEdges']
+  /** Reuses the prepared filtered run for the overall scope and every market. */
+  evaluator: MeasurementOverviewEvaluator
 } {
   const materialized = materializeWithDb(db, active, plan, run)
   const provider = filters.provider === undefined ? undefined : normalizeText(filters.provider)
@@ -193,16 +193,16 @@ function filteredOverviewWithDb(
   const usageEdges = materialized.input.usageEdges.filter(edge => (
     filters.queryClass === 'all' || materialized.edgeQueryClass.get(edge.id) === filters.queryClass
   ))
-  return {
-    materialized,
+  const evaluator = createMeasurementOverviewEvaluator({
+    ...materialized.input,
     expectedSlots,
     usageEdges,
-    overview: buildMeasurementOverview({
-      ...materialized.input,
-      expectedSlots,
-      usageEdges,
-      scopeTargetIds: [...targetKeys],
-    }),
+    scopeTargetIds: [...targetKeys],
+  })
+  return {
+    materialized,
+    evaluator,
+    overview: evaluator.evaluate(targetKeys),
   }
 }
 
@@ -401,9 +401,7 @@ function targetKeysForRun(
 function marketRollup(
   plan: MeasurementPlanV2,
   run: RunRow,
-  materialized: MaterializedRun,
-  expectedSlots: MaterializedRun['input']['expectedSlots'],
-  usageEdges: MaterializedRun['input']['usageEdges'],
+  evaluator: MeasurementOverviewEvaluator,
   scopedToOneGroup: boolean,
 ): MeasurementPortfolioMarket[] {
   if (scopedToOneGroup) return []
@@ -414,12 +412,7 @@ function marketRollup(
     // group-scoped read of the same market reaches it the same way — inventing
     // a reason here is how the two surfaces start disagreeing again.
     const targetKeys = targetKeysForRun(plan, run, group.targetKeys, false)
-    const overview = buildMeasurementOverview({
-      ...materialized.input,
-      expectedSlots,
-      usageEdges,
-      scopeTargetIds: targetKeys,
-    })
+    const overview = evaluator.evaluate(targetKeys)
     return {
       groupKey: group.stableKey,
       label: group.label,
@@ -517,22 +510,28 @@ function portfolioResponse(
     })
   }
 
-  const { materialized, overview, expectedSlots: filteredSlots, usageEdges: filteredEdges } = filteredOverviewWithDb(db, active, plan, run, filters, targetKeys)
+  const { materialized, overview, evaluator } = filteredOverviewWithDb(db, active, plan, run, filters, targetKeys)
   const measured = new Map(overview.properties.map(row => [row.targetId, row]))
-  const rows = targets.map(target => {
+  const ranked = targets.map(target => {
     const row = measured.get(target.stableKey)
-    const recommendations = recommendationRows(target, targetAnswers(plan, target, materialized, filters))
     return {
+      target,
       ...propertyDto(target),
       mentionCoverage: row ? coverageMetric(row.mentionCoverage) : unavailable('no_population'),
       citationCoverage: row ? coverageMetric(row.citationCoverage) : unavailable('no_population'),
       flags: row?.flags ?? 0,
+    }
+  }).sort(compareWeakest)
+  const limit = query.limit ?? DEFAULT_LIMIT
+  const rows = ranked.slice(0, limit).map(({ target, ...row }) => {
+    const recommendations = recommendationRows(target, targetAnswers(plan, target, materialized, filters))
+    return {
+      ...row,
       recommendedInstead: recommendations.slice(0, 5).map(({ name, occurrences }) => ({ name, occurrences })),
       recommendedInsteadTotal: recommendations.length,
       recommendedInsteadTruncated: recommendations.length > 5,
     }
-  }).sort(compareWeakest)
-  const limit = query.limit ?? DEFAULT_LIMIT
+  })
   return measurementPortfolioSummaryResponseSchema.parse({
     portfolio: {
       groupKey: group?.stableKey ?? null,
@@ -547,9 +546,9 @@ function portfolioResponse(
       citationCoverage: coverageMetric(overview.citationCoverage),
     },
     weakestProperties: rows.slice(0, limit),
-    markets: marketRollup(plan, run, materialized, filteredSlots, filteredEdges, group !== undefined),
-    totalProperties: rows.length,
-    truncated: rows.length > limit,
+    markets: marketRollup(plan, run, evaluator, group !== undefined),
+    totalProperties: ranked.length,
+    truncated: ranked.length > limit,
   })
 }
 

--- a/packages/api-routes/src/measurement-report.ts
+++ b/packages/api-routes/src/measurement-report.ts
@@ -320,6 +320,18 @@ export interface MeasurementOverviewBuildOptions extends MeasurementPreparationB
   onEvidenceIndexed?: (rows: number) => void
 }
 
+/**
+ * Reuses a run's prepared attribution evidence and indexes while evaluating
+ * several reporting scopes. A portfolio summary needs this for its overall
+ * scope plus every market: each scope changes only its selected Properties.
+ */
+export interface MeasurementOverviewEvaluator {
+  evaluate(
+    scopeTargetIds: readonly string[],
+    namedIdentities?: readonly MeasurementNamedIdentityInput[],
+  ): MeasurementOverview
+}
+
 interface ParsedSourceUrl {
   normalizedUrl: string
   host: string
@@ -1347,59 +1359,70 @@ function scopeNamedShareOfVoice(
  * kernel only has to reach the unique slots the selected Properties share. Two
  * Properties reusing one execution contribute one slot, never two.
  */
+export function createMeasurementOverviewEvaluator(
+  input: MeasurementOverviewInput,
+  options: MeasurementOverviewBuildOptions = {},
+): MeasurementOverviewEvaluator {
+  const prepared = prepareReport(input, options)
+  const indexes = buildMeasurementOverviewIndexes(input, prepared, options.onEvidenceIndexed)
+  return {
+    evaluate(scopeTargetIds, namedIdentities = input.namedIdentities) {
+      const targetIds = new Set(scopeTargetIds)
+      const edges = indexedScopeEdges(indexes, targetIds)
+      const slots = indexedSlotsForEdges(edges, indexes)
+      const answered = indexedAnsweredSlots(slots, indexes)
+
+      const properties = sortedUnique([...targetIds]).map(targetId => {
+        const ownEdges = indexes.targetEdgesByTargetId.get(targetId) ?? []
+        const ownSlots = indexedSlotsForEdges(ownEdges, indexes)
+        const ownAnswered = indexedAnsweredSlots(ownSlots, indexes)
+        const ownTargets = indexes.targetsById.get(targetId)
+        return {
+          targetId,
+          mentionCoverage: targetMentionRate(ownTargets, ownSlots, ownAnswered, indexes),
+          citationCoverage: indexedScopeCitationRate(ownSlots, ownEdges, indexes),
+          // Each engine is measured over the slots it owns, using exactly the
+          // functions the Property total uses. A per-engine reading is therefore
+          // withheld for the same reasons the total is, never rounded down to zero.
+          providers: providersFor(ownSlots).map(provider => {
+            const providerSlots = ownSlots.filter(slot => slot.provider === provider)
+            return {
+              provider,
+              mentionCoverage: targetMentionRate(
+                ownTargets,
+                providerSlots,
+                indexedAnsweredSlots(providerSlots, indexes),
+                indexes,
+              ),
+              citationCoverage: indexedScopeCitationRate(providerSlots, ownEdges, indexes),
+            }
+          }),
+          flags: indexes.ambiguousEvidenceKeysByTargetId.get(targetId)?.size ?? 0,
+        }
+      })
+
+      return {
+        eligibleSlots: slots.length,
+        answeredSlots: answered.length,
+        includesHistoricalData: prepared.diagnostics.bridgedObservationIds.length > 0
+          || prepared.diagnostics.historicalObservationIds.length > 0,
+        propertiesMentioned: scopePropertiesMentioned(input, targetIds, slots, answered, prepared),
+        mentionCoverage: scopeMentionRate(input, targetIds, slots, answered, prepared),
+        citationCoverage: indexedScopeCitationRate(slots, edges, indexes),
+        brandPresence: scopeBrandPresence(input, slots, answered, prepared),
+        namedShareOfVoice: scopeNamedShareOfVoice(namedIdentities ?? [], answered, prepared),
+        properties,
+        flags: properties.reduce((total, row) => total + row.flags, 0),
+      }
+    },
+  }
+}
+
 export function buildMeasurementOverview(
   input: MeasurementOverviewInput,
   options: MeasurementOverviewBuildOptions = {},
 ): MeasurementOverview {
-  const prepared = prepareReport(input, options)
-  const indexes = buildMeasurementOverviewIndexes(input, prepared, options.onEvidenceIndexed)
-  const targetIds = new Set(input.scopeTargetIds)
-  const edges = indexedScopeEdges(indexes, targetIds)
-  const slots = indexedSlotsForEdges(edges, indexes)
-  const answered = indexedAnsweredSlots(slots, indexes)
-
-  const properties = sortedUnique([...targetIds]).map(targetId => {
-    const ownEdges = indexes.targetEdgesByTargetId.get(targetId) ?? []
-    const ownSlots = indexedSlotsForEdges(ownEdges, indexes)
-    const ownAnswered = indexedAnsweredSlots(ownSlots, indexes)
-    const ownTargets = indexes.targetsById.get(targetId)
-    return {
-      targetId,
-      mentionCoverage: targetMentionRate(ownTargets, ownSlots, ownAnswered, indexes),
-      citationCoverage: indexedScopeCitationRate(ownSlots, ownEdges, indexes),
-      // Each engine is measured over the slots it owns, using exactly the
-      // functions the Property total uses. A per-engine reading is therefore
-      // withheld for the same reasons the total is, never rounded down to zero.
-      providers: providersFor(ownSlots).map(provider => {
-        const providerSlots = ownSlots.filter(slot => slot.provider === provider)
-        return {
-          provider,
-          mentionCoverage: targetMentionRate(
-            ownTargets,
-            providerSlots,
-            indexedAnsweredSlots(providerSlots, indexes),
-            indexes,
-          ),
-          citationCoverage: indexedScopeCitationRate(providerSlots, ownEdges, indexes),
-        }
-      }),
-      flags: indexes.ambiguousEvidenceKeysByTargetId.get(targetId)?.size ?? 0,
-    }
-  })
-
-  return {
-    eligibleSlots: slots.length,
-    answeredSlots: answered.length,
-    includesHistoricalData: prepared.diagnostics.bridgedObservationIds.length > 0
-      || prepared.diagnostics.historicalObservationIds.length > 0,
-    propertiesMentioned: scopePropertiesMentioned(input, targetIds, slots, answered, prepared),
-    mentionCoverage: scopeMentionRate(input, targetIds, slots, answered, prepared),
-    citationCoverage: indexedScopeCitationRate(slots, edges, indexes),
-    brandPresence: scopeBrandPresence(input, slots, answered, prepared),
-    namedShareOfVoice: scopeNamedShareOfVoice(input.namedIdentities ?? [], answered, prepared),
-    properties,
-    flags: properties.reduce((total, row) => total + row.flags, 0),
-  }
+  return createMeasurementOverviewEvaluator(input, options).evaluate(input.scopeTargetIds, input.namedIdentities)
 }
 
 export interface MeasurementEvidenceResult {

--- a/packages/api-routes/test/measurement-portfolio-reads.test.ts
+++ b/packages/api-routes/test/measurement-portfolio-reads.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { and, eq } from 'drizzle-orm'
 import Fastify, { type FastifyInstance } from 'fastify'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildMeasurementExecutionIdentity,
   canonicalMeasurementPlanV2Json,
@@ -24,6 +24,26 @@ import {
   runs,
   type DatabaseClient,
 } from '@ainyc/canonry-db'
+const portfolioReadWork = vi.hoisted(() => ({
+  evaluatorBuilds: 0,
+  targetMentionChecks: 0,
+}))
+
+vi.mock('../src/measurement-report.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/measurement-report.js')>()
+  return {
+    ...actual,
+    createMeasurementOverviewEvaluator: (...args: Parameters<typeof actual.createMeasurementOverviewEvaluator>) => {
+      portfolioReadWork.evaluatorBuilds++
+      return actual.createMeasurementOverviewEvaluator(...args)
+    },
+    targetMentionedInAnswer: (...args: Parameters<typeof actual.targetMentionedInAnswer>) => {
+      portfolioReadWork.targetMentionChecks++
+      return actual.targetMentionedInAnswer(...args)
+    },
+  }
+})
+
 import { apiRoutes } from '../src/index.js'
 import { compareWeakestMarket } from '../src/measurement-portfolio-reads.js'
 import { buildMeasurementPlanV2Manifest } from '../src/measurement-report-adapter.js'
@@ -191,6 +211,8 @@ beforeEach(async () => {
     updatedAt: NOW,
   }).run()
   plan = measurementPlanV2Fixture()
+  portfolioReadWork.evaluatorBuilds = 0
+  portfolioReadWork.targetMentionChecks = 0
 
   app = Fastify()
   app.register(apiRoutes, { db, skipAuth: true })
@@ -257,6 +279,28 @@ describe('measurement portfolio reads', () => {
     const harbor = await portfolio(`groupKey=regional&runId=${measured}&limit=2`)
     expect(harbor.body.weakestProperties.find(row => row.targetKey === 'harbor')?.recommendedInstead)
       .toEqual([{ name: 'Rival One', occurrences: 1 }])
+  })
+
+  it('prepares the filtered run once and reads recommendations only for displayed Properties', async () => {
+    plan = {
+      ...plan,
+      groups: [
+        ...plan.groups,
+        { stableKey: 'harbor-only', label: 'Harbor only', targetKeys: ['harbor'], competitors: [] },
+      ],
+    }
+    const versionId = seedVersion(1)
+    activate(versionId)
+    seedFullRun(versionId)
+
+    const { status, body } = await portfolio('limit=1')
+
+    expect(status).toBe(200)
+    expect(body.weakestProperties).toHaveLength(1)
+    expect(portfolioReadWork.evaluatorBuilds).toBe(1)
+    // One non-brand execution is shared by both Properties on two providers.
+    // A limit of one therefore reads two target-answer states, not all four.
+    expect(portfolioReadWork.targetMentionChecks).toBe(2)
   })
 
   it('scopes each market to its own members, worst-first, and agrees with a group-scoped read', async () => {

--- a/packages/api-routes/test/measurement-report.test.ts
+++ b/packages/api-routes/test/measurement-report.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildMeasurementOverview,
+  createMeasurementOverviewEvaluator,
   buildMeasurementReport,
   classifyCitedUrl,
   normalizeMeasurementLocation,
@@ -607,6 +608,25 @@ describe('scoped overview', () => {
 
     expect(overview.properties.map(row => [row.targetId, row.flags])).toEqual([['shared-a', 1], ['shared-b', 1]])
     expect(overview.flags).toBe(2)
+  })
+
+  it('reuses prepared attribution indexes across a portfolio of market scopes', () => {
+    const input = overviewInput()
+    const evidencePasses: number[] = []
+    const expected = buildMeasurementOverview({ ...input, scopeTargetIds: ['north'] })
+    const evaluator = createMeasurementOverviewEvaluator(input, {
+      onEvidenceIndexed: rows => evidencePasses.push(rows),
+    })
+
+    // A large portfolio evaluates its main scope plus every market. The work
+    // that walks every attributed source must remain one preparation pass.
+    for (let index = 0; index < 157; index++) {
+      const targetIds = index % 2 === 0 ? ['north'] : ['harbor', 'north']
+      const overview = evaluator.evaluate(targetIds)
+      if (index === 0) expect(overview).toEqual(expected)
+    }
+
+    expect(evidencePasses).toEqual([6])
   })
 
   it('indexes shared attribution evidence once before deriving every Property row', () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.190.0",
+  "version": "4.190.1",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.190.0",
+  "version": "4.190.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.190.0",
+  "version": "4.190.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.190.0",
+  "version": "4.190.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Context

Large portfolio summaries rebuilt run evidence for every group and calculated recommendations for every property before applying `limit`. Reuse one request-local aggregation index across scopes, rank all eligible properties, and calculate recommendations only for returned rows. Preserve market rollups, totals, filters, and unavailable-result semantics.

Managed sweep headers show only the next calendar date in the schedule timezone. Remove the overflowing tooltip and redundant default Advanced date label. Preserve running and unavailable states, explicit historical ranges, Simple mode, and Site Health behavior. Release: 4.190.1.

## Validation

- Rebased all three commits onto current main. Range-diff confirms only release versions changed during conflict resolution.
- 254 focused API and web tests passed, including aggregation, portfolio scopes, revision continuity, and managed sweep states. UI assertions use shared copy constants and semantic selectors.
- Saved-data replay: full summary **83.2s before the fix, 1.97s on the rebased branch**. Full, branded/provider-filtered, and one-property responses match the original JSON exactly. Limits 1, 10, and 50 preserve result prefixes and all market rollups. No provider calls or production changes.
- API and web typechecks, lint of all changed TypeScript files, web and CLI production builds, and committed drift gates passed.
- Earlier desktop/mobile browser previews passed at 1440px and 390px. The rebase changes release versions only; no new browser preview was required.
