### PR TITLE
fix: retain market context when opening property visibility

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -122,7 +122,10 @@ server-declared market keys; never infer query geography from a label or shared
 property membership. Standalone property questions are grouped by saved market.
 Query administration remains an assignment editor; entering it clears the report's
 market intersection instead of silently widening a scoped edit. Linked markets
-stay under their explicit groups in both pickers.
+stay under their explicit groups in both pickers; searches include nested markets.
+An explicitly selected market survives property navigation even when its group has
+multiple markets. Group rows and saved group URLs retain the report's existing
+filters; a navigation link alone must not change their totals.
 
 `ProjectPage` owns the shared measurement URL selection and the `/queries` route.
 `QueriesSection` in `DiscoverySection.tsx` owns tracked assignments and the separate Research workspace.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -116,6 +116,14 @@ export function fetchMyNewThing(name: string): Promise<MyNewDto> {
 
 ### Query control and measured results
 
+AI Visibility property drilldowns retain an explicit `measurementMarketKey` in
+URL, aggregate, evidence, pagination and cache identity. Linked groups use only
+server-declared market keys; never infer query geography from a label or shared
+property membership. Standalone property questions are grouped by saved market.
+Query administration remains an assignment editor; entering it clears the report's
+market intersection instead of silently widening a scoped edit. Linked markets
+stay under their explicit groups in both pickers.
+
 `ProjectPage` owns the shared measurement URL selection and the `/queries` route.
 `QueriesSection` in `DiscoverySection.tsx` owns tracked assignments and the separate Research workspace.
 Research retains ICP discovery and bounded tests. Promotion must use query-tracking preview and commit.

--- a/apps/web/src/components/project/DiscoverySection.tsx
+++ b/apps/web/src/components/project/DiscoverySection.tsx
@@ -726,7 +726,7 @@ function TrackingScopePicker({
         targetCount: group.targetKeys.length,
         ...(group.parentGroupKey ? { parentGroupIds: [group.parentGroupKey] } : {}),
       })),
