### PR TITLE
chore: add AEO and GEO keywords to npm metadata

### DIFF
--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -3,6 +3,21 @@
   "version": "5.0.0",
   "type": "module",
   "description": "Self-hosted AI visibility (AEO) platform: track how ChatGPT, Claude, Gemini, and Perplexity cite your domain, join it with Search Console, GA4, server-side traffic, and paid media, and fix what you find through agent tools (CLI, REST, MCP). Local SQLite.",
+  "keywords": [
+    "aeo",
+    "answer-engine-optimization",
+    "geo",
+    "generative-engine-optimization",
+    "ai-visibility",
+    "citation-tracking",
+    "seo",
+    "mcp",
+    "chatgpt",
+    "claude",
+    "gemini",
+    "perplexity",
+    "self-hosted"
+  ],
   "license": "MIT",
   "homepage": "https://canonry.ai",
   "repository": {


### PR DESCRIPTION
- Add 13 discovery keywords to the published package, including `aeo`, `geo`, and `generative-engine-optimization`.
- Apply the metadata to both npm package names through the existing publishing script; keywords appear with the next release.
- Validation: manifest parsing and unique-keyword checks, `pnpm check`, `git diff --check`, and all pre-push drift checks passed.