### PR TITLE
fix(web): keep Site Health defaults scannable

### DIFF
--- a/apps/web/src/components/project/TechnicalAeoSection.tsx
+++ b/apps/web/src/components/project/TechnicalAeoSection.tsx
@@ -276,15 +276,12 @@ export function TechnicalAeoSection({
     getSearchText: siteAuditPageSearchText,
   })
   const pagesCapped = score ? score.pagesAudited > allPages.length : false
-  const primaryFactorId = score?.crossCuttingIssues[0]?.factorId
-    ?? score?.factors.find((factor) => factor.pagesPartial + factor.pagesFailing > 0)?.id
-    ?? null
-
   useEffect(() => {
     setErrorsOnly(false)
-    // Onboarding uses the same closed-by-default disclosures as page findings.
-    setExpandedFactor(integrated && !compactCopy ? primaryFactorId : null)
-  }, [compactCopy, effectiveRunId, integrated, primaryFactorId])
+    // Every Page Health check begins closed. Its table row already gives the
+    // score, status, and affected-page count needed to choose what to inspect.
+    setExpandedFactor(null)
+  }, [compactCopy, effectiveRunId, integrated])
 
   if (scoreQuery.isLoading) {
     return (

--- a/apps/web/src/components/project/site-graph-sigma.ts
+++ b/apps/web/src/components/project/site-graph-sigma.ts
@@ -195,8 +195,13 @@ export const SITE_GRAPH_LABEL_BUDGETS = [
   { maxRatio: 0.45, budget: 60 },
   { maxRatio: SITE_GRAPH_OVERVIEW_CAMERA_RATIO, budget: 24 },
 ] as const
-/** The fitted overview: the root plus the best-linked handful. */
-export const SITE_GRAPH_OVERVIEW_LABEL_BUDGET = 10
+/**
+ * The fitted overview names only the crawl root. Even a small ranked handful
+ * can land in the same dense part of a real site's layout, which turns their
+ * long paths into unreadable overlapping text. Search, hover, selection, and
+ * zoom reveal every other page name when the reader asks for it.
+ */
+export const SITE_GRAPH_OVERVIEW_LABEL_BUDGET = 1
 
 export function siteGraphLabelBudget(cameraRatio: number): number {
   for (const tier of SITE_GRAPH_LABEL_BUDGETS) {

--- a/apps/web/test/site-graph-sigma-adapter.test.ts
+++ b/apps/web/test/site-graph-sigma-adapter.test.ts
@@ -240,9 +240,9 @@ describe('buildSigmaSiteGraph', () => {
     })
   })
 
-  it('spends a zoom-dependent label budget on the best-linked pages', () => {
-    // A fitted 50-page map used to draw every label at once, overlapping into
-    // unreadable text. The budget names the pages a reader looks for first.
+  it('names only the crawl root in the fitted overview, then reveals labels when zoomed in', () => {
+    // A fitted map can cluster even its highest-ranked paths in one small area.
+    // Naming only the root prevents that overview from becoming unreadable.
     const pages = Array.from({ length: 40 }, (_, index) => node(`p${String(index).padStart(2, '0')}`, {
       path: `/p${index}`,
       depth: 1 + (index % 3),
@@ -264,12 +264,8 @@ describe('buildSigmaSiteGraph', () => {
     }
 
     const overview = labelled(1)
-    expect(overview.length).toBeLessThanOrEqual(SITE_GRAPH_OVERVIEW_LABEL_BUDGET)
-    // The root is always one of them, whatever its link score.
-    expect(overview).toContain('home')
-    // The rest are the best-linked pages, not an arbitrary slice.
-    expect(overview).toContain('p39')
-    expect(overview).not.toContain('p00')
+    expect(overview).toEqual(['home'])
+    expect(overview).toHaveLength(SITE_GRAPH_OVERVIEW_LABEL_BUDGET)
 
     // Zooming in reveals more, and a close zoom holds nothing back.
     expect(labelled(0.6).length).toBeGreaterThan(overview.length)
@@ -495,12 +491,13 @@ describe('a real template-mesh site (canonry.ai shape: 50 pages, ~1,259 links)',
 
     const fitted = createSigmaSiteGraphReducers(built.graph, null, 1, theme)
 
-    // Labels stay inside the budget instead of overlapping into a smear.
+    // The fitted overview names only the root, so dense page clusters cannot
+    // turn their long paths into overlapping text.
     const labelled = built.graph.nodes().filter((nodeKey) => (
       fitted.nodeReducer(nodeKey, built.graph.getNodeAttributes(nodeKey)).label !== ''
     ))
-    expect(labelled.length).toBeLessThanOrEqual(SITE_GRAPH_OVERVIEW_LABEL_BUDGET)
-    expect(labelled).toContain('page-00')
+    expect(labelled).toEqual(['page-00'])
+    expect(labelled).toHaveLength(SITE_GRAPH_OVERVIEW_LABEL_BUDGET)
 
     // Exactly one page carries the root marker, and it is the one the server
     // identified. Its label is its path like every other page.

--- a/apps/web/test/technical-aeo-section.test.tsx
+++ b/apps/web/test/technical-aeo-section.test.tsx
@@ -424,7 +424,11 @@ test('distills the integrated view to a score and its actionable findings', asyn
   expect(screen.queryByText('Recover unavailable Page health')).toBeNull()
 
   const failingFactor = screen.getByRole('button', { name: 'AI Crawler Access' })
-  await waitFor(() => expect(failingFactor.getAttribute('aria-expanded')).toBe('true'))
+  expect(failingFactor.getAttribute('aria-expanded')).toBe('false')
+  expect(screen.queryByText('Allow GPTBot in robots.txt')).toBeNull()
+  expect(screen.queryByRole('link', { name: 'https://citypoint.example/services' })).toBeNull()
+  fireEvent.click(failingFactor)
+  expect(failingFactor.getAttribute('aria-expanded')).toBe('true')
   expect(screen.getByText('Allow GPTBot in robots.txt')).not.toBeNull()
   expect(screen.getByRole('link', { name: 'https://citypoint.example/services' })).not.toBeNull()
 
@@ -445,6 +449,9 @@ test('keeps the integrated findings table readable while affected pages load', a
     </QueryClientProvider>,
   )
 
+  const factorButton = screen.getByRole('button', { name: 'AI Crawler Access' })
+  expect(factorButton.getAttribute('aria-expanded')).toBe('false')
+  fireEvent.click(factorButton)
   expect(await screen.findByText('Loading affected pages...')).not.toBeNull()
   expect(screen.getByRole('table').className).toContain('min-w-[42rem]')
   expect(screen.queryByText('Page details are not available in the loaded audit sample.')).toBeNull()
@@ -590,6 +597,9 @@ test('shows a focused retry when integrated affected pages fail to load', async 
     </QueryClientProvider>,
   )
 
+  const factorButton = screen.getByRole('button', { name: 'AI Crawler Access' })
+  expect(factorButton.getAttribute('aria-expanded')).toBe('false')
+  fireEvent.click(factorButton)
   expect(await screen.findByText('Affected pages could not load')).not.toBeNull()
   expect(screen.queryByText('Page details are not available in the loaded audit sample.')).toBeNull()
   expect(screen.queryByText(/Showing the worst 0 audited pages/)).toBeNull()
@@ -620,7 +630,9 @@ test('keeps recommendation-free integrated findings truthful and single-column',
   expect(screen.queryByRole('heading', { name: 'Recommended fixes' })).toBeNull()
 
   const factorButton = screen.getByRole('button', { name: 'AI Crawler Access' })
-  await waitFor(() => expect(factorButton.getAttribute('aria-expanded')).toBe('true'))
+  expect(factorButton.getAttribute('aria-expanded')).toBe('false')
+  fireEvent.click(factorButton)
+  expect(factorButton.getAttribute('aria-expanded')).toBe('true')
   expect(factorButton.hasAttribute('aria-controls')).toBe(false)
   const affectedPagesHeading = screen.getByRole('heading', { name: 'Affected pages (2)' })
   expect(affectedPagesHeading.closest('.grid')?.className).not.toContain('lg:grid-cols-2')


### PR DESCRIPTION
## Context

Site Health should open as a scannable overview. Ranked labels can cluster in the fitted graph, and auto-expanding a failing check hides that summary-first workflow.

## Summary

- Restrict the fitted graph to its crawl-root label, while retaining labels after zoom or focus.
- Start every Page Health check collapsed, including the integrated Site Health view.

## What ships

- Regression coverage for the fitted overview and each on-demand detail state.

## Validation

- pnpm run verify