-      ...workspace.markets.map(market => ({ id: market.stableKey, label: market.label, kind: 'market' as const, targetCount: 0 })),
+      ...workspace.markets.map(market => ({ id: market.stableKey, label: market.label, kind: 'market' as const, targetCount: new Set(market.usageEdges.map(edge => edge.targetKey)).size, ...(market.groupKey ? { parentGroupIds: [market.groupKey] } : {}) })),
       ...workspace.targets.map(target => ({
         id: target.stableKey,
         label: target.label,

--- a/apps/web/src/components/project/VisibilityScopePicker.tsx
+++ b/apps/web/src/components/project/VisibilityScopePicker.tsx
@@ -11,7 +11,7 @@ export const MARKET_SCOPE_COPY = {
   select: (label: string) => `Select ${label}`,
   browseAll: 'Browse all properties',
 }
-export const marketForGroup = (scope?: VisibilityReportScopeOption) => scope?.kind === 'group' && scope.marketKeys?.length === 1 ? scope.marketKeys[0] : undefined
+const marketForGroup = (scope?: VisibilityReportScopeOption) => scope?.kind === 'group' && scope.marketKeys?.length === 1 ? scope.marketKeys[0] : undefined
 const countFor = (count: number) => `${count} ${count === 1 ? 'property' : 'properties'}`
 
 /** Navigation uses explicit frozen memberships, never labels or inferred containment. */
@@ -54,10 +54,20 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
   const visibleGroups = (allProperties ? [] : current
     ? groups.filter(group => query ? isDescendant(group) : group.parentGroupIds?.includes(current.id))
     : query ? groups : roots).filter(matches)
-  const currentMarketKey = allowGroupSelect ? marketForGroup(current) : undefined
+  const selectedMarket = options.find(option => option.kind === 'market' && option.id === (marketKey ?? (selected.kind === 'market' ? selected.id : undefined)))
+  const explicitCurrentMarketKey = current && selectedMarket && (current.marketKeys?.includes(selectedMarket.id) || selectedMarket.parentGroupIds?.includes(current.id)) ? selectedMarket.id : undefined
+  const currentMarketKey = allowGroupSelect ? explicitCurrentMarketKey ?? marketForGroup(current) : undefined
   const visibleProperties = (current ? properties.filter(property => property.parentGroupIds?.includes(current.id) && (!currentMarketKey || property.marketKeys?.includes(currentMarketKey)))
     : query || allProperties || groups.length === 0 ? properties : []).filter(matches)
-  const markets = allProperties || (allowGroupSelect && current?.marketKeys?.length === 1) ? [] : options.filter(scope => scope.kind === 'market' && (allowGroupSelect || current || query || groups.length === 0) && (current ? scope.parentGroupIds?.includes(current.id) : !scope.parentGroupIds?.some(key => groupById.has(key))) && matches(scope))
+  const markets = options.filter(scope => {
+    if (scope.kind !== 'market' || allProperties) return false
+    if (!allowGroupSelect && !current && !query && groups.length > 0) return false
+    if (allowGroupSelect && current?.marketKeys?.length === 1 && !query) return false
+    const withinSearch = current
+      ? query ? isDescendant(scope) : scope.parentGroupIds?.includes(current.id)
+      : query || !scope.parentGroupIds?.some(key => groupById.has(key))
+    return withinSearch && matches(scope)
+  })
   const projects = current || allProperties ? [] : options.filter(scope => scope.kind === 'project' && matches(scope))
 
   useEffect(() => {
@@ -70,7 +80,7 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
 
   const choose = (scope: VisibilityReportScopeOption) => {
     if (picker.current) { picker.current.open = false; picker.current.querySelector('summary')?.focus() }
-    const selectedMarketKey = allowGroupSelect ? scope.kind === 'property' ? marketForGroup(current) : marketForGroup(scope) : undefined
+    const selectedMarketKey = allowGroupSelect ? scope.kind === 'property' ? currentMarketKey : scope.kind === 'group' && scope.id === current?.id ? explicitCurrentMarketKey : undefined : undefined
     if (selectedMarketKey) onSelect(scope, selectedMarketKey)
     else onSelect(scope)
   }
@@ -85,7 +95,6 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
   }
   const restoreSelection = () => {
     const selectedGroup = selected.kind === 'group' ? groupById.get(selected.id) : undefined
-    const selectedMarket = options.find(option => option.kind === 'market' && option.id === (marketKey ?? (selected.kind === 'market' ? selected.id : undefined)))
     const marketGroup = groupById.get(selectedMarket?.parentGroupIds?.[0] ?? '')
     const memberPaths = (selected.parentGroupIds ?? []).flatMap(key => {
       const group = groupById.get(key)

--- a/apps/web/src/components/project/VisibilityScopePicker.tsx
+++ b/apps/web/src/components/project/VisibilityScopePicker.tsx
@@ -5,13 +5,21 @@ import type { VisibilityReportScopeOption } from '@ainyc/canonry-contracts'
 const CONTROL = 'min-h-11 w-full rounded-md border border-default bg-surface px-3 py-2 text-sm text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400'
 const ROW = 'flex min-h-11 w-full items-center justify-between gap-3 rounded px-2 text-left text-sm text-primary hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400'
 const labelFor = (scope: VisibilityReportScopeOption) => scope.kind === 'project' ? 'Whole site' : scope.label
+export const MARKET_SCOPE_COPY = {
+  allMarkets: 'All markets',
+  browse: (label: string) => `Browse ${label}`,
+  select: (label: string) => `Select ${label}`,
+  browseAll: 'Browse all properties',
+}
+export const marketForGroup = (scope?: VisibilityReportScopeOption) => scope?.kind === 'group' && scope.marketKeys?.length === 1 ? scope.marketKeys[0] : undefined
 const countFor = (count: number) => `${count} ${count === 1 ? 'property' : 'properties'}`
 
 /** Navigation uses explicit frozen memberships, never labels or inferred containment. */
-export function VisibilityScopePicker({ options: suppliedOptions, selected, onSelect, label = 'Measurement scope', allowGroupSelect = true }: {
+export function VisibilityScopePicker({ options: suppliedOptions, selected, onSelect, marketKey, label = 'Measurement scope', allowGroupSelect = true }: {
   options: VisibilityReportScopeOption[]
   selected: VisibilityReportScopeOption
-  onSelect: (scope: VisibilityReportScopeOption) => void
+  onSelect: (scope: VisibilityReportScopeOption, marketKey?: string) => void
+  marketKey?: string
   label?: string
   allowGroupSelect?: boolean
 }) {
@@ -46,9 +54,10 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
   const visibleGroups = (allProperties ? [] : current
     ? groups.filter(group => query ? isDescendant(group) : group.parentGroupIds?.includes(current.id))
     : query ? groups : roots).filter(matches)
-  const visibleProperties = (current ? properties.filter(property => property.parentGroupIds?.includes(current.id))
+  const currentMarketKey = allowGroupSelect ? marketForGroup(current) : undefined
+  const visibleProperties = (current ? properties.filter(property => property.parentGroupIds?.includes(current.id) && (!currentMarketKey || property.marketKeys?.includes(currentMarketKey)))
     : query || allProperties || groups.length === 0 ? properties : []).filter(matches)
-  const markets = allProperties || (allowGroupSelect && current) ? [] : options.filter(scope => scope.kind === 'market' && (allowGroupSelect || current || query || groups.length === 0) && (!current || scope.parentGroupIds?.includes(current.id)) && matches(scope))
+  const markets = allProperties || (allowGroupSelect && current?.marketKeys?.length === 1) ? [] : options.filter(scope => scope.kind === 'market' && (allowGroupSelect || current || query || groups.length === 0) && (current ? scope.parentGroupIds?.includes(current.id) : !scope.parentGroupIds?.some(key => groupById.has(key))) && matches(scope))
   const projects = current || allProperties ? [] : options.filter(scope => scope.kind === 'project' && matches(scope))
 
   useEffect(() => {
@@ -61,7 +70,9 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
 
   const choose = (scope: VisibilityReportScopeOption) => {
     if (picker.current) { picker.current.open = false; picker.current.querySelector('summary')?.focus() }
-    onSelect(scope)
+    const selectedMarketKey = allowGroupSelect ? scope.kind === 'property' ? marketForGroup(current) : marketForGroup(scope) : undefined
+    if (selectedMarketKey) onSelect(scope, selectedMarketKey)
+    else onSelect(scope)
   }
   const groupPath = (scope: VisibilityReportScopeOption) => {
     const ancestors: string[] = []
@@ -74,15 +85,16 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
   }
   const restoreSelection = () => {
     const selectedGroup = selected.kind === 'group' ? groupById.get(selected.id) : undefined
+    const selectedMarket = options.find(option => option.kind === 'market' && option.id === (marketKey ?? (selected.kind === 'market' ? selected.id : undefined)))
+    const marketGroup = groupById.get(selectedMarket?.parentGroupIds?.[0] ?? '')
     const memberPaths = (selected.parentGroupIds ?? []).flatMap(key => {
       const group = groupById.get(key)
       return group ? [groupPath(group)] : []
     })
-    // A property can belong to overlapping groups. Retain the browsed membership
-    // when possible; otherwise reopen its deepest explicitly declared group.
-    const propertyPath = memberPaths.find(value => value.at(-1) === current?.id)
+    const legacyPath = memberPaths.find(value => value.at(-1) === current?.id)
       ?? memberPaths.sort((left, right) => right.length - left.length)[0] ?? []
-    setPath(selectedGroup ? groupPath(selectedGroup) : selected.kind === 'property' ? propertyPath : [])
+    const propertyPath = marketGroup ? groupPath(marketGroup) : selected.marketKeys?.length ? [] : legacyPath
+    setPath(selectedGroup ? groupPath(selectedGroup) : propertyPath)
     setAllProperties(selected.kind === 'property' && propertyPath.length === 0 && groups.length > 0)
     setSearch('')
   }
@@ -93,14 +105,14 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
     <button
       type="button"
       className={ROW}
-      aria-label={scope.kind === 'group' && !allowGroupSelect ? `Browse ${labelFor(scope)}` : `Select ${labelFor(scope)}`}
+      aria-label={scope.kind === 'group' && !allowGroupSelect ? MARKET_SCOPE_COPY.browse(labelFor(scope)) : MARKET_SCOPE_COPY.select(labelFor(scope))}
       aria-current={selected.kind === scope.kind && selected.id === scope.id ? 'true' : undefined}
       onClick={() => scope.kind === 'group' && !allowGroupSelect ? browse(scope) : choose(scope)}
     >
       <span className="min-w-0 break-words">{displayLabel}{query && parentLabels(scope) ? <span className="block text-[13px] text-secondary">{parentLabels(scope)}</span> : null}</span>
       <span className="shrink-0 text-right text-[13px] text-secondary">{scope.kind === 'market' ? allowGroupSelect ? 'Query context' : 'Market' : scope.kind === 'property' ? 'Property' : countFor(scope.targetCount)}</span>
     </button>
-    {allowGroupSelect && scope.kind === 'group' && scope.id !== current?.id && options.some(option => option.parentGroupIds?.includes(scope.id)) ? <button type="button" aria-label={`Browse ${scope.label}`} title={`Browse ${scope.label}`} className="flex min-h-11 min-w-11 items-center justify-center rounded text-secondary hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400" onClick={() => browse(scope)}><ChevronRight size={18} aria-hidden="true" /></button> : null}
+    {allowGroupSelect && scope.kind === 'group' && scope.id !== current?.id && options.some(option => option.parentGroupIds?.includes(scope.id)) ? <button type="button" aria-label={MARKET_SCOPE_COPY.browse(scope.label)} title={`Browse ${scope.label}`} className="flex min-h-11 min-w-11 items-center justify-center rounded text-secondary hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400" onClick={() => browse(scope)}><ChevronRight size={18} aria-hidden="true" /></button> : null}
   </div>
   const section = (label: string, scopes: VisibilityReportScopeOption[]) => scopes.length > 0 ? <section aria-label={label} className="mt-2">
     <h3 className="px-2 py-2 text-[13px] font-medium text-secondary">{label}</h3>{scopes.map(scope => row(scope))}
@@ -118,7 +130,7 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
       if (event.key === 'Escape') { event.preventDefault(); event.currentTarget.open = false; event.currentTarget.querySelector('summary')?.focus() }
     }}>
       <summary id={`${id}-value`} aria-labelledby={`${id}-label ${id}-value`} className={`${CONTROL} visibility-scope-trigger`} onClick={() => { if (!picker.current?.open) restoreSelection() }}>
-        {`${labelFor(selected)}${selected.kind === 'group' ? ` · ${countFor(selected.targetCount)}` : selected.kind === 'property' ? ' · Property' : selected.kind === 'market' ? ' · Market' : ''}`}<ChevronDown size={16} aria-hidden="true" className="shrink-0 text-secondary" />
+        {`${labelFor(selected)}${selected.kind === 'group' ? ` · ${countFor(selected.targetCount)}` : selected.kind === 'property' ? ` · ${options.find(option => option.kind === 'market' && option.id === marketKey)?.label ?? (selected.marketKeys?.length ? MARKET_SCOPE_COPY.allMarkets : 'Property')}` : selected.kind === 'market' ? ' · Market' : ''}`}<ChevronDown size={16} aria-hidden="true" className="shrink-0 text-secondary" />
       </summary>
       <div className="visibility-scope-menu">
         {current || allProperties ? <div className="mb-2 border-b border-default pb-2">
@@ -132,7 +144,7 @@ export function VisibilityScopePicker({ options: suppliedOptions, selected, onSe
           {current && !query ? disclosure('Subgroups', visibleGroups, true) : section(current ? 'Subgroups' : 'Groups', visibleGroups)}
           {query ? section('Properties', visibleProperties) : disclosure(current && visibleGroups.length > 0 ? 'All properties' : 'Properties', visibleProperties, !current || visibleGroups.length === 0)}
           {section('Markets', markets)}
-          {!current && !allProperties && !query && groups.length > 0 && properties.length > 0 ? <button type="button" className={`${ROW} mt-2 border-t border-default`} aria-label="Browse all properties" onClick={() => { setAllProperties(true); searchInput.current?.focus() }}><span>All properties</span><ChevronRight size={18} aria-hidden="true" /></button> : null}
+          {!current && !allProperties && !query && groups.length > 0 && properties.length > 0 ? <button type="button" className={`${ROW} mt-2 border-t border-default`} aria-label={MARKET_SCOPE_COPY.browseAll} onClick={() => { setAllProperties(true); searchInput.current?.focus() }}><span>All properties</span><ChevronRight size={18} aria-hidden="true" /></button> : null}
           {query && visibleGroups.length + visibleProperties.length + markets.length + projects.length === 0 ? <p className="py-3 text-sm text-secondary">No matching scopes.</p> : null}
         </div>
       </div>

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -10,7 +10,7 @@ import { heyClient } from '../../api.js'
 import type { VisibilityAnswerSelection, VisibilitySelectionState } from '../../lib/measurement-view-url.js'
 import { Button } from '../ui/button.js'
 import { Check, ChevronRight, Minus } from 'lucide-react'
-import { VisibilityScopePicker, marketForGroup } from './VisibilityScopePicker.js'
+import { VisibilityScopePicker } from './VisibilityScopePicker.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
 import { safeExternalUrl } from '../../lib/safe-url.js'
 import {
@@ -410,7 +410,7 @@ function ReportScopeBreakdown({ population, scope, scopeOptions, marketKey, onSe
       <div className="flex gap-2">{(['groups', 'properties'] as const).map(value => <Button key={value} variant={kind === value ? 'secondary' : 'ghost'} onClick={() => { setKind(value); table.setPage(1) }}>{value === 'groups' ? 'Groups' : 'Properties'}</Button>)}</div>
       <input type="search" aria-label="Search breakdown" placeholder="Search" value={table.query} onChange={event => table.setQuery(event.target.value)} className={`${REPORT_CONTROL} max-w-sm`} />
     </div>
-    <div className="mt-3 overflow-x-auto"><table className="evidence-table"><thead><tr><th>{kind === 'groups' ? 'Group' : 'Property'}</th><th>Queries</th><th>Mentioned</th><th>Cited</th></tr></thead><tbody>{table.rows.map(row => <tr key={row.id}><td><button className="min-h-11 text-left text-link hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400" onClick={() => onSelectionChange({ measurementScope: kind === 'groups' ? 'group' : 'property', measurementScopeKey: row.id, measurementMarketKey: kind === 'groups' ? marketForGroup(groupOptions.get(row.id)) : marketKey })}>{row.label}</button></td><td>{row.queryCount}</td><td><ReportRate value={row.mentionCoverage} /></td><td><ReportRate value={row.citationCoverage} /></td></tr>)}</tbody></table></div>
+    <div className="mt-3 overflow-x-auto"><table className="evidence-table"><thead><tr><th>{kind === 'groups' ? 'Group' : 'Property'}</th><th>Queries</th><th>Mentioned</th><th>Cited</th></tr></thead><tbody>{table.rows.map(row => <tr key={row.id}><td><button className="min-h-11 text-left text-link hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400" onClick={() => onSelectionChange({ measurementScope: kind === 'groups' ? 'group' : 'property', measurementScopeKey: row.id, measurementMarketKey: marketKey })}>{row.label}</button></td><td>{row.queryCount}</td><td><ReportRate value={row.mentionCoverage} /></td><td><ReportRate value={row.citationCoverage} /></td></tr>)}</tbody></table></div>
     {table.rows.length === 0 ? <p className="py-3 text-sm text-secondary">No {kind} match this search.</p> : null}
     <DataTablePagination page={table.page} pageSize={table.pageSize} visibleRows={table.rows.length} totalRows={table.totalRows} itemLabel={kind} onPageChange={table.setPage} />
   </section>
@@ -463,13 +463,7 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
     enabled: Boolean(selection.queryKey) && Boolean(reportQuery.data) && !reportQuery.isPlaceholderData,
     retry: false,
   })
-  const linkedGroupMarket = selection.measurementScope === 'group' && !selection.marketKey && reportQuery.data
-    ? marketForGroup(reportQuery.data.selection.scope) : undefined
   useEffect(() => {
-    if (linkedGroupMarket && !reportQuery.isPlaceholderData && !reportQuery.isFetching && !reportQuery.isError) {
-      onSelectionChange({ measurementMarketKey: linkedGroupMarket })
-      return
-    }
     if (selection.queryClass !== 'all' || !reportQuery.data || reportQuery.isPlaceholderData || reportQuery.isFetching || reportQuery.isError
       || reportQuery.data.selection.availability.state === 'unsupported' || reportQuery.data.populations.length === 0) return
     // Older links carry only a query key. Wait for its evidence when it is
@@ -493,7 +487,7 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
       queryClass: population.queryClass,
       ...(selection.queryKey ? { measurementQueryKey: selection.queryKey, measurementAnswer: selection.answer ? JSON.stringify(selection.answer) : undefined } : {}),
     })
-  }, [linkedGroupMarket, selection.queryClass, selection.queryKey, selection.answer, reportQuery.data, reportQuery.dataUpdatedAt, reportQuery.isPlaceholderData, reportQuery.isFetching, reportQuery.isError, evidenceQuery.data, onSelectionChange, queryClient, projectName, sharedQuery, cursor, search])
+  }, [selection.queryClass, selection.queryKey, selection.answer, reportQuery.data, reportQuery.dataUpdatedAt, reportQuery.isPlaceholderData, reportQuery.isFetching, reportQuery.isError, evidenceQuery.data, onSelectionChange, queryClient, projectName, sharedQuery, cursor, search])
   if (reportQuery.data?.selection.availability.state === 'unsupported') return <>{fallback}</>
   if (showUnmeasuredFallback && reportQuery.data?.selection.mode === 'simple' && reportQuery.data.selection.measurement.state === 'not-measured') return <>{fallback}</>
   if (reportQuery.error) {
@@ -505,7 +499,7 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
         : <Button variant="outline" onClick={() => { setCursor(undefined); void reportQuery.refetch() }}>Retry</Button>}
     </section>
   }
-  if (!reportQuery.data || linkedGroupMarket) return <section className="page-section-divider" role="status" aria-label="Loading AI visibility"><div className="h-64 animate-pulse rounded-md bg-surface" /></section>
+  if (!reportQuery.data) return <section className="page-section-divider" role="status" aria-label="Loading AI visibility"><div className="h-64 animate-pulse rounded-md bg-surface" /></section>
   return <div aria-busy={reportQuery.isFetching}><VisibilityReportView
     report={reportQuery.data}
     isRefreshing={reportQuery.isFetching}

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -10,7 +10,7 @@ import { heyClient } from '../../api.js'
 import type { VisibilityAnswerSelection, VisibilitySelectionState } from '../../lib/measurement-view-url.js'
 import { Button } from '../ui/button.js'
 import { Check, ChevronRight, Minus } from 'lucide-react'
-import { VisibilityScopePicker } from './VisibilityScopePicker.js'
+import { VisibilityScopePicker, marketForGroup } from './VisibilityScopePicker.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
 import { safeExternalUrl } from '../../lib/safe-url.js'
 import {
@@ -89,10 +89,13 @@ function ReportRate({ value, unit }: { value: VisibilityReportRate; unit?: 'answ
   return <span className="inline-flex flex-col gap-1"><strong className="tabular-nums text-heading">{reportPercent.format(value.rate)}</strong><span className="text-sm tabular-nums text-secondary">{value.numerator} of {value.denominator}{unit ? ` ${unit}` : ''}</span></span>
 }
 
+export const REPORT_MARKET_COPY = { otherQueries: 'Other queries' }
+
 export interface VisibilityQueryGroup {
   queryKey: string
   query: string
   rows: VisibilityReportQueryRow[]
+  marketLabel?: string
 }
 
 /**
@@ -101,14 +104,20 @@ export interface VisibilityQueryGroup {
  * the current page so model, location, denominator, and property scope never become an invented
  * query-level aggregate.
  */
-export function groupVisibilityQueryRows(rows: readonly VisibilityReportQueryRow[]): VisibilityQueryGroup[] {
+export function groupVisibilityQueryRows(rows: readonly VisibilityReportQueryRow[], markets?: Map<string, string>): VisibilityQueryGroup[] {
   const groups = new Map<string, VisibilityQueryGroup>()
   for (const row of rows) {
     const group = groups.get(row.queryKey)
     if (group) group.rows.push(row)
     else groups.set(row.queryKey, { queryKey: row.queryKey, query: row.query, rows: [row] })
   }
-  return [...groups.values()]
+  const result = [...groups.values()]
+  if (!markets || !rows.some(row => row.marketKeys?.length)) return result
+  for (const group of result) {
+    const keys = [...new Set(group.rows.flatMap(row => row.marketKeys ?? []))].sort()
+    group.marketLabel = keys.map(key => markets.get(key) ?? key).join(' · ') || REPORT_MARKET_COPY.otherQueries
+  }
+  return result.sort((left, right) => left.marketLabel!.localeCompare(right.marketLabel!) || left.query.localeCompare(right.query))
 }
 
 function QueryResultRate({ value, singleAnswer }: { value: VisibilityReportRate; singleAnswer: boolean }) {
@@ -130,9 +139,10 @@ function QueryProperties({ targetKeys, labels }: { targetKeys: string[]; labels:
   </details>
 }
 
-function QueryResultGroup({ group, advanced, targetLabels, onViewAnswers }: {
+function QueryResultGroup({ group, advanced, targetLabels, marketHeading, onViewAnswers }: {
   group: VisibilityQueryGroup
   advanced: boolean
+  marketHeading?: string
   targetLabels: Map<string, string>
   onViewAnswers: (row: VisibilityReportQueryRow) => void
 }) {
@@ -142,6 +152,7 @@ function QueryResultGroup({ group, advanced, targetLabels, onViewAnswers }: {
   const sharedLocation = group.rows.every(row => row.location === first.location)
   const locationLabel = (location: string | null) => location === null ? 'No location targeting' : `Search location: ${location}`
   return <tbody data-query-key={group.queryKey}>
+    {marketHeading ? <tr><th colSpan={4} className="border-t border-default py-4 text-left"><h3 className="text-base font-semibold text-heading">{marketHeading}</h3></th></tr> : null}
     <tr className="measurement-result-heading"><th scope="rowgroup" colSpan={4}>
       <h3 className="break-words text-base font-medium text-heading">{group.query}</h3>
       <div className="flex flex-wrap items-center gap-x-5 text-sm font-normal text-secondary">
@@ -264,8 +275,8 @@ export function VisibilityReportFilters({ report, onSelectionChange, queryClass 
   )
 
   return <div className="visibility-filter-container"><div className="visibility-report-filters" data-has-scope={scopeOptions.length > 1} role="group" aria-label="Visibility filters">
-    {scopeOptions.length > 1 ? <VisibilityScopePicker options={scopeOptions} selected={selection.scope} onSelect={scope => {
-      onSelectionChange({ measurementScope: scope.kind, measurementScopeKey: scope.kind === 'project' ? undefined : scope.id })
+    {scopeOptions.length > 1 ? <VisibilityScopePicker options={scopeOptions} selected={selection.scope} marketKey={selection.market?.id} onSelect={(scope, marketKey) => {
+      onSelectionChange({ measurementScope: scope.kind, measurementScopeKey: scope.kind === 'project' ? undefined : scope.id, measurementMarketKey: marketKey })
     }} /> : null}
     {select('Query type', 'queryClass', queryClass, [{ value: 'non-brand', label: 'Non-brand' }, { value: 'branded', label: 'Branded' }, { value: 'unknown', label: 'Unclassified' }])}
     {select('Answer engine', 'measurementProvider', selection.provider ?? '', [{ value: '', label: 'All engines' }, ...filterOptions.providers.map(provider => ({ value: provider, label: provider }))])}
@@ -334,7 +345,7 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
       {filterSelect('Results from', 'measurementRunId', selection.run.explicit ? selection.run.id ?? '' : '', [{ value: '', label: 'Latest saved sweep' }, ...[...selectedPopulation.trend].reverse().map(point => ({ value: point.runId, label: new Date(point.createdAt).toLocaleString() }))], 'Choose a saved AI sweep to view its results. No new sweep starts.')}
     </div></details>
     {[selectedPopulation].map(population => {
-      const queryGroups = groupVisibilityQueryRows(population.queries.items)
+      const queryGroups = groupVisibilityQueryRows(population.queries.items, selection.scope.kind === 'property' && !selection.market && population.queryClass === 'non-brand' ? new Map(report.scopeOptions.filter(option => option.kind === 'market').map(option => [option.id, option.label])) : undefined)
       return <section key={population.queryClass} aria-label={REPORT_CLASS_LABEL[population.queryClass]} className="py-4">
       <div className="section-head"><h2>{REPORT_CLASS_LABEL[population.queryClass]}</h2><InfoTooltip text={population.queryClass === 'non-brand' ? 'Queries that do not name the measured identity. Geography alone is not a brand.' : population.queryClass === 'branded' ? 'Queries that name the measured identity.' : 'These queries were not labeled as branded or non-brand when measured. Their saved results remain available here, separate from branded and non-brand rates.'} /></div>
       <div className="flex flex-wrap gap-x-8 gap-y-4 border-y border-default py-4">
@@ -347,7 +358,7 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
       {selection.mode === 'advanced' ? <details className="border-t border-default text-sm text-secondary" aria-label={`${REPORT_CLASS_LABEL[population.queryClass]} property outcomes`}><summary className="min-h-11 cursor-pointer py-3">Property outcomes</summary><div className="flex flex-wrap gap-x-8 gap-y-3 pb-4">
         {([['bothSignals', 'mentioned and cited'], ['mentionedOnly', 'mentioned only'], ['citedOnly', 'cited only'], ['neither', 'neither signal'], ['notMeasured', 'not measured']] as const).map(([key, label]) => <div key={key}><strong className="block tabular-nums text-heading">{population.summary.outcomes[key]}</strong><span className="text-sm text-secondary">{label}</span>{key === 'notMeasured' ? <InfoTooltip text="No eligible completed measurement for this selection. This is not the same as a measured answer with neither signal." /> : null}</div>)}
       </div></details> : null}
-      {selection.mode === 'advanced' && selection.scope.kind !== 'property' && (population.breakdown.groups.length > 0 || population.breakdown.properties.length > 0) ? <ReportScopeBreakdown key={`${selection.scope.kind}:${selection.scope.id}`} population={population} scope={selection.scope} scopeOptions={report.scopeOptions} onSelectionChange={onSelectionChange} /> : null}
+      {selection.mode === 'advanced' && selection.scope.kind !== 'property' && (population.breakdown.groups.length > 0 || population.breakdown.properties.length > 0) ? <ReportScopeBreakdown key={`${selection.scope.kind}:${selection.scope.id}`} population={population} scope={selection.scope} scopeOptions={report.scopeOptions} marketKey={selection.market?.id} onSelectionChange={onSelectionChange} /> : null}
       <details className="border-t border-default" data-query-results={population.queryClass} aria-label={`${REPORT_CLASS_LABEL[population.queryClass]} query results`}>
         <summary className="min-h-11 cursor-pointer py-5 text-heading focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400"><span className="font-semibold">Query results</span><span className="ml-3 text-sm font-normal text-secondary">{population.queries.total} {population.queries.total === 1 ? 'result' : 'results'} · {scopeLabel}</span></summary>
         <div className="pb-5">
@@ -355,7 +366,7 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
         <div className="overflow-x-auto">
           <table className="evidence-table measurement-responsive-table measurement-results-table" aria-label={`${REPORT_CLASS_LABEL[population.queryClass]} engine results`}>
             <thead><tr><th scope="col">Answer engine</th><th scope="col">Mentioned</th><th scope="col">Cited</th><th scope="col"><span className="sr-only">Evidence</span></th></tr></thead>
-            {queryGroups.map(group => <QueryResultGroup key={group.queryKey} group={group} advanced={selection.mode === 'advanced'} targetLabels={targetLabels} onViewAnswers={row => onSelectionChange({ measurementQueryKey: row.queryKey, measurementAnswer: JSON.stringify({ queryKey: row.queryKey, queryClass: population.queryClass, provider: row.provider, model: row.model, location: row.location, runId: selection.run.id, revision: selection.revision } satisfies VisibilityAnswerSelection) })} />)}
+            {queryGroups.map((group, index) => <QueryResultGroup key={group.queryKey} group={group} marketHeading={group.marketLabel !== queryGroups[index - 1]?.marketLabel ? group.marketLabel : undefined} advanced={selection.mode === 'advanced'} targetLabels={targetLabels} onViewAnswers={row => onSelectionChange({ measurementQueryKey: row.queryKey, measurementAnswer: JSON.stringify({ queryKey: row.queryKey, queryClass: population.queryClass, provider: row.provider, model: row.model, location: row.location, runId: selection.run.id, revision: selection.revision } satisfies VisibilityAnswerSelection) })} />)}
           </table>
         </div>
         {population.queries.items.length === 0 ? <p className="py-4 text-sm text-secondary">No measured queries match this selection.</p> : <p className="mt-3 text-sm text-secondary">{queryGroups.length} {queryGroups.length === 1 ? 'query' : 'queries'} · {population.queries.items.length} {population.queries.items.length === 1 ? 'engine result' : 'engine results'} shown of {population.queries.total} results</p>}
@@ -377,10 +388,11 @@ export function VisibilityReportView({ report, isRefreshing = false, onSelection
   </section>
 }
 
-function ReportScopeBreakdown({ population, scope, scopeOptions, onSelectionChange }: {
+function ReportScopeBreakdown({ population, scope, scopeOptions, marketKey, onSelectionChange }: {
   population: VisibilityReportPopulation
   scope: VisibilityReportResponse['selection']['scope']
   scopeOptions: VisibilityReportResponse['scopeOptions']
+  marketKey?: string
   onSelectionChange: VisibilityReportViewProps['onSelectionChange']
 }) {
   const groupOptions = new Map(scopeOptions.filter(option => option.kind === 'group').map(option => [option.id, option]))
@@ -398,7 +410,7 @@ function ReportScopeBreakdown({ population, scope, scopeOptions, onSelectionChan
       <div className="flex gap-2">{(['groups', 'properties'] as const).map(value => <Button key={value} variant={kind === value ? 'secondary' : 'ghost'} onClick={() => { setKind(value); table.setPage(1) }}>{value === 'groups' ? 'Groups' : 'Properties'}</Button>)}</div>
       <input type="search" aria-label="Search breakdown" placeholder="Search" value={table.query} onChange={event => table.setQuery(event.target.value)} className={`${REPORT_CONTROL} max-w-sm`} />
     </div>
-    <div className="mt-3 overflow-x-auto"><table className="evidence-table"><thead><tr><th>{kind === 'groups' ? 'Group' : 'Property'}</th><th>Queries</th><th>Mentioned</th><th>Cited</th></tr></thead><tbody>{table.rows.map(row => <tr key={row.id}><td><button className="min-h-11 text-left text-link hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400" onClick={() => onSelectionChange({ measurementScope: kind === 'groups' ? 'group' : 'property', measurementScopeKey: row.id })}>{row.label}</button></td><td>{row.queryCount}</td><td><ReportRate value={row.mentionCoverage} /></td><td><ReportRate value={row.citationCoverage} /></td></tr>)}</tbody></table></div>
+    <div className="mt-3 overflow-x-auto"><table className="evidence-table"><thead><tr><th>{kind === 'groups' ? 'Group' : 'Property'}</th><th>Queries</th><th>Mentioned</th><th>Cited</th></tr></thead><tbody>{table.rows.map(row => <tr key={row.id}><td><button className="min-h-11 text-left text-link hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400" onClick={() => onSelectionChange({ measurementScope: kind === 'groups' ? 'group' : 'property', measurementScopeKey: row.id, measurementMarketKey: kind === 'groups' ? marketForGroup(groupOptions.get(row.id)) : marketKey })}>{row.label}</button></td><td>{row.queryCount}</td><td><ReportRate value={row.mentionCoverage} /></td><td><ReportRate value={row.citationCoverage} /></td></tr>)}</tbody></table></div>
     {table.rows.length === 0 ? <p className="py-3 text-sm text-secondary">No {kind} match this search.</p> : null}
     <DataTablePagination page={table.page} pageSize={table.pageSize} visibleRows={table.rows.length} totalRows={table.totalRows} itemLabel={kind} onPageChange={table.setPage} />
   </section>
@@ -417,10 +429,10 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
   const [answerCursor, setAnswerCursor] = useState<{ selection: string; cursor: string }>()
   const queryClient = useQueryClient()
   const sharedQuery = useMemo(() => ({
-    scope: selection.measurementScope, scopeKey: selection.measurementScopeKey, queryClass: selection.queryClass,
+    scope: selection.measurementScope, scopeKey: selection.measurementScopeKey, marketKey: selection.marketKey, queryClass: selection.queryClass,
     provider: selection.provider, model: selection.model, location: selection.location,
     from: selection.from, to: selection.to, revision: selection.revision, runId: selection.measurementRunId,
-  }), [selection.measurementScope, selection.measurementScopeKey, selection.queryClass, selection.provider, selection.model, selection.location, selection.from, selection.to, selection.revision, selection.measurementRunId])
+  }), [selection.measurementScope, selection.measurementScopeKey, selection.marketKey, selection.queryClass, selection.provider, selection.model, selection.location, selection.from, selection.to, selection.revision, selection.measurementRunId])
   const reportQuery = useQuery({
     ...getApiV1ProjectsByNameVisibilityReportOptions({ client: heyClient, path: { name: projectName }, query: {
       ...sharedQuery, limit: 25, cursor, search: search || undefined,
@@ -451,7 +463,13 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
     enabled: Boolean(selection.queryKey) && Boolean(reportQuery.data) && !reportQuery.isPlaceholderData,
     retry: false,
   })
+  const linkedGroupMarket = selection.measurementScope === 'group' && !selection.marketKey && reportQuery.data
+    ? marketForGroup(reportQuery.data.selection.scope) : undefined
   useEffect(() => {
+    if (linkedGroupMarket && !reportQuery.isPlaceholderData && !reportQuery.isFetching && !reportQuery.isError) {
+      onSelectionChange({ measurementMarketKey: linkedGroupMarket })
+      return
+    }
     if (selection.queryClass !== 'all' || !reportQuery.data || reportQuery.isPlaceholderData || reportQuery.isFetching || reportQuery.isError
       || reportQuery.data.selection.availability.state === 'unsupported' || reportQuery.data.populations.length === 0) return
     // Older links carry only a query key. Wait for its evidence when it is
@@ -475,7 +493,7 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
       queryClass: population.queryClass,
       ...(selection.queryKey ? { measurementQueryKey: selection.queryKey, measurementAnswer: selection.answer ? JSON.stringify(selection.answer) : undefined } : {}),
     })
-  }, [selection.queryClass, selection.queryKey, selection.answer, reportQuery.data, reportQuery.dataUpdatedAt, reportQuery.isPlaceholderData, reportQuery.isFetching, reportQuery.isError, evidenceQuery.data, onSelectionChange, queryClient, projectName, sharedQuery, cursor, search])
+  }, [linkedGroupMarket, selection.queryClass, selection.queryKey, selection.answer, reportQuery.data, reportQuery.dataUpdatedAt, reportQuery.isPlaceholderData, reportQuery.isFetching, reportQuery.isError, evidenceQuery.data, onSelectionChange, queryClient, projectName, sharedQuery, cursor, search])
   if (reportQuery.data?.selection.availability.state === 'unsupported') return <>{fallback}</>
   if (showUnmeasuredFallback && reportQuery.data?.selection.mode === 'simple' && reportQuery.data.selection.measurement.state === 'not-measured') return <>{fallback}</>
   if (reportQuery.error) {
@@ -487,7 +505,7 @@ export function VisibilityWorkspace({ projectName, selection, onSelectionChange,
         : <Button variant="outline" onClick={() => { setCursor(undefined); void reportQuery.refetch() }}>Retry</Button>}
     </section>
   }
-  if (!reportQuery.data) return <section className="page-section-divider" role="status" aria-label="Loading AI visibility"><div className="h-64 animate-pulse rounded-md bg-surface" /></section>
+  if (!reportQuery.data || linkedGroupMarket) return <section className="page-section-divider" role="status" aria-label="Loading AI visibility"><div className="h-64 animate-pulse rounded-md bg-surface" /></section>
   return <div aria-busy={reportQuery.isFetching}><VisibilityReportView
     report={reportQuery.data}
     isRefreshing={reportQuery.isFetching}

--- a/apps/web/src/lib/measurement-view-url.ts
+++ b/apps/web/src/lib/measurement-view-url.ts
@@ -114,6 +114,7 @@ function parseAnswerSelection(value: unknown, queryKey: string | undefined): Vis
 export interface VisibilitySelectionState {
   measurementScope: 'project' | 'group' | 'market' | 'property'
   measurementScopeKey?: string
+  marketKey?: string
   queryClass: MeasurementQueryClass | 'unknown'
   provider?: string
   model?: string
@@ -138,7 +139,7 @@ export function parseVisibilitySelection(search: Record<string, unknown>): Visib
   }
   if (result.measurementScope !== 'project') result.measurementScopeKey = key
   for (const [urlKey, field] of [
-    ['measurementProvider', 'provider'], ['measurementModel', 'model'], ['measurementLocation', 'location'],
+    ['measurementMarketKey', 'marketKey'], ['measurementProvider', 'provider'], ['measurementModel', 'model'], ['measurementLocation', 'location'],
     ['measurementFrom', 'from'], ['measurementTo', 'to'], ['measurementRunId', 'measurementRunId'], ['measurementQueryKey', 'queryKey'],
   ] as const) {
     const value = string(urlKey)
@@ -157,7 +158,7 @@ export function patchVisibilitySelection(
 ): Record<string, unknown> {
   const next = { ...previous, ...patch }
   if ([
-    'measurementScope', 'measurementScopeKey', 'queryClass', 'measurementProvider', 'measurementModel',
+    'measurementScope', 'measurementScopeKey', 'measurementMarketKey', 'queryClass', 'measurementProvider', 'measurementModel',
     'measurementLocation', 'measurementFrom', 'measurementTo', 'measurementRevision', 'measurementRunId',
   ].some(key => key in patch)) {
     // Filter changes close answers unless the caller explicitly carries an
@@ -170,6 +171,7 @@ export function patchVisibilitySelection(
   // Legacy scope tokens must not reappear when the user returns to the project.
   if ('measurementScope' in patch) {
     next.scope = undefined
+    if (!('measurementMarketKey' in patch)) next.measurementMarketKey = undefined
     next.measurementQueryKey = undefined
     if (patch.measurementScope === 'project') next.measurementScopeKey = undefined
   }

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -2080,6 +2080,7 @@ function ProjectPageContent({
     },
   } as const
   const competitorLandscapeAvailable = tab === 'overview'
+    && !visibilitySelection.marketKey
     && Boolean(projectName)
     && (isSimpleOverview || planGroupKeysLoaded)
     && !isMeasurementModeUnresolved
@@ -2639,9 +2640,9 @@ function ProjectPageContent({
           && visibilitySelection.queryClass === 'all'
           && !visibilitySelection.provider && !visibilitySelection.model && !visibilitySelection.location
           && !visibilitySelection.from && !visibilitySelection.to && !visibilitySelection.revision
-          && !visibilitySelection.measurementRunId && !visibilitySelection.queryKey}
+          && !visibilitySelection.measurementRunId && !visibilitySelection.queryKey && !visibilitySelection.marketKey}
         onSelectionChange={updateVisibilitySearch}
-        onManageQueries={!isEmbed() ? () => { void navigate({ to: '/projects/$projectName/queries', params: { projectName }, search: previous => ({ ...previous, queryWorkspace: 'tracked', trackingQueryId: undefined }) }) } : undefined}
+        onManageQueries={!isEmbed() ? () => { void navigate({ to: '/projects/$projectName/queries', params: { projectName }, search: previous => ({ ...previous, queryWorkspace: 'tracked', trackingQueryId: undefined, measurementMarketKey: undefined }) }) } : undefined}
         fallback={overview}
       />
     )

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -99,6 +99,7 @@ type SearchParams = {
   trackingQueryId?: string
   measurementScope?: string
   measurementScopeKey?: string
+  measurementMarketKey?: string
   queryClass?: string
   measurementProvider?: string
   measurementModel?: string
@@ -142,7 +143,7 @@ export const rootRoute = createRootRouteWithContext<RouterContext>()({
     scope: typeof search.scope === 'string' ? search.scope : undefined,
     class: typeof search.class === 'string' ? search.class : undefined,
     ...Object.fromEntries([
-      'queryWorkspace', 'researchMode', 'trackingQueryId', 'measurementScope', 'measurementScopeKey', 'queryClass',
+      'queryWorkspace', 'researchMode', 'trackingQueryId', 'measurementScope', 'measurementScopeKey', 'measurementMarketKey', 'queryClass',
       'measurementProvider', 'measurementModel', 'measurementLocation', 'measurementFrom', 'measurementTo',
       'measurementRevision', 'measurementRunId', 'measurementQueryKey', 'measurementAnswer',
     ].map(key => [key, typeof search[key] === 'string' ? search[key] : undefined])),

--- a/apps/web/test/measurement-view-url.test.ts
+++ b/apps/web/test/measurement-view-url.test.ts
@@ -119,3 +119,15 @@ test('explicit query types survive navigation and reload without losing unrelate
     expect(next.runId).toBe('drawer-run')
   }
 })
+
+
+it('retains an exact market across property filters and clears it on a fresh scope selection', () => {
+  const initial = { measurementScope: 'group', measurementScopeKey: 'north', measurementMarketKey: 'market-north', measurementProvider: 'gemini', queryClass: 'non-brand', measurementQueryKey: 'answer-question' }
+  const property = patchVisibilitySelection(initial, { measurementScope: 'property', measurementScopeKey: 'shared', measurementMarketKey: initial.measurementMarketKey })
+  expect(parseVisibilitySelection(property)).toMatchObject({ measurementScope: 'property', measurementScopeKey: 'shared', marketKey: initial.measurementMarketKey })
+  expect(property.measurementQueryKey).toBeUndefined()
+  expect(parseVisibilitySelection(patchVisibilitySelection(property, { measurementProvider: 'openai' })).marketKey).toBe(initial.measurementMarketKey)
+  expect(parseVisibilitySelection(patchVisibilitySelection(property, { measurementScope: 'property', measurementScopeKey: 'shared' })).marketKey).toBeUndefined()
+  expect(parseVisibilitySelection(patchVisibilitySelection(property, { measurementScope: 'project' })).marketKey).toBeUndefined()
+  expect(patchVisibilitySelection(initial, { measurementMarketKey: 'market-south' }).measurementQueryKey).toBeUndefined()
+})

--- a/apps/web/test/visibility-report-view.test.tsx
+++ b/apps/web/test/visibility-report-view.test.tsx
@@ -1002,3 +1002,91 @@ it('client report preserves earlier unclassified history after a classified base
   expect(within(tables[1]!).getByText(reportQueryClassLabel(historicalOnly.queryClass))).toBeTruthy()
   expect(within(tables[1]!).getByText(historicalDate.slice(0, 10))).toBeTruthy()
 })
+
+
+describe('market-aware report selection', () => {
+  const market = { id: 'market-one', label: 'Market One', kind: 'market' as const, targetCount: 1, parentGroupIds: ['group-one'] }
+  const property = { id: 'property-one', label: 'Property One', kind: 'property' as const, targetCount: 1, parentGroupIds: ['group-one'], marketKeys: [market.id, 'market-two'] }
+
+  it('retains the market when drilling from a group breakdown into a property', () => {
+    const report = reportFixture()
+    const group = { id: 'group-one', label: 'Group One', kind: 'group' as const, targetCount: 1, marketKeys: [market.id] }
+    report.selection.scope = group
+    report.selection.market = market
+    report.scopeOptions.push(group, market, property)
+    report.populations[0]!.breakdown = { groups: [], properties: [{ id: property.id, label: property.label, queryCount: 1, mentionCoverage: report.populations[0]!.summary.mentionCoverage, citationCoverage: report.populations[0]!.summary.citationCoverage }] }
+    const onSelectionChange = vi.fn()
+    render(<VisibilityReportView report={report} onSelectionChange={onSelectionChange} />)
+    fireEvent.click(screen.getByRole('button', { name: property.label, exact: true }))
+    expect(onSelectionChange).toHaveBeenCalledWith({ measurementScope: 'property', measurementScopeKey: property.id, measurementMarketKey: market.id })
+  })
+
+  it('groups a standalone property question list by saved market without repeating shared questions', () => {
+    const report = reportFixture()
+    report.selection.scope = property
+    const secondMarket = { ...market, id: 'market-two', label: 'Market Two' }
+    report.scopeOptions.push(market, secondMarket, property)
+    const row = report.populations[0]!.queries.items[0]!
+    report.populations[0]!.queries.items = [
+      { ...row, queryKey: 'second-query', query: 'second saved question', targetKeys: [property.id], marketKeys: [secondMarket.id] },
+      { ...row, queryKey: 'first-query', query: 'first saved question', targetKeys: [property.id], marketKeys: [market.id] },
+      { ...row, queryKey: 'first-query', query: 'first saved question', provider: 'openai', targetKeys: [property.id], marketKeys: [market.id] },
+    ]
+    const view = render(<VisibilityReportView report={report} onSelectionChange={vi.fn()} />)
+    const queryDetails = view.container.querySelector('details[data-query-results]')!
+    fireEvent.click(queryDetails.querySelector('summary')!)
+    expect(within(queryDetails as HTMLElement).getByRole('heading', { name: market.label })).toBeTruthy()
+    expect(within(queryDetails as HTMLElement).getByRole('heading', { name: secondMarket.label })).toBeTruthy()
+    expect(view.container.querySelectorAll('tbody[data-query-key]')).toHaveLength(2)
+    expect([...view.container.querySelectorAll('tbody[data-query-key]')].map(element => element.getAttribute('data-query-key'))).toEqual(['first-query', 'second-query'])
+    expect(view.container.querySelectorAll('tbody[data-query-key="first-query"] tr.measurement-engine-result')).toHaveLength(2)
+  })
+
+  it('sends the same market in aggregate and answer requests and separates cached markets', async () => {
+    const requests: URL[] = []
+    const savedText = 'A recorded answer from the selected market.'
+    onTestFinished(mockFetch(url => {
+      const request = new URL(url); requests.push(request)
+      const report = reportWithAnswer('query-context', savedText)
+      report.selection.scope = property
+      report.selection.market = { ...market, id: request.searchParams.get('marketKey')! }
+      report.scopeOptions.push(market, property)
+      return jsonResponse(report)
+    }))
+    const client = createQueryClient()
+    onTestFinished(() => client.clear())
+    const base = { measurementScope: 'property' as const, measurementScopeKey: property.id, queryClass: 'non-brand' as const, marketKey: market.id, queryKey: 'query-context' }
+    const view = render(<QueryClientProvider client={client}><VisibilityWorkspace projectName="demo" selection={base} onSelectionChange={vi.fn()} /></QueryClientProvider>)
+    await screen.findByText(savedText)
+    expect(requests.some(request => request.searchParams.has('queryKey'))).toBe(true)
+    expect(requests.every(request => request.searchParams.get('marketKey') === market.id)).toBe(true)
+    const before = requests.length
+    view.rerender(<QueryClientProvider client={client}><VisibilityWorkspace projectName="demo" selection={{ ...base, marketKey: 'market-two' }} onSelectionChange={vi.fn()} /></QueryClientProvider>)
+    await waitFor(() => expect(requests.slice(before).filter(request => request.searchParams.get('marketKey') === 'market-two')).toHaveLength(2))
+  })
+})
+
+
+it('upgrades a saved group-only URL to its explicit market before showing its report', async () => {
+  const group = { id: 'saved-group', kind: 'group' as const, label: 'Saved group', targetCount: 1, marketKeys: ['saved-market'] }
+  const market = { id: 'saved-market', kind: 'market' as const, label: 'Saved market', targetCount: 1, parentGroupIds: [group.id] }
+  const requests: URL[] = []
+  onTestFinished(mockFetch(url => {
+    const request = new URL(url); requests.push(request)
+    const report = reportFixture()
+    report.selection.scope = group
+    if (request.searchParams.get('marketKey')) report.selection.market = market
+    report.scopeOptions.push(group, market)
+    return jsonResponse(report)
+  }))
+  let currentSearch: Record<string, unknown> = { measurementScope: 'group', measurementScopeKey: group.id, queryClass: 'non-brand' }
+  function Workspace() {
+    const [search, setSearch] = useState(currentSearch)
+    return <VisibilityWorkspace projectName="demo" selection={parseVisibilitySelection(search)} onSelectionChange={patch => setSearch(previous => { currentSearch = patchVisibilitySelection(previous, patch); return currentSearch })} />
+  }
+  const client = createQueryClient()
+  onTestFinished(() => client.clear())
+  render(<QueryClientProvider client={client}><Workspace /></QueryClientProvider>)
+  await waitFor(() => expect(requests.some(request => request.searchParams.get('marketKey') === market.id)).toBe(true))
+  expect(currentSearch.measurementMarketKey).toBe(market.id)
+})

--- a/apps/web/test/visibility-report-view.test.tsx
+++ b/apps/web/test/visibility-report-view.test.tsx
@@ -1021,6 +1021,18 @@ describe('market-aware report selection', () => {
     expect(onSelectionChange).toHaveBeenCalledWith({ measurementScope: 'property', measurementScopeKey: property.id, measurementMarketKey: market.id })
   })
 
+  it.each([undefined, 'market-one', 'market-two'])('keeps the displayed market filter when opening a group row: %s', marketKey => {
+    const report = reportFixture()
+    const group = { id: 'group-one', label: 'Group One', kind: 'group' as const, targetCount: 1, marketKeys: [market.id] }
+    if (marketKey) report.selection.market = { ...market, id: marketKey }
+    report.scopeOptions.push(group, market, property)
+    report.populations[0]!.breakdown = { properties: [], groups: [{ id: group.id, label: group.label, queryCount: 1, mentionCoverage: report.populations[0]!.summary.mentionCoverage, citationCoverage: report.populations[0]!.summary.citationCoverage }] }
+    const onSelectionChange = vi.fn()
+    render(<VisibilityReportView report={report} onSelectionChange={onSelectionChange} />)
+    fireEvent.click(screen.getByRole('button', { name: group.label, exact: true }))
+    expect(onSelectionChange).toHaveBeenCalledWith({ measurementScope: 'group', measurementScopeKey: group.id, measurementMarketKey: marketKey })
+  })
+
   it('groups a standalone property question list by saved market without repeating shared questions', () => {
     const report = reportFixture()
     report.selection.scope = property
@@ -1067,7 +1079,7 @@ describe('market-aware report selection', () => {
 })
 
 
-it('upgrades a saved group-only URL to its explicit market before showing its report', async () => {
+it('keeps a saved group-only URL on its original population after linking a market', async () => {
   const group = { id: 'saved-group', kind: 'group' as const, label: 'Saved group', targetCount: 1, marketKeys: ['saved-market'] }
   const market = { id: 'saved-market', kind: 'market' as const, label: 'Saved market', targetCount: 1, parentGroupIds: [group.id] }
   const requests: URL[] = []
@@ -1086,7 +1098,9 @@ it('upgrades a saved group-only URL to its explicit market before showing its re
   }
   const client = createQueryClient()
   onTestFinished(() => client.clear())
-  render(<QueryClientProvider client={client}><Workspace /></QueryClientProvider>)
-  await waitFor(() => expect(requests.some(request => request.searchParams.get('marketKey') === market.id)).toBe(true))
-  expect(currentSearch.measurementMarketKey).toBe(market.id)
+  const view = render(<QueryClientProvider client={client}><Workspace /></QueryClientProvider>)
+  await waitFor(() => expect(view.container.querySelector('.visibility-report')).toBeTruthy())
+  expect(requests).toHaveLength(1)
+  expect(requests[0]!.searchParams.has('marketKey')).toBe(false)
+  expect(currentSearch.measurementMarketKey).toBeUndefined()
 })

--- a/apps/web/test/visibility-scope-picker.test.tsx
+++ b/apps/web/test/visibility-scope-picker.test.tsx
@@ -195,12 +195,34 @@ describe('market context through property navigation', () => {
     expect(screen.queryByRole('button', { name: MARKET_SCOPE_COPY.select(sibling.label) })).toBeNull()
   })
 
-  it('selects the exact question market for a group', () => {
+  it('keeps a group selection free of an implicit market filter', () => {
     const group = marketScopes.find(scope => scope.id === 'center')!
     const view = openPicker(vi.fn(), marketScopes)
     fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.browse(region.label) }))
     fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(group.label) }))
-    expect(view.onSelect).toHaveBeenLastCalledWith(group, group.marketKeys![0])
+    expect(view.onSelect).toHaveBeenLastCalledWith(group)
+  })
+
+  it.each(['market', 'property', 'group'] as const)('retains an explicit market from a %s selection within a group containing multiple markets', kind => {
+    const group = { ...marketScopes.find(scope => scope.id === 'center')!, marketKeys: property.marketKeys }
+    const market = { ...marketScopes.find(scope => scope.id === 'market-waterfront')!, parentGroupIds: [group.id] }
+    const options = marketScopes.map(scope => scope.id === group.id ? group : scope.id === market.id ? market : scope)
+    const onSelect = vi.fn()
+    const view = render(<VisibilityScopePicker options={options} selected={kind === 'market' ? market : kind === 'group' ? group : property} marketKey={kind === 'market' ? undefined : market.id} onSelect={onSelect} />)
+    fireEvent.click(view.container.querySelector('summary')!)
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(property.label) }))
+    expect(onSelect).toHaveBeenCalledWith(property, market.id)
+  })
+
+  it.each(['root', 'region', 'group'])('finds nested markets by their exact name from the %s', level => {
+    const market = marketScopes.find(scope => scope.id === 'market-center')!
+    const view = openPicker(vi.fn(), marketScopes)
+    if (level !== 'root') fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.browse(region.label) }))
+    if (level === 'group') fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.browse(marketScopes.find(scope => scope.id === market.parentGroupIds![0])!.label) }))
+    expect(screen.queryByRole('button', { name: MARKET_SCOPE_COPY.select(market.label) })).toBeNull()
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: market.label } })
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(market.label) }))
+    expect(view.onSelect).toHaveBeenCalledWith(market)
   })
 
   it('opens a direct property selection across all its markets and clears a previous market', () => {

--- a/apps/web/test/visibility-scope-picker.test.tsx
+++ b/apps/web/test/visibility-scope-picker.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { VisibilityReportScopeOption } from '@ainyc/canonry-contracts'
-import { VisibilityScopePicker } from '../src/components/project/VisibilityScopePicker.js'
+import { VisibilityScopePicker, MARKET_SCOPE_COPY } from '../src/components/project/VisibilityScopePicker.js'
 
 afterEach(cleanup)
 
@@ -157,5 +157,59 @@ describe('group-first scope navigation', () => {
     fireEvent.keyDown(search, { key: 'Escape' })
     expect(view.container.querySelector('details')!.open).toBe(false)
     expect(document.activeElement).toBe(view.container.querySelector('summary'))
+  })
+})
+
+
+describe('market context through property navigation', () => {
+  const marketScopes: VisibilityReportScopeOption[] = scopes.map(scope => ({
+    ...scope,
+    ...(['center', 'waterfront'].includes(scope.id) ? { marketKeys: [`market-${scope.id}`] } : scope.id === 'a' ? { marketKeys: ['market-center', 'market-waterfront'] } : {}),
+  })).concat(['center', 'waterfront'].map(id => ({ id: `market-${id}`, label: `${id} questions`, kind: 'market' as const, targetCount: 1, parentGroupIds: [id] })))
+  const property = marketScopes.find(scope => scope.id === 'a')!
+  const region = marketScopes.find(scope => scope.id === 'north')!
+
+  it.each(['center', 'waterfront'])('keeps %s when selecting a shared property and reopening from its URL', id => {
+    const group = marketScopes.find(scope => scope.id === id)!
+    const view = openPicker(vi.fn(), marketScopes)
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.browse(region.label) }))
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.browse(group.label) }))
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(property.label) }))
+    expect(view.onSelect).toHaveBeenLastCalledWith(property, `market-${id}`)
+    view.unmount()
+    const restored = render(<VisibilityScopePicker options={marketScopes} selected={property} marketKey={`market-${id}`} onSelect={view.onSelect} />)
+    fireEvent.click(restored.container.querySelector('summary')!)
+    expect(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(group.label) })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(property.label) }))
+    expect(view.onSelect).toHaveBeenLastCalledWith(property, `market-${id}`)
+  })
+
+  it('limits property choices to the linked market when it covers only part of a group', () => {
+    const group = marketScopes.find(scope => scope.id === 'center')!
+    const sibling = { ...marketScopes.find(scope => scope.id === 'b')!, parentGroupIds: [region.id, group.id] }
+    const options = marketScopes.map(scope => scope.id === sibling.id ? sibling : scope.id === group.id ? { ...group, targetCount: 2 } : scope)
+    openPicker(vi.fn(), options)
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.browse(region.label) }))
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.browse(group.label) }))
+    expect(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(property.label) })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: MARKET_SCOPE_COPY.select(sibling.label) })).toBeNull()
+  })
+
+  it('selects the exact question market for a group', () => {
+    const group = marketScopes.find(scope => scope.id === 'center')!
+    const view = openPicker(vi.fn(), marketScopes)
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.browse(region.label) }))
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(group.label) }))
+    expect(view.onSelect).toHaveBeenLastCalledWith(group, group.marketKeys![0])
+  })
+
+  it('opens a direct property selection across all its markets and clears a previous market', () => {
+    const onSelect = vi.fn()
+    const view = render(<VisibilityScopePicker options={marketScopes} selected={property} onSelect={onSelect} />)
+    expect(view.container.querySelector('summary')!.textContent).toContain(MARKET_SCOPE_COPY.allMarkets)
+    fireEvent.click(view.container.querySelector('summary')!)
+    expect(screen.queryByRole('button', { name: MARKET_SCOPE_COPY.select(marketScopes.find(scope => scope.id === 'center')!.label) })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: MARKET_SCOPE_COPY.select(property.label) }))
+    expect(onSelect).toHaveBeenCalledWith(property)
   })
 })

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -253,7 +253,7 @@ before enabling spend.
 
 The full 213-tool catalog (211 API tools plus two meta-tools) is too large to expose eagerly in most sessions. `canonry-mcp` defaults to a small **core tier** and registers the rest on demand via `notifications/tools/list_changed`.
 
-For shared query assignments and measured results, see [Query control and AI visibility](query-visibility.md). The setup toolkit provides workspace, preview, and commit tools. Monitoring provides `canonry_visibility_report`. Preview requires write access but starts no provider calls.
+For shared query assignments and measured results, see [Query control and AI visibility](query-visibility.md). The setup toolkit provides workspace, preview, and commit tools. Monitoring provides `canonry_visibility_report`. Its optional `marketKey` narrows a project, group, or property report to exact saved market assignments, including metrics, competitors and answer details. Omit it to read the full selected scope. Preview requires write access but starts no provider calls.
 
 Core tier (always loaded):
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.192.0",
+  "version": "4.192.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -14,6 +14,15 @@ export type VisibilityReportResponse = {
             kind: 'project' | 'group' | 'market' | 'property';
             targetCount: number;
             parentGroupIds?: Array<string>;
+            marketKeys?: Array<string>;
+        };
+        market?: {
+            id: string;
+            label: string;
+            kind: 'project' | 'group' | 'market' | 'property';
+            targetCount: number;
+            parentGroupIds?: Array<string>;
+            marketKeys?: Array<string>;
         };
         provider: string | null;
         model: string | null;
@@ -68,6 +77,7 @@ export type VisibilityReportResponse = {
         kind: 'project' | 'group' | 'market' | 'property';
         targetCount: number;
         parentGroupIds?: Array<string>;
+        marketKeys?: Array<string>;
     }>;
     filterOptions: {
         providers: Array<string>;
@@ -161,6 +171,7 @@ export type VisibilityReportResponse = {
                 model: string | null;
                 location: string | null;
                 targetKeys: Array<string>;
+                marketKeys?: Array<string>;
                 answerCount: number;
                 mentionCoverage: {
                     numerator: number | null;
@@ -296,6 +307,7 @@ export type QueryTrackingWorkspaceResponse = {
     }>;
     markets: Array<{
         stableKey: string;
+        groupKey?: string;
         label: string;
         usageEdges: Array<{
             executionNodeKey: string;
@@ -5526,6 +5538,7 @@ export type MeasurementDraftCompilePreviewResponse = {
             stableKey: string;
             label: string;
             kind: 'market';
+            groupKey?: string;
             usageEdges: Array<{
                 executionNodeKey: string;
                 targetKey: string;
@@ -5661,6 +5674,7 @@ export type MeasurementDraftDiffPreviewResponse = {
             stableKey: string;
             label: string;
             kind: 'market';
+            groupKey?: string;
             usageEdges: Array<{
                 executionNodeKey: string;
                 targetKey: string;
@@ -6311,6 +6325,7 @@ export type MeasurementDraftResponse = {
                 stableKey: string;
                 label: string;
                 kind: 'market';
+                groupKey?: string;
                 usageEdges: Array<{
                     executionNodeKey: string;
                     targetKey: string;
@@ -6401,6 +6416,7 @@ export type MeasurementDraftUpsertMarketRequest = {
         stableKey: string;
         label: string;
         kind: 'market';
+        groupKey?: string;
         usageEdges: Array<{
             executionNodeKey: string;
             targetKey: string;
@@ -7505,6 +7521,7 @@ export type MeasurementPlanResponse = {
                 stableKey: string;
                 label: string;
                 kind: 'market';
+                groupKey?: string;
                 usageEdges: Array<{
                     executionNodeKey: string;
                     targetKey: string;
@@ -7618,6 +7635,7 @@ export type MeasurementPlanV2PublishResponse = {
                 stableKey: string;
                 label: string;
                 kind: 'market';
+                groupKey?: string;
                 usageEdges: Array<{
                     executionNodeKey: string;
                     targetKey: string;
@@ -7813,6 +7831,7 @@ export type MeasurementPlanVersionResponse = {
                 stableKey: string;
                 label: string;
                 kind: 'market';
+                groupKey?: string;
                 usageEdges: Array<{
                     executionNodeKey: string;
                     targetKey: string;
@@ -9186,6 +9205,15 @@ export type ProjectReportDto = {
                 kind: 'project' | 'group' | 'market' | 'property';
                 targetCount: number;
                 parentGroupIds?: Array<string>;
+                marketKeys?: Array<string>;
+            };
+            market?: {
+                id: string;
+                label: string;
+                kind: 'project' | 'group' | 'market' | 'property';
+                targetCount: number;
+                parentGroupIds?: Array<string>;
+                marketKeys?: Array<string>;
             };
             provider: string | null;
             model: string | null;

--- a/packages/api-routes/AGENTS.md
+++ b/packages/api-routes/AGENTS.md
@@ -113,7 +113,8 @@ Research rejects normalized duplicate queries before dispatch while preserving a
 `visibility-report` owns metrics, denominators, scope, provenance, trends, and paginated evidence.
 Historical trends use the shared compact measurement signals. Reconstruct detailed answer/source evidence only for the selected run; preserve frozen-manifest validation, selectable older evidence, and immediate visibility of changed or deleted snapshots. Do not share request-specific summaries across callers or selections.
 Groups select properties. Markets select frozen `reportingScopes` execution edges.
-Label-only revisions use the comparable chain. Material changes read prior evidence through its own frozen plan.
+The optional `marketKey` intersects a project, group, or property selection with exact market edges before every report section and answer read. It participates in cursor identity. Explicit `reportingScopes.groupKey` links navigation; never infer it from overlapping properties.
+Display-only revisions and additive reporting scopes use the comparable chain only when every existing market population and all other measurement semantics remain exact. Material changes read prior evidence through its own frozen plan.
 Never infer a market from a group label or reuse the browser's global run drawer parameter.
 
 ### Portfolio summary aggregation

--- a/packages/api-routes/AGENTS.md
+++ b/packages/api-routes/AGENTS.md
@@ -112,7 +112,7 @@ Publication starts zero provider calls. Existing drafts become stale through the
 Research rejects normalized duplicate queries before dispatch while preserving accepted text exactly. Research templates must be project-configured; editor and server expansion share declared bindings, and saved provenance remains immutable.
 `visibility-report` owns metrics, denominators, scope, provenance, trends, and paginated evidence.
 Historical trends use the shared compact measurement signals. Reconstruct detailed answer/source evidence only for the selected run; preserve frozen-manifest validation, selectable older evidence, and immediate visibility of changed or deleted snapshots. Do not share request-specific summaries across callers or selections.
-Groups select properties. Markets select frozen `reportingScopes` execution edges.
+Groups select properties. Markets select frozen `reportingScopes` execution edges. Group breakdown rows use the same selected population as direct group summaries; navigation metadata alone never adds a market filter.
 The optional `marketKey` intersects a project, group, or property selection with exact market edges before every report section and answer read. It participates in cursor identity. Explicit `reportingScopes.groupKey` links navigation; never infer it from overlapping properties.
 Display-only revisions and additive reporting scopes use the comparable chain only when every existing market population and all other measurement semantics remain exact. Material changes read prior evidence through its own frozen plan.
 Never infer a market from a group label or reuse the browser's global run drawer parameter.

--- a/packages/api-routes/src/measurement-draft-actions.ts
+++ b/packages/api-routes/src/measurement-draft-actions.ts
@@ -650,6 +650,10 @@ function upsertGroup(authoring: MeasurementDraftAuthoring, body: unknown): Draft
 
 function upsertMarket(authoring: MeasurementDraftAuthoring, body: unknown): DraftActionResult {
   const { market } = parseBody(measurementDraftUpsertMarketRequestSchema, body, 'upsert-market')
+  if (market.groupKey !== undefined) {
+    const group = authoring.groups.find(group => group.stableKey === market.groupKey)
+    if (!group || market.usageEdges.some(edge => !group.targetKeys.includes(edge.targetKey))) throw validationError('A market must link to an existing group containing all its assigned properties.')
+  }
   const included = new Set(authoring.targets.filter(target => target.status === 'included').map(target => target.stableKey))
   const frozen = new Set(authoring.assignments.flatMap(assignment => (assignment.executionContexts ?? [])
     .filter(context => context.executionNodeKey !== undefined)

--- a/packages/api-routes/src/measurement-draft-compile.ts
+++ b/packages/api-routes/src/measurement-draft-compile.ts
@@ -785,8 +785,17 @@ export function diffCompiledPlans(
  * (`measurement_plan_versions.comparable_to_version_id`) promises the reads.
  */
 export function plansAreLabelOnlyVariants(active: MeasurementPlanV2, candidate: MeasurementPlanV2): boolean {
+  // Adding a named selection over existing frozen edges does not change their
+  // questions, assignments or attribution. Existing market populations must
+  // remain exact; changing or removing one is a material measurement change.
+  const marketSurface = (scope: MeasurementV2ReportingScope) => {
+    const { groupKey: _groupKey, ...population } = scope
+    return JSON.stringify(canonicalJsonValue({ ...population, label: '' }))
+  }
+  const nextMarkets = new Map((canonicalMeasurementPlanV2(candidate).reportingScopes ?? []).map(scope => [scope.stableKey, marketSurface(scope)]))
+  if ((canonicalMeasurementPlanV2(active).reportingScopes ?? []).some(scope => nextMarkets.get(scope.stableKey) !== marketSurface(scope))) return false
   /**
-   * Continuity is promised only when labels or navigation parents change.
+   * Continuity permits display changes and additive reporting selections only.
    * Compare the full canonical document with those display fields neutralized,
    * not the execution nodes alone. Execution-node equality looked sufficient and was
    * not: queryClass lives on assignments, aliases and urlMatchers on targets,
@@ -804,6 +813,7 @@ export function plansAreLabelOnlyVariants(active: MeasurementPlanV2, candidate: 
       // The checksum includes labels and navigation parents. Neutralize it
       // with those display fields; all measurement semantics stay in the comparison.
       compiledChecksum: '',
+      reportingScopes: [],
       targets: doc.targets.map((target) => ({ ...target, label: '' })),
       groups: doc.groups.map(({ parentGroupKey: _parentGroupKey, ...group }) => ({
         // Parentage changes navigation only. It changes the frozen document and

--- a/packages/api-routes/src/query-tracking.ts
+++ b/packages/api-routes/src/query-tracking.ts
@@ -815,7 +815,7 @@ function workspaceDto(db: DbLike, state: WorkspaceState, opts: QueryTrackingRout
       stableKey: group.stableKey, label: group.label, targetKeys: group.targetKeys,
       ...(group.parentGroupKey ? { parentGroupKey: group.parentGroupKey } : {}),
     })) ?? [],
-    markets: plan?.reportingScopes?.map(scope => ({ stableKey: scope.stableKey, label: scope.label, usageEdges: scope.usageEdges })) ?? [],
+    markets: plan?.reportingScopes?.map(scope => ({ stableKey: scope.stableKey, label: scope.label, usageEdges: scope.usageEdges, ...(scope.groupKey ? { groupKey: scope.groupKey } : {}) })) ?? [],
     tracked: trackedRows(db, state, rows, plan, opts),
     savedSources: savedSources(db, state.project.id),
   })

--- a/packages/api-routes/src/visibility-report-reader.ts
+++ b/packages/api-routes/src/visibility-report-reader.ts
@@ -115,6 +115,8 @@ export interface VisibilityReportReaderSelection {
   queryClass: 'branded' | 'non-brand' | 'unknown' | 'all'
   scope: VisibilityReportScopeKind
   scopeKey?: string
+  /** Exact frozen reporting-scope selection layered onto the primary scope. */
+  marketKey?: string
   provider?: string
   model?: string
   location: VisibilityReportLocationSelection
@@ -166,6 +168,7 @@ interface Candidate {
 
 interface ScopeResolution {
   option: VisibilityReportScopeOption
+  market?: VisibilityReportScopeOption
   edgeIds: Set<string>
 }
 
@@ -217,37 +220,44 @@ function scopeResolution(
 ): ScopeResolution {
   const project = definition.scopeOptions.find(option => option.kind === 'project')
   if (!project) throw new VisibilityReportScopeError('Frozen definition has no project scope.')
+
+  let option = project
+  let edgeIds: Set<string>
   if (selection.scope === 'project') {
-    return { option: project, edgeIds: new Set(definition.edges.map(edge => edge.id)) }
-  }
-
-  const key = selection.scopeKey
-  if (!key) throw new VisibilityReportScopeError(`${selection.scope} scope requires a scope key.`)
-  const option = definition.scopeOptions.find(candidate => candidate.kind === selection.scope && candidate.id === key)
-  if (!option) throw new VisibilityReportScopeError(`${selection.scope} scope "${key}" is not in this frozen definition.`)
-
-  if (selection.scope === 'property') {
-    return {
-      option,
-      edgeIds: new Set(definition.edges.filter(edge => edge.targetKey === key).map(edge => edge.id)),
-    }
-  }
-  if (selection.scope === 'group') {
-    const group = definition.groups.find(candidate => candidate.id === key)
-    if (!group) throw new VisibilityReportScopeError(`Group "${key}" is not in this frozen definition.`)
-    const targetKeys = new Set(group.targetKeys)
-    return {
-      option,
-      edgeIds: new Set(definition.edges.filter(edge => targetKeys.has(edge.targetKey)).map(edge => edge.id)),
+    edgeIds = new Set(definition.edges.map(edge => edge.id))
+  } else {
+    const key = selection.scopeKey
+    if (!key) throw new VisibilityReportScopeError(`${selection.scope} scope requires a scope key.`)
+    const scoped = definition.scopeOptions.find(candidate => candidate.kind === selection.scope && candidate.id === key)
+    if (!scoped) throw new VisibilityReportScopeError(`${selection.scope} scope "${key}" is not in this frozen definition.`)
+    option = scoped
+    if (selection.scope === 'property') {
+      edgeIds = new Set(definition.edges.filter(edge => edge.targetKey === key).map(edge => edge.id))
+    } else if (selection.scope === 'group') {
+      const group = definition.groups.find(candidate => candidate.id === key)
+      if (!group) throw new VisibilityReportScopeError(`Group "${key}" is not in this frozen definition.`)
+      const targetKeys = new Set(group.targetKeys)
+      edgeIds = new Set(definition.edges.filter(edge => targetKeys.has(edge.targetKey)).map(edge => edge.id))
+    } else {
+      // A market scope selects only exact frozen triples. A Target that has an
+      // Alpha and a Beta node does not let Alpha borrow Beta by target membership.
+      edgeIds = new Set(definition.edges.filter(edge => edge.marketKeys.includes(key)).map(edge => edge.id))
     }
   }
 
-  // Crucial: market scope selects only exact frozen triples. A Target that has
-  // an Alpha and a Beta node does NOT let Alpha borrow Beta merely because both
-  // edges name the same Target.
+  if (selection.scope === 'market' && selection.marketKey !== undefined) {
+    throw new VisibilityReportScopeError('marketKey is not valid for market scope.')
+  }
+  const marketKey = selection.scope === 'market' ? selection.scopeKey : selection.marketKey
+  if (marketKey === undefined) return { option, edgeIds }
+  const market = definition.scopeOptions.find(candidate => candidate.kind === 'market' && candidate.id === marketKey)
+  if (!market) throw new VisibilityReportScopeError(`Market "${marketKey}" is not in this frozen definition.`)
   return {
     option,
-    edgeIds: new Set(definition.edges.filter(edge => edge.marketKeys.includes(key)).map(edge => edge.id)),
+    market,
+    edgeIds: new Set(definition.edges
+      .filter(edge => edgeIds.has(edge.id) && edge.marketKeys.includes(marketKey))
+      .map(edge => edge.id)),
   }
 }
 
@@ -262,6 +272,9 @@ function scopeTargetKeys(
   selection: VisibilityReportReaderSelection,
 ): string[] {
   const resolution = scopeResolution(definition, selection)
+  if (resolution.market !== undefined) return [...new Set(definition.edges
+    .filter(edge => resolution.edgeIds.has(edge.id))
+    .map(edge => edge.targetKey))].sort(compareText)
   if (selection.scope === 'project') return definition.targets.map(target => target.id).sort(compareText)
   if (selection.scope === 'property') return [resolution.option.id]
   if (selection.scope === 'group') {
@@ -509,12 +522,19 @@ function queryRows(candidates: readonly Candidate[], definition: VisibilityRepor
       model: first.observation?.model ?? null,
       location: first.slot.location,
       targetKeys: selectedTargetKeys(rows),
+      ...(() => {
+        const marketKeys = [...new Set(rows.flatMap(row => row.edges.flatMap(edge => edge.marketKeys)))].sort(compareText)
+        return marketKeys.length === 0 ? {} : { marketKeys }
+      })(),
       answerCount: value.answerCount,
       mentionCoverage: value.mentionCoverage,
       citationCoverage: value.citationCoverage,
     }
   }).sort((left, right) => (
-    compareText(normalizeText(left.query), normalizeText(right.query))
+    (selection.scope === 'property' && selection.marketKey === undefined
+      ? compareText((left.marketKeys ?? []).join('\u0000'), (right.marketKeys ?? []).join('\u0000'))
+      : 0)
+    || compareText(normalizeText(left.query), normalizeText(right.query))
     || compareText(left.provider, right.provider)
     || compareText(left.model ?? '', right.model ?? '')
     || compareText(left.location ?? '', right.location ?? '')
@@ -636,7 +656,12 @@ function breakdown(
     .filter(({ targetKeys }) => targetKeys.length > 0)
     .map(({ group, targetKeys }) => {
       const groupTargetKeys = new Set(targetKeys)
-      const own = candidates
+      const explicitMarkets = definition.scopeOptions.find(option => option.kind === 'group' && option.id === group.id)?.marketKeys
+      const groupCandidates = explicitMarkets?.length === 1
+        ? candidates.map(candidate => ({ ...candidate, edges: candidate.edges.filter(edge => edge.marketKeys.includes(explicitMarkets[0]!)) }))
+          .filter(candidate => candidate.edges.length > 0)
+        : candidates
+      const own = groupCandidates
         .map(candidate => narrowedToTargetKeys(candidate, groupTargetKeys))
         .filter((candidate): candidate is Candidate => candidate !== null)
       const metrics = mentionRate(own, targets)
@@ -697,6 +722,7 @@ function page<Row>(
     queryClass,
     scope: input.selection.scope,
     scopeKey: input.selection.scopeKey ?? null,
+    marketKey: input.selection.marketKey ?? null,
     provider: input.selection.provider ?? null,
     model: input.selection.model ?? null,
     location: input.selection.location,
@@ -821,7 +847,8 @@ export function buildVisibilityReport(input: VisibilityReportReaderInput): Visib
     ? (input.preferredRunId === undefined ? runs.at(-1) : runs.find(run => run.id === input.preferredRunId))
     : runs.find(run => run.id === input.selection.runId)
   const definition = selectedRun?.definition ?? input.activeDefinition
-  const selectedScope = scopeResolution(definition, input.selection).option
+  const selectedResolution = scopeResolution(definition, input.selection)
+  const selectedScope = selectedResolution.option
   const populationTargetKeys = scopeTargetKeys(definition, input.selection)
   const classes = selectedClasses(input.selection.queryClass)
   const runCandidates = new Map<string, Map<VisibilityReportPopulationClass, Candidate[]>>()
@@ -884,6 +911,7 @@ export function buildVisibilityReport(input: VisibilityReportReaderInput): Visib
       mode: input.mode,
       queryClass: input.selection.queryClass,
       scope: selectedScope,
+      ...(selectedResolution.market === undefined ? {} : { market: selectedResolution.market }),
       provider: input.selection.provider ?? null,
       model: input.selection.model ?? null,
       location: input.selection.location,

--- a/packages/api-routes/src/visibility-report-reader.ts
+++ b/packages/api-routes/src/visibility-report-reader.ts
@@ -656,12 +656,9 @@ function breakdown(
     .filter(({ targetKeys }) => targetKeys.length > 0)
     .map(({ group, targetKeys }) => {
       const groupTargetKeys = new Set(targetKeys)
-      const explicitMarkets = definition.scopeOptions.find(option => option.kind === 'group' && option.id === group.id)?.marketKeys
-      const groupCandidates = explicitMarkets?.length === 1
-        ? candidates.map(candidate => ({ ...candidate, edges: candidate.edges.filter(edge => edge.marketKeys.includes(explicitMarkets[0]!)) }))
-          .filter(candidate => candidate.edges.length > 0)
-        : candidates
-      const own = groupCandidates
+      // Candidates already carry the selected market and other report filters.
+      // A navigation link must not change this group's measured population.
+      const own = candidates
         .map(candidate => narrowedToTargetKeys(candidate, groupTargetKeys))
         .filter((candidate): candidate is Candidate => candidate !== null)
       const metrics = mentionRate(own, targets)

--- a/packages/api-routes/src/visibility-report.ts
+++ b/packages/api-routes/src/visibility-report.ts
@@ -268,16 +268,47 @@ function v2Definition(
   for (const group of plan.groups) {
     for (const targetKey of group.targetKeys) groupKeysForTarget.get(targetKey)?.push(group.stableKey)
   }
+  const marketKeysForGroup = new Map<string, string[]>()
+  const marketKeysForTarget = new Map(plan.targets.map(target => [target.stableKey, [] as string[]]))
+  for (const market of plan.reportingScopes ?? []) {
+    if (market.groupKey !== undefined) {
+      const keys = marketKeysForGroup.get(market.groupKey) ?? []
+      keys.push(market.stableKey)
+      marketKeysForGroup.set(market.groupKey, keys)
+    }
+    for (const edge of market.usageEdges) marketKeysForTarget.get(edge.targetKey)?.push(market.stableKey)
+  }
   const scopeOptions = [
     { id: 'project', label: 'Project', kind: 'project' as const, targetCount: plan.targets.length },
-    ...plan.groups.map(group => ({ id: group.stableKey, label: group.label, kind: 'group' as const, targetCount: group.targetKeys.length, ...(group.parentGroupKey === undefined ? {} : { parentGroupIds: [group.parentGroupKey] }) })),
+    ...plan.groups.map(group => {
+      const marketKeys = [...new Set(marketKeysForGroup.get(group.stableKey) ?? [])].sort()
+      return {
+        id: group.stableKey,
+        label: group.label,
+        kind: 'group' as const,
+        targetCount: group.targetKeys.length,
+        ...(group.parentGroupKey === undefined ? {} : { parentGroupIds: [group.parentGroupKey] }),
+        ...(marketKeys.length === 0 ? {} : { marketKeys }),
+      }
+    }),
     ...plan.reportingScopes?.map(market => ({
       id: market.stableKey,
       label: market.label,
       kind: 'market' as const,
       targetCount: new Set(market.usageEdges.map(edge => edge.targetKey)).size,
+      ...(market.groupKey === undefined ? {} : { parentGroupIds: [market.groupKey] }),
     })) ?? [],
-    ...plan.targets.map(target => ({ id: target.stableKey, label: target.label, kind: 'property' as const, targetCount: 1, parentGroupIds: [...new Set(groupKeysForTarget.get(target.stableKey) ?? [])].sort() })),
+    ...plan.targets.map(target => {
+      const marketKeys = [...new Set(marketKeysForTarget.get(target.stableKey) ?? [])].sort()
+      return {
+        id: target.stableKey,
+        label: target.label,
+        kind: 'property' as const,
+        targetCount: 1,
+        parentGroupIds: [...new Set(groupKeysForTarget.get(target.stableKey) ?? [])].sort(),
+        ...(marketKeys.length === 0 ? {} : { marketKeys }),
+      }
+    }),
   ]
   return {
     revision,

--- a/packages/api-routes/test/measurement-draft-actions.test.ts
+++ b/packages/api-routes/test/measurement-draft-actions.test.ts
@@ -433,14 +433,14 @@ describe('measurement draft group hierarchy', () => {
 })
 
 
-it('configures a named market from exact frozen memberships without changing assignments', () => {
+it('configures a named market from exact frozen memberships and an explicit containing group without changing assignments', () => {
   const authoring = audienceFixture()
   authoring.assignments = [{
     targetKey: 'dallas-1', queryId: 'q-market', queryClass: 'non-brand', classificationSource: 'operator',
     executionContexts: [{ providers: ['openai'], models: {}, location: null, executionNodeKey: 'existing-context' }],
   }]
   const edge = { executionNodeKey: 'existing-context', targetKey: 'dallas-1', queryId: 'q-market' }
-  const market = { stableKey: 'uptown', kind: 'market', label: 'Uptown', usageEdges: [edge] }
+  const market = { stableKey: 'uptown', kind: 'market', label: 'Uptown', groupKey: 'dallas', usageEdges: [edge] }
   const added = applyDraftAction('upsert-market', authoring, { market }, audienceContext).authoring
   expect(added.reportingScopes).toEqual([market])
   expect(added.assignments).toEqual(authoring.assignments)
@@ -449,6 +449,9 @@ it('configures a named market from exact frozen memberships without changing ass
   const renamed = applyDraftAction('upsert-market', added, { market: { ...market, label: 'Uptown district' } }, audienceContext).authoring
   expect(renamed.reportingScopes).toHaveLength(1)
   expect(renamed.reportingScopes?.[0]?.label).toBe('Uptown district')
+  expect(renamed.reportingScopes?.[0]?.groupKey).toBe('dallas')
   expect(() => applyDraftAction('upsert-market', authoring, { market: { ...market, usageEdges: [{ ...edge, executionNodeKey: 'unpublished' }] } }, audienceContext)).toThrow(/existing frozen assignments/)
   expect(() => applyDraftAction('upsert-market', authoring, { market: { ...market, usageEdges: [edge, edge] } }, audienceContext)).toThrow(/duplicate assignment/)
+  expect(() => applyDraftAction('upsert-market', authoring, { market: { ...market, groupKey: 'missing' } }, audienceContext)).toThrow(/existing group containing all its assigned properties/)
+  expect(() => applyDraftAction('upsert-market', authoring, { market: { ...market, groupKey: 'luxury' } }, audienceContext)).toThrow(/existing group containing all its assigned properties/)
 })

--- a/packages/api-routes/test/measurement-draft-compile.test.ts
+++ b/packages/api-routes/test/measurement-draft-compile.test.ts
@@ -162,7 +162,7 @@ describe('measurement draft compiler', () => {
         urlMatchers: ['https://northwind.example/widgets/*'], source: 'manual',
       }],
       assignments: [{ targetKey: 'widgets', queryId: 'q-best-widgets', queryClass: 'non-brand', classificationSource: 'operator' }],
-      groups: [],
+      groups: [{ stableKey: 'collection', label: 'Collection', targetKeys: ['widgets'], competitors: [] }],
     })
     const context = {
       canonicalDomain: 'northwind.example', ownedDomains: [], brandNames: ['Northwind'], locations: [],
@@ -176,12 +176,13 @@ describe('measurement draft compiler', () => {
     const changed = compileMeasurementDraft({
       ...base,
       defaultContext: { providers: ['gemini'], locations: [] },
-      reportingScopes: [{ stableKey: 'alpha', label: 'Alpha', kind: 'market', usageEdges: [edge] }],
+      reportingScopes: [{ stableKey: 'alpha', label: 'Alpha', kind: 'market', groupKey: 'collection', usageEdges: [edge] }],
     }, context)
 
     expect(changed.ok).toBe(true)
     if (!changed.ok) return
     expect(changed.plan.reportingScopes?.[0]?.usageEdges).toEqual(changed.plan.usageEdges)
+    expect(changed.plan.reportingScopes?.[0]?.groupKey).toBe('collection')
     expect(changed.checks).toContainEqual(expect.objectContaining({ ruleId: 'reporting-scope-edge-rebuilt', severity: 'warn' }))
   })
 

--- a/packages/api-routes/test/measurement-draft.test.ts
+++ b/packages/api-routes/test/measurement-draft.test.ts
@@ -22,6 +22,9 @@ import {
   measurementPlanVersionResponseSchema,
   measurementPlanV2PublishResponseSchema,
   measurementSetupResponseSchema,
+  RunKinds,
+  RunStatuses,
+  RunTriggers,
 } from '@ainyc/canonry-contracts'
 import {
   apiKeys,
@@ -35,12 +38,14 @@ import {
   migrate,
   projects,
   queries,
+  querySnapshots,
   runs,
   schedules,
   type DatabaseClient,
 } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 import { plansAreLabelOnlyVariants } from '../src/measurement-draft-compile.js'
+import { buildMeasurementPlanV2Manifest } from '../src/measurement-report-adapter.js'
 import { hashApiKey } from '../src/auth.js'
 import { sha256Hex } from '../src/measurement-draft-repo.js'
 
@@ -1463,6 +1468,78 @@ describe('measurement draft publish', () => {
     expect(revisionSix.comparableToVersionId).toBeNull()
   })
 
+  it('publishes additive market metadata without replacing a measured baseline or its stored answers', async () => {
+    const initial = await readyDraft()
+    await initial.run('upsert-group', { group: { stableKey: 'metro', label: 'Metro', targetKeys: ['widgets'], competitors: [] } })
+    expect((await publish(initial, null)).statusCode).toBe(200)
+    const originalVersion = db.select().from(measurementPlanVersions).where(eq(measurementPlanVersions.revision, 1)).get()!
+    const originalPlan = measurementPlanV2Schema.parse(JSON.parse(originalVersion.canonicalJson))
+    const manifest = buildMeasurementPlanV2Manifest(originalPlan)
+    const runId = 'run_market_baseline'
+    db.insert(runs).values({
+      id: runId,
+      projectId: 'prj_northwind',
+      kind: RunKinds['answer-visibility'],
+      status: RunStatuses.completed,
+      trigger: RunTriggers.manual,
+      measurementPlanVersionId: originalVersion.id,
+      measurementManifest: { schemaVersion: 1, expectedSlots: manifest.expectedSlots },
+      measurementExecutionIdentity: { schemaVersion: 1, providers: ['gemini', 'openai'], models: { gemini: 'gemini-test', openai: 'gpt-test' }, checksum: 'test-market-baseline' },
+      finishedAt: NOW,
+      createdAt: NOW,
+    }).run()
+    for (const slot of manifest.expectedSlots) {
+      db.insert(querySnapshots).values({
+        id: crypto.randomUUID(),
+        runId,
+        queryId: null,
+        queryText: slot.queryText,
+        provider: slot.provider,
+        model: slot.requestedModel ?? null,
+        servedModel: `${slot.provider}-served`,
+        citationState: 'cited',
+        answerMentioned: true,
+        answerText: 'Northwind Widgets is a measured result.',
+        citedDomains: [],
+        citedUrls: ['https://northwind.example/widgets/'],
+        captureStatus: 'complete',
+        recommendedCompetitors: [],
+        location: slot.context?.label ?? null,
+        measurementExecutionId: slot.executionId,
+        requestedContext: slot.context,
+        supportedContext: slot.context === null ? null : { status: 'applied', resolved: slot.context },
+        createdAt: NOW,
+      }).run()
+    }
+    const beforeRuns = db.select().from(runs).all()
+    const beforeSnapshots = db.select().from(querySnapshots).all()
+
+    const metadata = await DraftSession.start(1)
+    await metadata.run('upsert-market', {
+      market: {
+        stableKey: 'metro-market',
+        label: 'Metro market',
+        kind: 'market',
+        groupKey: 'metro',
+        usageEdges: originalPlan.usageEdges.filter(edge => edge.queryId === queryId('best widget supplier')),
+      },
+    })
+    expect((await publish(metadata, 1)).statusCode).toBe(200)
+    const metadataVersion = db.select().from(measurementPlanVersions).where(eq(measurementPlanVersions.revision, 2)).get()!
+    expect(metadataVersion.comparableToVersionId).toBe(originalVersion.id)
+    const metadataPlan = measurementPlanV2Schema.parse(JSON.parse(metadataVersion.canonicalJson))
+    expect(metadataPlan.reportingScopes).toEqual([expect.objectContaining({ stableKey: 'metro-market', groupKey: 'metro' })])
+
+    const report = await request('GET', '/visibility-report?scope=market&scopeKey=metro-market&queryClass=non-brand')
+    expect(report.statusCode, report.body).toBe(200)
+    expect(report.json()).toMatchObject({
+      selection: { run: { id: runId }, measurement: { activeRevision: 2, measuredRevision: 2, awaitingSweep: false, pendingAssignmentCount: 0 } },
+      scopeOptions: expect.arrayContaining([expect.objectContaining({ id: 'metro-market', label: 'Metro market', kind: 'market' })]),
+    })
+    expect(db.select().from(runs).all()).toEqual(beforeRuns)
+    expect(db.select().from(querySnapshots).all()).toEqual(beforeSnapshots)
+  })
+
   it('deletes only the active-plan pointer on deactivate', async () => {
     const session = await readyDraft()
     await publish(session, null)
@@ -1889,6 +1966,22 @@ describe('measurement draft hierarchy continuity', () => {
     const changedContext = structuredClone(firstPlan)
     changedContext.executionNodes[0]!.context.models = { ...changedContext.executionNodes[0]!.context.models, openai: 'changed-model' }
     expect(plansAreLabelOnlyVariants(firstPlan, changedContext)).toBe(false)
+    const changedProvider = structuredClone(firstPlan)
+    changedProvider.executionNodes[0]!.context.providers = ['openai']
+    expect(plansAreLabelOnlyVariants(firstPlan, changedProvider)).toBe(false)
+
+    const marketEdge = firstPlan.usageEdges[0]!
+    const additiveMarket = structuredClone(firstPlan)
+    additiveMarket.reportingScopes = [{ stableKey: 'metro-market', label: 'Metro market', kind: 'market', groupKey: 'metro', usageEdges: [marketEdge] }]
+    expect(plansAreLabelOnlyVariants(firstPlan, additiveMarket)).toBe(true)
+    const navigationOnlyMarket = structuredClone(additiveMarket)
+    navigationOnlyMarket.reportingScopes![0]!.label = 'Metro display name'
+    navigationOnlyMarket.reportingScopes![0]!.groupKey = 'submarket'
+    expect(plansAreLabelOnlyVariants(additiveMarket, navigationOnlyMarket)).toBe(true)
+    const changedMarketPopulation = structuredClone(additiveMarket)
+    changedMarketPopulation.reportingScopes![0]!.usageEdges = []
+    expect(plansAreLabelOnlyVariants(additiveMarket, changedMarketPopulation)).toBe(false)
+    expect(plansAreLabelOnlyVariants(additiveMarket, firstPlan)).toBe(false)
 
     const attach = await DraftSession.start(1)
     await attach.run('upsert-group', { group: { stableKey: 'submarket', label: 'Submarket', parentGroupKey: 'metro', targetKeys: ['widgets'] } })

--- a/packages/api-routes/test/visibility-report-reader.test.ts
+++ b/packages/api-routes/test/visibility-report-reader.test.ts
@@ -199,6 +199,88 @@ describe('buildVisibilityReport', () => {
     expect(population.queries.total).toBe(1)
   })
 
+  it('intersects a linked market with its group before summary, evidence, competitors, and filters', () => {
+    const selection = {
+      queryClass: 'non-brand' as const,
+      scope: 'group' as const,
+      scopeKey: 'collection',
+      marketKey: 'alpha',
+      queryKey: 'nearby:alpha',
+      location: { kind: 'all' as const },
+      limit: 50,
+    }
+    const report = buildVisibilityReport(input({ selection }))
+    const population = report.populations[0]!
+
+    expect(report.selection.market).toMatchObject({ id: 'alpha', kind: 'market' })
+    expect(population.summary).toMatchObject({ queryCount: 1, answerCount: 1 })
+    expect(population.queries.items.map(row => row.location)).toEqual(['Alpha'])
+    expect(population.evidence.items.map(row => row.answerId)).toEqual(['answer-alpha'])
+    expect(population.competitors).toEqual([expect.objectContaining({
+      domain: 'rival.example',
+      mentionCoverage: { numerator: 1, denominator: 1, rate: 1 },
+    })])
+    expect(report.filterOptions.locations).toEqual([{ kind: 'all' }, { kind: 'exact', value: 'Alpha' }])
+  })
+
+  it('binds cursors to the selected market and rejects unknown markets', () => {
+    const selected = run()
+    selected.definition = {
+      ...selected.definition,
+      edges: selected.definition.edges.map(edge => edge.id === 'north-brand'
+        ? { ...edge, queryClass: 'non-brand' as const }
+        : edge),
+    }
+    const alpha = buildVisibilityReport(input({
+      runs: [selected],
+      selection: { queryClass: 'non-brand', scope: 'group', scopeKey: 'collection', marketKey: 'alpha', location: { kind: 'all' }, limit: 1 },
+    }))
+    const cursor = alpha.populations[0]!.queries.nextCursor
+    expect(cursor).not.toBeNull()
+    expect(() => buildVisibilityReport(input({
+      runs: [selected],
+      selection: { queryClass: 'non-brand', scope: 'group', scopeKey: 'collection', marketKey: 'beta', location: { kind: 'all' }, limit: 1, cursor: cursor! },
+    }))).toThrow('does not match the current selection')
+    expect(() => buildVisibilityReport(input({
+      selection: { queryClass: 'non-brand', scope: 'market', scopeKey: 'alpha', marketKey: 'beta', location: { kind: 'all' }, limit: 50 },
+    }))).toThrow('marketKey is not valid for market scope')
+    expect(() => buildVisibilityReport(input({
+      selection: { queryClass: 'non-brand', scope: 'project', marketKey: 'missing', location: { kind: 'all' }, limit: 50 },
+    }))).toThrow('Market "missing" is not in this frozen definition')
+  })
+
+  it('keeps a market absent from an older frozen definition as an empty trend gap', () => {
+    const older = run({ id: 'run-1', createdAt: '2026-09-03T12:00:00.000Z' })
+    older.definition = {
+      ...older.definition,
+      scopeOptions: older.definition.scopeOptions.filter(option => option.id !== 'alpha'),
+      edges: older.definition.edges.map(edge => ({ ...edge, marketKeys: edge.marketKeys.filter(key => key !== 'alpha') })),
+    }
+    const report = buildVisibilityReport(input({
+      runs: [older, run()],
+      selection: { queryClass: 'non-brand', scope: 'group', scopeKey: 'collection', marketKey: 'alpha', location: { kind: 'all' }, limit: 50 },
+    }))
+    expect(report.populations[0]!.trend.map(point => point.answerCount)).toEqual([0, 1])
+  })
+
+  it('uses a group’s single explicit market for its project-level breakdown row', () => {
+    const selected = run()
+    selected.definition = {
+      ...selected.definition,
+      scopeOptions: selected.definition.scopeOptions.map(option => option.id === 'collection'
+        ? { ...option, marketKeys: ['alpha'] }
+        : option),
+    }
+    const report = buildVisibilityReport(input({
+      runs: [selected],
+      selection: { queryClass: 'non-brand', scope: 'project', location: { kind: 'all' }, limit: 50 },
+    }))
+    expect(report.populations[0]!.breakdown.groups).toEqual([expect.objectContaining({
+      id: 'collection',
+      mentionCoverage: { numerator: 1, denominator: 1, rate: 1 },
+    })])
+  })
+
   it('narrows a group’s shared-answer signals to the group’s own target edges', () => {
     const multiClass = run()
     multiClass.definition = {

--- a/packages/api-routes/test/visibility-report-reader.test.ts
+++ b/packages/api-routes/test/visibility-report-reader.test.ts
@@ -263,7 +263,7 @@ describe('buildVisibilityReport', () => {
     expect(report.populations[0]!.trend.map(point => point.answerCount)).toEqual([0, 1])
   })
 
-  it('uses a group’s single explicit market for its project-level breakdown row', () => {
+  it.each([undefined, 'alpha', 'beta'])('keeps group rows and direct summaries on the same population with market %s', marketKey => {
     const selected = run()
     selected.definition = {
       ...selected.definition,
@@ -271,14 +271,16 @@ describe('buildVisibilityReport', () => {
         ? { ...option, marketKeys: ['alpha'] }
         : option),
     }
-    const report = buildVisibilityReport(input({
-      runs: [selected],
-      selection: { queryClass: 'non-brand', scope: 'project', location: { kind: 'all' }, limit: 50 },
-    }))
+    const selection = { queryClass: 'non-brand' as const, scope: 'project' as const, marketKey, location: { kind: 'all' as const }, limit: 50 }
+    const report = buildVisibilityReport(input({ runs: [selected], selection }))
+    const direct = buildVisibilityReport(input({ runs: [selected], selection: { ...selection, scope: 'group', scopeKey: 'collection' } }))
+    const summary = direct.populations[0]!.summary
+    expect(summary.mentionCoverage.rate).toBe(marketKey === undefined ? 0.5 : marketKey === 'alpha' ? 1 : 0)
     expect(report.populations[0]!.breakdown.groups).toEqual([expect.objectContaining({
-      id: 'collection',
-      mentionCoverage: { numerator: 1, denominator: 1, rate: 1 },
+      id: 'collection', queryCount: summary.queryCount,
+      mentionCoverage: summary.mentionCoverage, citationCoverage: summary.citationCoverage,
     })])
+    expect(direct.populations[0]!.breakdown.groups).toEqual(report.populations[0]!.breakdown.groups)
   })
 
   it('narrows a group’s shared-answer signals to the group’s own target edges', () => {

--- a/packages/api-routes/test/visibility-report.test.ts
+++ b/packages/api-routes/test/visibility-report.test.ts
@@ -247,6 +247,12 @@ afterEach(async () => {
 })
 
 describe('visibility report route', () => {
+  it('rejects a market refinement against a legacy/simple definition without market edges', async () => {
+    const result = await report('scope=project&marketKey=harbor-market&queryClass=non-brand')
+    expect(result.status).toBe(400)
+    expect(result.body).toMatchObject({ error: { message: 'Market "harbor-market" is not in this frozen definition.' } })
+  })
+
   it('keeps historical evidence selectable and re-reads changed or removed history without stale summaries', async () => {
     const frozenPlan = plan()
     const versionId = seedVersion(1, frozenPlan)
@@ -301,6 +307,41 @@ describe('visibility report route', () => {
     expect(population.breakdown.properties.map(row => row.id)).toEqual(['harbor'])
     expect(population.summary.answerCount).toBe(2)
     expect(population.observedCompetitors).toEqual([{ name: 'Observed Alternative', answerCount: 2 }])
+  })
+
+  it('intersects marketKey with a group scope and returns only explicit frozen market navigation', async () => {
+    const frozenPlan = plan({ reportingScopes: [
+      {
+        stableKey: 'harbor-market', label: 'Harbor market', kind: 'market', groupKey: 'regional',
+        usageEdges: [
+          { executionNodeKey: 'exec-nearby', targetKey: 'harbor', queryId: 'q-nearby' },
+          { executionNodeKey: 'exec-brand', targetKey: 'harbor', queryId: 'q-brand' },
+        ],
+      },
+      {
+        stableKey: 'bayside-market', label: 'Bayside market', kind: 'market',
+        usageEdges: [{ executionNodeKey: 'exec-nearby', targetKey: 'bayside', queryId: 'q-nearby' }],
+      },
+    ] })
+    const versionId = seedVersion(1, frozenPlan)
+    activate(versionId)
+    seedAdvancedRun({ versionId, frozenPlan, createdAt: FIRST })
+
+    const result = await report('scope=group&scopeKey=regional&marketKey=harbor-market&queryClass=non-brand')
+    expect(result.status).toBe(200)
+    const body = result.body as VisibilityReportResponse
+    expect(body.selection.scope.id).toBe('regional')
+    expect(body.selection.market).toMatchObject({ id: 'harbor-market', kind: 'market' })
+    expect(body.scopeOptions.find(scope => scope.id === 'harbor-market')?.parentGroupIds).toEqual(['regional'])
+    expect(body.populations[0]!.summary).toMatchObject({
+      queryCount: 1,
+      answerCount: 2,
+      outcomes: expect.objectContaining({ total: 1 }),
+    })
+    expect(body.populations[0]!.breakdown.properties.map(row => row.id)).toEqual(['harbor'])
+    expect(body.scopeOptions.find(scope => scope.id === 'regional')?.marketKeys).toEqual(['harbor-market'])
+    expect(body.scopeOptions.find(scope => scope.id === 'harbor')?.marketKeys).toEqual(['harbor-market'])
+    expect(body.scopeOptions.find(scope => scope.id === 'bayside')?.marketKeys).toEqual(['bayside-market'])
   })
 
   it('uses the active frozen definition across a label-only comparable chain without awaiting a sweep', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.192.0",
+  "version": "4.192.1",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/test/query-visibility-parity.test.ts
+++ b/packages/canonry/test/query-visibility-parity.test.ts
@@ -25,8 +25,8 @@ describe('query and visibility CLI parity', () => {
     const result = { selection: { queryClass: 'all', revision: 2 }, populations: [{ queryClass: 'branded' }, { queryClass: 'non-brand' }] }
     client.getVisibilityReport.mockResolvedValue(result)
     const output = vi.spyOn(console, 'log').mockImplementation(() => {})
-    await runAdvancedMeasurementOperation('demo', 'visibility', inputFile({ queryClass: 'all', scope: 'market', scopeKey: 'alpha', provider: 'gemini', model: 'exact-model', location: 'none', runId: 'measurement-run' }), 'json')
-    expect(client.getVisibilityReport).toHaveBeenCalledWith('demo', expect.objectContaining({ queryClass: 'all', scope: 'market', scopeKey: 'alpha', provider: 'gemini', model: 'exact-model', runId: 'measurement-run' }))
+    await runAdvancedMeasurementOperation('demo', 'visibility', inputFile({ queryClass: 'all', scope: 'group', scopeKey: 'regional', marketKey: 'alpha', provider: 'gemini', model: 'exact-model', location: 'none', runId: 'measurement-run' }), 'json')
+    expect(client.getVisibilityReport).toHaveBeenCalledWith('demo', expect.objectContaining({ queryClass: 'all', scope: 'group', scopeKey: 'regional', marketKey: 'alpha', provider: 'gemini', model: 'exact-model', runId: 'measurement-run' }))
     expect(JSON.parse(output.mock.calls[0]![0] as string)).toEqual(result)
   })
 
@@ -54,7 +54,7 @@ describe('query and visibility MCP parity', () => {
   it('keeps all selection fields in the agent contract and forwards them unchanged', async () => {
     const tool = canonryMcpTools.find(tool => tool.name === 'canonry_visibility_report')
     expect(tool).toBeDefined()
-    const input = tool!.inputSchema.parse({ project: 'demo', scope: 'market', scopeKey: 'alpha', queryClass: 'all', provider: 'gemini', model: 'actual-model', location: 'none', runId: 'measured', queryKey: 'context-node', from: '2026-09-01T00:00:00.000Z', to: '2026-09-04T23:59:59.999Z' })
+    const input = tool!.inputSchema.parse({ project: 'demo', scope: 'group', scopeKey: 'regional', marketKey: 'alpha', queryClass: 'all', provider: 'gemini', model: 'actual-model', location: 'none', runId: 'measured', queryKey: 'context-node', from: '2026-09-01T00:00:00.000Z', to: '2026-09-04T23:59:59.999Z' })
     await tool!.handler(client as unknown as ApiClient, input)
     const { project, ...selection } = input
     expect(client.getVisibilityReport).toHaveBeenCalledWith(project, selection)

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -59,6 +59,10 @@ Shared DTOs, enums, Zod schemas, error codes, config validation, and **generic u
 4. Add a test file in `test/<topic>.test.ts` with happy path + edge cases (empty input, invalid input, boundary values).
 5. Migrate any inline duplicates you discover in the same change — don't leave duplication for "later."
 
+### Market selection
+
+`visibility-report` accepts `marketKey` as an exact refinement of project, group, or property scope. Market scope already selects a market and rejects an additional `marketKey`. Optional scope/query `marketKeys` and `selection.market` carry frozen memberships to consumers. A reporting market may declare `groupKey` only when that group contains every target in its usage edges.
+
 ### Competitor model comparisons
 
 `competitorLandscapeQuerySchema` accepts optional `groupBy: model` and an exact

--- a/packages/contracts/src/measurement-plan-v2.ts
+++ b/packages/contracts/src/measurement-plan-v2.ts
@@ -182,6 +182,8 @@ export const measurementV2ReportingScopeSchema = z.object({
   stableKey: measurementV2StableKeySchema,
   label: z.string().trim().min(1),
   kind: z.literal('market'),
+  /** Explicit navigation association; never inferred from labels or shared properties. */
+  groupKey: measurementV2StableKeySchema.optional(),
   usageEdges: z.array(measurementV2UsageEdgeSchema),
 }).strict()
 export type MeasurementV2ReportingScope = z.output<typeof measurementV2ReportingScopeSchema>
@@ -259,6 +261,12 @@ export const measurementPlanV2Schema = z.object({
       })
     }
     reportingScopeKeys.add(scope.stableKey)
+    if (scope.groupKey !== undefined) {
+      const group = plan.groups.find(group => group.stableKey === scope.groupKey)
+      if (!group || scope.usageEdges.some(edge => !group.targetKeys.includes(edge.targetKey))) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['reportingScopes', scopeIndex, 'groupKey'], message: 'A market must link to an existing group containing all its assigned properties.' })
+      }
+    }
     const memberKeys = new Set<string>()
     scope.usageEdges.forEach((edge, edgeIndex) => {
       const key = measurementV2UsageEdgeKey(edge)

--- a/packages/contracts/src/query-tracking.ts
+++ b/packages/contracts/src/query-tracking.ts
@@ -175,6 +175,7 @@ export type QueryTrackingGroup = z.output<typeof queryTrackingGroupSchema>
 
 export const queryTrackingMarketSchema = z.object({
   stableKey: measurementV2StableKeySchema,
+  groupKey: measurementV2StableKeySchema.optional(),
   label: z.string().trim().min(1),
   usageEdges: z.array(measurementV2UsageEdgeSchema),
 }).strict()

--- a/packages/contracts/src/visibility-report.ts
+++ b/packages/contracts/src/visibility-report.ts
@@ -56,6 +56,8 @@ const visibilityReportRequestShape = {
   queryClass: visibilityReportQueryClassSchema.default('non-brand'),
   scope: visibilityReportScopeKindSchema.default('project'),
   scopeKey: nonBlankIdSchema.optional(),
+  /** Exact frozen market refinement for a project, group, or Property selection. */
+  marketKey: nonBlankIdSchema.optional(),
   provider: nonBlankIdSchema.optional(),
   /** Exact stored served-model identity. Null/absent model evidence never matches this filter. */
   model: nonBlankIdSchema.optional(),
@@ -89,6 +91,13 @@ export const visibilityReportRequestSchema = z.object(visibilityReportRequestSha
       code: z.ZodIssueCode.custom,
       path: ['scopeKey'],
       message: 'scopeKey is not valid for project scope',
+    })
+  }
+  if (value.scope === 'market' && value.marketKey !== undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['marketKey'],
+      message: 'marketKey is not valid for market scope',
     })
   }
   if (value.from !== undefined && value.to !== undefined && value.from > value.to) {
@@ -165,6 +174,8 @@ export const visibilityReportScopeOptionSchema = z.object({
   targetCount: z.number().int().nonnegative(),
   /** Group and Property membership is frozen and explicit; groups have zero or one id. */
   parentGroupIds: z.array(nonBlankIdSchema).optional(),
+  /** Explicit frozen market links; absent for scopes without market metadata. */
+  marketKeys: z.array(nonBlankIdSchema).optional(),
 }).strict()
 export type VisibilityReportScopeOption = z.output<typeof visibilityReportScopeOptionSchema>
 
@@ -234,6 +245,8 @@ export const visibilityReportQueryRowSchema = z.object({
   model: z.string().nullable(),
   location: z.string().nullable(),
   targetKeys: z.array(nonBlankIdSchema),
+  /** Frozen market memberships for standalone Property query grouping. */
+  marketKeys: z.array(nonBlankIdSchema).optional(),
   answerCount: z.number().int().nonnegative(),
   mentionCoverage: visibilityReportRateSchema,
   citationCoverage: visibilityReportRateSchema,
@@ -338,6 +351,8 @@ export const visibilityReportSelectionSchema = z.object({
   mode: visibilityReportResolvedModeSchema,
   queryClass: visibilityReportQueryClassSchema,
   scope: visibilityReportScopeOptionSchema,
+  /** Selected frozen market refinement, omitted when reading the full scope. */
+  market: visibilityReportScopeOptionSchema.optional(),
   provider: z.string().nullable(),
   model: z.string().nullable(),
   location: visibilityReportLocationSelectionSchema,

--- a/packages/contracts/test/measurement-plan-v2.test.ts
+++ b/packages/contracts/test/measurement-plan-v2.test.ts
@@ -142,6 +142,26 @@ describe('published measurement plan v2', () => {
     }).success).toBe(false)
   })
 
+  it('round-trips an explicit market-to-group association and rejects a missing or outside group', () => {
+    const plan = planV2()
+    const edge = { executionNodeKey: 'exec-best', targetKey: 'harbor-point', queryId: 'q-best' }
+    const scoped = measurementPlanV2Schema.parse({
+      ...plan,
+      reportingScopes: [{ stableKey: 'harbor-market', label: 'Harbor market', kind: 'market', groupKey: 'northbridge-portfolio', usageEdges: [edge] }],
+    })
+    expect(measurementPlanV2Schema.parse(JSON.parse(canonicalMeasurementPlanV2Json(scoped))).reportingScopes)
+      .toEqual(scoped.reportingScopes)
+
+    expect(measurementPlanV2Schema.safeParse({
+      ...scoped,
+      reportingScopes: [{ ...scoped.reportingScopes![0]!, groupKey: 'missing-group' }],
+    }).success).toBe(false)
+    expect(measurementPlanV2Schema.safeParse({
+      ...scoped,
+      reportingScopes: [{ ...scoped.reportingScopes![0]!, groupKey: 'northbridge-harbor' }],
+    }).success).toBe(false)
+  })
+
   it('keeps a new assignment classification basis frozen without breaking historic rows', () => {
     const plan = planV2()
     expect(plan.assignments[0]?.classificationSource).toBeUndefined()

--- a/packages/contracts/test/visibility-report.test.ts
+++ b/packages/contracts/test/visibility-report.test.ts
@@ -22,6 +22,15 @@ describe('visibility report contract', () => {
     })
   })
 
+  it('accepts an optional market refinement alongside a project, group, or Property scope', () => {
+    expect(visibilityReportQuerySchema.parse({ scope: 'group', scopeKey: 'collection', marketKey: 'north-market' }))
+      .toMatchObject({ scope: 'group', scopeKey: 'collection', marketKey: 'north-market' })
+  })
+
+  it('rejects a duplicate marketKey when market scope already selects the market', () => {
+    expect(visibilityReportQuerySchema.safeParse({ scope: 'market', scopeKey: 'north-market', marketKey: 'north-market' }).success).toBe(false)
+  })
+
   it('carries optional frozen parent memberships without fabricating them for old definitions', () => {
     expect(visibilityReportResponseSchema.safeParse({ selection: { mode: 'advanced', queryClass: 'non-brand', scope: { id: 'project', label: 'Project', kind: 'project', targetCount: 1 }, provider: null, model: null, location: { kind: 'all' }, time: { from: null, to: null }, revision: 1, run: { id: null, explicit: false }, provenance: { kind: 'frozen-advanced', definitionRevision: 1 }, measurement: { state: 'not-measured', activeRevision: 1, measuredRevision: null, awaitingSweep: true, pendingAssignmentCount: 1, completedAt: null }, availability: { state: 'available' } }, scopeOptions: [{ id: 'metro', label: 'Metro', kind: 'group', targetCount: 1 }, { id: 'submarket', label: 'Submarket', kind: 'group', targetCount: 1, parentGroupIds: ['metro'] }, { id: 'property', label: 'Property', kind: 'property', targetCount: 1, parentGroupIds: ['metro', 'submarket'] }], filterOptions: { providers: [], models: [], locations: [{ kind: 'all' }] }, populations: [population('non-brand')] }).success).toBe(true)
   })

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.192.0",
+  "version": "4.192.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.192.0",
+  "version": "4.192.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/plugin.json
+++ b/plugins/canonry/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "canonry",
-  "version": "4.192.0",
+  "version": "4.192.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Opening a property from a market previously showed every query assigned to that property, including queries for other markets. The report now keeps the selected market through navigation and refresh, and applies the same filter to metrics, trends, competitors and answer details. Opening a property directly groups its non-brand questions by market.

- Group table rows and direct summaries retain the same report filters. Linking navigation metadata does not silently narrow their totals or rewrite saved group URLs.
- Retain explicitly selected markets through property navigation in groups with multiple markets, and include nested markets in root and group search.
- Add explicit group-to-market metadata and intersect exact saved query/property assignments. No geography is inferred from query text.
- Preserve baseline continuity when adding reporting selections over existing assignments. Changing or removing an existing market population still requires a new measurement.
- `marketKey` is an **identity** parameter: it participates in report/evidence request keys and pagination cursor fingerprints. Query administration clears this read filter before editing assignments.
- Bump Canonry to 4.192.1 and regenerate the SDK/plugin manifests.

Validation: focused contract, API, CLI/MCP parity and web regression tests; relevant typechecks; lint; CLI/web builds. Read-only desktop/mobile browser replay confirms market-specific navigation and refresh, while isolated metadata publication preserves saved answers and whole-project metrics. No paid measurements or production data changes.
